### PR TITLE
Add initial localStorage support for intermittent offline beacons

### DIFF
--- a/js/src/helpers.js
+++ b/js/src/helpers.js
@@ -138,6 +138,26 @@ SnowPlow.hasLocalStorage = function () {
 	}
 }
 
+/*
+ * Checks whether localStorage is accessible
+ * reuses the "modernizr" string to keep global namespace tromping to a minimum.
+ * sets and removes an item to handle IOS5 private browsing.
+ * (http://git.io/jFB2Xw)
+ */
+SnowPlow.localStorageAccessible = function() {
+    var mod = 'modernizr';
+    if( !SnowPlow.hasLocalStorage() ) {
+      return false;
+    }
+    try {
+      SnowPlow.windowAlias.localStorage.setItem(mod,mod);
+      SnowPlow.windowAlias.localStorage.removeItem(mod);
+      return true;
+    } catch(e) {
+      return false;
+    }
+}
+
 
 /*
  * Converts a date object to Unix timestamp with or without milliseconds

--- a/js/src/tracker.js
+++ b/js/src/tracker.js
@@ -190,7 +190,7 @@ SnowPlow.Tracker = function Tracker(argmap) {
 		ecommerceTransaction = ecommerceTransactionTemplate(),
 
 		// Detect whether we have localStorage available
-		hasLocalStorage = SnowPlow.hasLocalStorage(),
+		hasLocalStorage = SnowPlow.localStorageAccessible(),
 		executingQueue = false,
 		imageQueue;
 


### PR DESCRIPTION
This adds support for queuing request into localStorage when they can't be loaded immediately.

The queue will try to fire all requests off to the collector whenever a request is requested and successful.

I haven't been able to test in a browser without localStorage support -- any tips there?
