### PR TITLE
setPlatform support

### DIFF
--- a/js/src/tracker.js
+++ b/js/src/tracker.js
@@ -68,7 +68,7 @@ SnowPlow.Tracker = function Tracker(argmap) {
 		// Request method is always GET for SnowPlow
 		configRequestMethod = 'GET',
 
-		// Platform is always web for this tracker
+		// Platform defaults to web for this tracker
 		configPlatform = 'web',
 
 		// SnowPlow collector URL
@@ -1675,6 +1675,15 @@ SnowPlow.Tracker = function Tracker(argmap) {
 		 */
 		setCollectorUrl: function (rawUrl) {
 			configCollectorUrl = asCollectorUrl(rawUrl);
+		},
+
+		/**
+		 * Specify the platform
+		 *
+		 * @param string userId The business-defined user ID
+		 */
+		setPlatform: function(platform) {
+			configPlatform = platform;
 		},
 
 		/**


### PR DESCRIPTION
Adds support for setPlatform in the javascript tracker. Example use case here would be html+js running inside node-webkit, or a webview on a mobile platform.
