### PR TITLE
Make tracker object available in onload callbacks

### DIFF
--- a/src/js/in_queue.js
+++ b/src/js/in_queue.js
@@ -175,14 +175,8 @@
 
 				namedTrackers = getNamedTrackers(names);
 
-				if (lodash.isString(f)) {
-					for (j = 0; j < namedTrackers.length; j++) {
-						namedTrackers[j][f].apply(namedTrackers[j], parameterArray);
-					}
-				} else {
-					for (j = 0; j < namedTrackers.length; j++) {
-						f.apply(namedTrackers[j], parameterArray);
-					}
+				for (j = 0; j < namedTrackers.length; j++) {
+					namedTrackers[j][f].apply(namedTrackers[j], parameterArray);
 				}
 			}
 		}


### PR DESCRIPTION
In snowplow javascript tracker 1.x it was possible although undocumented for one to pass in a function in to the tracker which would get executed with the tracker object as the context.

In snowplow javascript tracker 2.x it seems this ability has been formalised and documented which is great (https://github.com/snowplow/snowplow/wiki/1-General-parameters-for-the-Javascript-tracker#24-setting-onload-callbacks) but sadly the tracker object is no longer available in these callbacks.

This pull request changes the current onload callback functionality to execute the callback once per named tracker and set the tracker object as the context of the callback.  This slightly breaks backwards compatibility because your onload callbacks may get executed more than once if you have more than one tracker.  This is similar to the undocumented behaviour in 1.x.

There were a couple of other options I thought of which might be preferable though -
- Add the array of all trackers as an argument to the executed callback, this means your callback will only be executed once but does break backwards compatibility by changing the arguments list.
- Create a an object containing the available trackers and set the context of the callback to that. Backwards compatible but a but odd.
- when I say backwards compatible I'm ignoring anyone who was relying on the behaviour of the `this` object being `window` in the callback, I think that's unlikely.

Fyi, we want to get the tracker object to call the getDomainUserId method which we then log to different analytics to allow us to stitch between Snowplow sessions and those sessions.
