### PR TITLE
Log error when pixel fails to load

### DIFF
--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -221,7 +221,9 @@
 					executeQueue();
 				};
 
-				image.onerror = function () {
+				image.onerror = function (error) {
+					console.log('Error loading snowplow pixel', error);
+
 					executingQueue = false;
 				};
 


### PR DESCRIPTION
If there is an error while loading the pixel from the server, the current behavior is that snowplow fails silently. This change logs an error.
