### PR TITLE
Respect doNotTrack in IE 11 and Safari 7.1.3+

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -155,7 +155,7 @@
 			configCookiePath = '/',
 
 			// Do Not Track browser feature
-			dnt = navigatorAlias.doNotTrack || navigatorAlias.msDoNotTrack,
+			dnt = navigatorAlias.doNotTrack || navigatorAlias.msDoNotTrack || windowAlias.doNotTrack,
 
 			// Do Not Track
 			configDoNotTrack = argmap.hasOwnProperty('respectDoNotTrack') ? argmap.respectDoNotTrack && (dnt === 'yes' || dnt === '1') : false,


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack IE 11 as well as Safari 7.1.3+ store doNotTrack setting in window rather than navigator object.