### PR TITLE
Add support for OptimizelyX context #551

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1167,7 +1167,7 @@
 		function getOptimizelyXSummaryContexts() {
 			return lodash.map(getOptimizelyXSummary(), function(experiment) {
 				return {
-					schema: 'iglu.com.optimizely.snowplow/optimizelyx_summary/jsonschema/1-0-0', // this schema does not yet exist
+					schema: 'iglu:com.optimizely.snowplow/optimizelyx_summary/jsonschema/1-0-0',
 					data: experiment
 				};
 			});


### PR DESCRIPTION
RFC for adding support for an Optimizely X summary context. Currently the Optimizely summary context does not work due to changes in the Javascript API between 'Classic' and 'X'.

Note: This context doesn't currently existing in Iglu Central though it's a pretty simple schema. I think it makes sense to have this as a separate schema (rather than adding to `getOptimizelySummary`) as Optimizely consider it a separate product and some fields are either not accessible or applicable between Optimizely Classic and Optimizely X.

Would love to get your thoughts on this @chuwy @alexanderdean 