### PR TITLE
Patch for null optimizely.data check

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -985,7 +985,7 @@
 				}
 			}
 
-			var state = windowAlias.optimizely.data.state;
+			var state = (windowAlias.optimizely && windowAlias.optimizely.data) ? windowAlias.optimizely.data.state : null;
 			if (state) {
 				var contexts = [];
 				var activeExperiments = state.activeExperiments || [];


### PR DESCRIPTION
Required when optimizely is blocked by 3rd party - otherwise stack error occurs because optimizely.data.state is looking for state of null.