### PR TITLE
Allow external activity tracking

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1683,6 +1683,17 @@
 			},
 
 			/**
+			 * Triggers the activityHandler manually to allow external user defined
+			 * activity. i.e. While watching a video
+			 */
+			updatePageActivity: function () {
+				if(activityTrackingInstalled) {
+					var now = new Date();
+					lastActivityTime = now.getTime();
+				}
+			},
+
+			/**
 			 * Enables automatic form tracking.
 			 * An event will be fired when a form field is changed or a form submitted.
 			 * This can be called multiple times: only forms not already tracked will be tracked.

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1687,10 +1687,7 @@
 			 * activity. i.e. While watching a video
 			 */
 			updatePageActivity: function () {
-				if(activityTrackingInstalled) {
-					var now = new Date();
-					lastActivityTime = now.getTime();
-				}
+				activityHandler();
 			},
 
 			/**


### PR DESCRIPTION
Added a updatePageActivity call to the tracker to allow external triggering of the activityHandler for ping events.

Our use case is that when a user is watching a video it isn't marking the user as engaged so not sending pings, we link this new function into our video player to also update the activity handler when a video is playing.