### PR TITLE
2.8.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,20 @@
+Version 2.8.0 (2017-05-18)
+--------------------------
+Add support for users opting out of state tracking using cookie or localStorage (#459)
+Add support for recording state in localStorage rather than cookies (#506)
+Exclude password fields from form tracking (#521)
+Add Parrable context (#525)
+Add support for OptimizelyX context (#551)
+Update README markdown in according with CommonMark (#561)
+Add support for not recording any state (#563)
+Deprecate useCookies (#565)
+Deprecate useLocalStorage (#566)
+Prevent multiple setInterval from being created (#571)
+Guard against non-integer values for minimumVisitLength and heartBeatDelay (#572)
+Provide read-only access to domainSessionIndex (#573)
+Provide read-only access to cookieName (#574)
+Provide read-only access to pageViewId (#575)
+
 Version 2.7.2 (2017-03-07)
 --------------------------
 Add defensive check for window.optimizely.data in getOptimizelyStateContexts (#555)

--- a/README.md
+++ b/README.md
@@ -1,30 +1,32 @@
 # JavaScript web analytics for Snowplow
 
-[ ![Build Status] [travis-image] ] [travis]
-[ ![Selenium Test Status] [saucelabs-button-image]][saucelabs]
-[ ![Code Climate] [codeclimate-image] ] [codeclimate]
-[ ![Built with Grunt] [grunt-image] ] [grunt]
-[ ![License] [license-image] ] [bsd]
+[![Build Status][travis-image]][travis]
+[![Selenium Test Status][saucelabs-button-image]][saucelabs]
+[![Code Climate][codeclimate-image]][codeclimate]
+[![Built with Grunt][grunt-image]][grunt]
+[![License][license-image]][bsd]
 
 ## Overview
 
-Add analytics to your websites and web apps with the [Snowplow] [snowplow] event tracker for JavaScript.
+Add analytics to your websites and web apps with the [Snowplow][snowplow] event tracker for
+JavaScript.
 
-With this tracker you can collect user event data (page views, e-commerce transactions etc) from the client-side tier of your websites and web apps.
+With this tracker you can collect user event data (page views, e-commerce transactions etc) from the
+client-side tier of your websites and web apps.
 
 ## Find out more
 
-| Technical Docs              | Setup Guide           | Roadmap & Contributing               |         
-|-----------------------------|-----------------------|--------------------------------------|
-| [ ![i1] [techdocs-image] ] [tech-docs]      | [ ![i2] [setup-image] ] [setup]   | ![i3] [roadmap-image]                |
-| [Technical Docs] [tech-docs] | [Setup Guide] [setup] | _coming soon_                        |
+| Technical Docs                      | Setup Guide                  | Roadmap & Contributing               |         
+|-------------------------------------|------------------------------|--------------------------------------|
+| [![i1] [techdocs-image]][tech-docs] | [ ![i2][setup-image]][setup] | ![i3][roadmap-image]                 |
+| [Technical Docs][tech-docs]         | [Setup Guide][setup]         | _coming soon_                        |
 
 
 ## Developers
 
 ### Contributing quickstart
 
-Assuming git, [Vagrant] [vagrant-install] and [VirtualBox] [virtualbox-install] installed:
+Assuming git, [Vagrant][vagrant-install] and [VirtualBox][virtualbox-install] installed:
 
 ```
  host$ git clone https://github.com/snowplow/snowplow-javascript-tracker.git
@@ -36,21 +38,25 @@ guest$ cd core
 guest$ sudo npm install
 ```
 
-Set up an `./aws.json` file using the example `./aws.sample.json`. If you just want to concat + minify without uploading then you don't need to fill out the `aws.json` file with valid credentials.
+Set up an `./aws.json` file using the example `./aws.sample.json`. If you just want to concat +
+minify without uploading then you don't need to fill out the `aws.json` file with valid credentials.
 
 Build the package (default task concatenates and minifies) using `grunt`.
 
 ## Testing
 
-[ ![Selenium Test Status][saucelabs-matrix-image]][saucelabs]
+[![Selenium Test Status][saucelabs-matrix-image]][saucelabs]
 
 ## Copyright and license
 
-The Snowplow JavaScript Tracker is based on Anthon Pang's [`piwik.js`] [piwikjs], the JavaScript tracker for the open-source [Piwik] [piwik] project, and is distributed under the same license ([Simplified BSD] [bsd]).
+The Snowplow JavaScript Tracker is based on Anthon Pang's [`piwik.js`][piwikjs], the JavaScript
+tracker for the open-source [Piwik][piwik] project, and is distributed under the same license
+([Simplified BSD][bsd]).
 
-Significant portions of the Snowplow JavaScript Tracker copyright 2010 Anthon Pang. Remainder copyright 2012-14 Snowplow Analytics Ltd.
+Significant portions of the Snowplow JavaScript Tracker copyright 2010 Anthon Pang. Remainder
+copyright 2012-14 Snowplow Analytics Ltd.
 
-Licensed under the [Simplified BSD] [bsd] license.
+Licensed under the [Simplified BSD][bsd] license.
 
 [snowplow]: http://snowplowanalytics.com/
 

--- a/examples/ads/async.html
+++ b/examples/ads/async.html
@@ -38,7 +38,7 @@
         ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.7.2/sp.js","adTracker"));
+        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js","adTracker"));
 
         window.adTracker('newTracker', rnd, 'd3rkrsqld9gmqf.cloudfront.net', {
             'encodeBase64': false
@@ -110,7 +110,7 @@
         ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.7.2/sp.js","adTracker"));
+        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js","adTracker"));
 
         window.adTracker('newTracker', rnd, 'd3rkrsqld9gmqf.cloudfront.net', {
             'encodeBase64': false
@@ -141,7 +141,7 @@
         ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.7.2/sp.js","adTracker"));
+        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js","adTracker"));
         
         window.adTracker('newTracker', rnd, 'd3rkrsqld9gmqf.cloudfront.net', {
             'encodeBase64': false

--- a/examples/web/async-large.html
+++ b/examples/web/async-large.html
@@ -23,7 +23,7 @@
         ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.7.2/sp.js","snowplow_1"));
+        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js","snowplow_1"));
 
         window.snowplow_1('newTracker', 'cf', 'd3rkrsqld9gmqf.cloudfront.net', { // Initialise a tracker
           encodeBase64: false, // Default is true
@@ -83,7 +83,7 @@
         ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.7.2/sp.js","snowplow_2"));
+        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js","snowplow_2"));
 
         window.snowplow_2('newTracker', 'cf', 'd3rkrsqld9gmqf.cloudfront.net', { // Initialise a tracker
           encodeBase64: false, // Default is true

--- a/examples/web/async-medium.html
+++ b/examples/web/async-medium.html
@@ -24,7 +24,7 @@
         ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.7.2/sp.js","new_name_here"));
+        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js","new_name_here"));
 
         window.new_name_here('newTracker', 'cf', 'd3rkrsqld9gmqf.cloudfront.net', {
           encodeBase64: false,

--- a/examples/web/async-small.html
+++ b/examples/web/async-small.html
@@ -23,7 +23,7 @@
         ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.7.2/sp.js","snowplow"));
+        n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js","snowplow"));
 
         window.snowplow('newTracker', 'cf', 'd3rkrsqld9gmqf.cloudfront.net', { // Initialise a tracker
           encodeBase64: false, // Default is true

--- a/examples/web/sync.html
+++ b/examples/web/sync.html
@@ -19,7 +19,7 @@
 
     <!-- Snowplow starts plowing -->
     <script type="text/javascript">
-    var spSrc = ('https:' == document.location.protocol ? 'https' : 'http') + '://d1fc8wv8zag5ca.cloudfront.net/2.7.0/sp.js';
+    var spSrc = ('https:' == document.location.protocol ? 'https' : 'http') + '://d1fc8wv8zag5ca.cloudfront.net/2.8.0/sp.js';
     document.write(unescape("%3Cscript src='" + spSrc + "' type='text/javascript'%3E%3C/script%3E"));
     </script>
     <script type="text/javascript">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "dependencies": {
     "browser-cookie-lite": "0.3.1",
     "jstimezonedetect": "1.0.5",

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -161,7 +161,7 @@ object.getFormTrackingManager = function (core, trackerId, contextAdder) {
 
 					lodash.forEach(innerElementTags, function (tagname) {
 						lodash.forEach(form.getElementsByTagName(tagname), function (innerElement) {
-							if (fieldFilter(innerElement) && !innerElement[trackingMarker]) {
+							if (fieldFilter(innerElement) && !innerElement[trackingMarker] && innerElement.type.toLowerCase() !== 'password') {
 								helpers.addEventListener(innerElement, 'change', getFormChangeListener(context), false);
 								innerElement[trackingMarker] = true;
 							}

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1468,6 +1468,15 @@
 			},
 
 			/**
+			 * Get the cookie name as cookieNamePrefix + basename + . + domain.
+			 *
+			 * @return string Cookie name
+			 */
+			getCookieName: function(basename) {
+				return getSnowplowCookieName(basename);
+			},
+
+			/**
 			 * Get the current user ID (as set previously
 			 * with setUserId()).
 			 *

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -81,6 +81,8 @@
 	 * 19. maxPostBytes, 40000
 	 * 20. discoverRootDomain, false
 	 * 21. cookieLifetime, 63072000
+	 * 22. stateStorageStrategy, 'cookie'
+	 * 22. stateStorageStrategy, 'cookieAndLocalStorage'
 	 */
 	object.Tracker = function Tracker(functionName, namespace, version, mutSnowplowState, argmap) {
 
@@ -186,14 +188,20 @@
 			// Whether to use cookies
 			configUseCookies = argmap.hasOwnProperty('useCookies') ? argmap.useCookies : true,
 
-			// Whether we can store stuff in localStorage
-			localStorageAccessible = detectors.localStorageAccessible,
+			// Strategy defining how to store the state: cookie, localStorage or none
+			configStateStorageStrategy = argmap.hasOwnProperty('stateStorageStrategy') ?
+				argmap.stateStorageStrategy : (!configUseCookies && !useLocalStorage ?
+				'none' : (configUseCookies && useLocalStorage ?
+				'cookieAndLocalStorage' : (configUseCookies ? 'cookie' : 'localStorage'))),
 
 			// Browser language (or Windows language for IE). Imperfect but CloudFront doesn't log the Accept-Language header
 			browserLanguage = navigatorAlias.userLanguage || navigatorAlias.language,
 
 			// Browser features via client-side data collection
-			browserFeatures = detectors.detectBrowserFeatures(configUseCookies, getSnowplowCookieName('testcookie')),
+			browserFeatures = detectors.detectBrowserFeatures(
+				configStateStorageStrategy == 'cookie' ||
+					configStateStorageStrategy == 'cookieAndLocalStorage',
+				getSnowplowCookieName('testcookie')),
 
 			// Visitor fingerprint
 			userFingerprint = (argmap.userFingerprint === false) ? '' : detectors.detectSignature(configUserFingerprintHashSeed),
@@ -252,7 +260,8 @@
 				functionName,
 				namespace,
 				mutSnowplowState,
-				useLocalStorage,
+				configStateStorageStrategy == 'localStorage' ||
+					configStateStorageStrategy == 'cookieAndLocalStorage',
 				argmap.post,
 				argmap.bufferSize,
 				argmap.maxPostBytes || 40000),
@@ -444,13 +453,12 @@
 		 * Cookie getter.
 		 */
 		function getSnowplowCookieValue(cookieName) {
-			if (localStorageAccessible) {
-				var fromLocalStorage = helpers.attemptGetLocalStorage(cookieName);
-				if (fromLocalStorage) {
-					return fromLocalStorage;
-				}
+			if (configStateStorageStrategy == 'localStorage') {
+				return helpers.attemptGetLocalStorage(cookieName);
+			} else if (configStateStorageStrategy == 'cookie' ||
+					configStateStorageStrategy == 'cookieAndLocalStorage') {
+				return cookie.cookie(getSnowplowCookieName(cookieName));
 			}
-			return cookie.cookie(getSnowplowCookieName(cookieName));
 		}
 
 		/*
@@ -543,15 +551,7 @@
 		function setSessionCookie() {
 			var cookieName = getSnowplowCookieName('ses');
 			var cookieValue = '*';
-			if (localStorageAccessible) {
-				if (!helpers.attemptWriteLocalStorage(cookieName, cookieValue)) {
-					cookie.cookie(cookieName, cookieValue, configSessionCookieTimeout,
-						configCookiePath, configCookieDomain);
-				}
-			} else {
-				cookie.cookie(cookieName, cookieValue, configSessionCookieTimeout, configCookiePath,
-					configCookieDomain);
-			}
+			setCookie(cookieName, cookieValue, configSessionCookieTimeout);
 		}
 
 		/*
@@ -559,17 +559,24 @@
 		 * or when there is a new visit or a new page view
 		 */
 		function setDomainUserIdCookie(_domainUserId, createTs, visitCount, nowTs, lastVisitTs, sessionId) {
-			var cookieName = getSnowplowCookieValue('id');
+			var cookieName = getSnowplowCookieName('id');
 			var cookieValue = _domainUserId + '.' + createTs + '.' + visitCount + '.' + nowTs +
 				'.' + lastVisitTs + '.' + sessionId;
-			if (localStorageAccessible) {
-				if (!helpers.attemptWriteLocalStorage(cookieName, cookieValue)) {
-					cookie.cookie(cookieName, cookieValue, configVisitorCookieTimeout,
-						configCookiePath, configCookieDomain);
-				}
-			} else {
-				cookie.cookie(cookieName, cookieValue, configVisitorCookieTimeout,
-					configCookiePath, configCookieDomain);
+			setCookie(cookieName, cookieValue, configVisitorCookieTimeout);
+		}
+
+		/*
+		 * Sets a cookie based on the storage strategy:
+		 * - if 'localStorage': attemps to write to local storage
+		 * - if 'cookie': writes to cookies
+		 * - otherwise: no-op
+		 */
+		function setCookie(name, value, timeout) {
+			if (configStateStorageStrategy == 'localStorage') {
+				helpers.attemptWriteLocalStorage(name, value);
+			} else if (configStateStorageStrategy == 'cookie' ||
+					configStateStorageStrategy == 'cookieAndLocalStorage') {
+				cookie.cookie(name, value, timeout, configCookiePath, configCookieDomain);
 			}
 		}
 
@@ -598,10 +605,8 @@
 			memorizedSessionId = idCookieComponents[6];
 
 			if (!sesCookieSet) {
-
 				// Increment the session ID
 				idCookieComponents[3] ++;
-
 				// Create a new sessionId
 				memorizedSessionId = uuid.v4();
 				idCookieComponents[6] = memorizedSessionId;
@@ -632,12 +637,12 @@
 
 			if (id) {
 				tmpContainer = id.split('.');
-				// New visitor set to 0 now
+				// cookies enabled
 				tmpContainer.unshift('0');
 			} else {
 
 				tmpContainer = [
-					// New visitor
+					// cookies disabled
 					'1',
 					// Domain user ID
 					domainUserId,
@@ -653,6 +658,7 @@
 			}
 
 			if (!tmpContainer[6]) {
+				// session id
 				tmpContainer[6] = uuid.v4();
 			}
 
@@ -668,7 +674,7 @@
 			var nowTs = Math.round(new Date().getTime() / 1000),
 				idname = getSnowplowCookieName('id'),
 				sesname = getSnowplowCookieName('ses'),
-				ses = getSnowplowCookieValue('ses'), // aka cookie.cookie(sesname)
+				ses = getSnowplowCookieValue('ses'),
 				id = loadDomainUserIdCookie(),
 				cookiesDisabled = id[0],
 				_domainUserId = id[1], // We could use the global (domainUserId) but this is better etiquette
@@ -678,11 +684,12 @@
 				lastVisitTs = id[5],
 				sessionIdFromCookie = id[6];
 
-			if (configDoNotTrack && (configUseCookies || localStorageAccessible)) {
-				if (localStorageAccessible) {
+			if (configDoNotTrack && configUseCookies) {
+				if (configStateStorageStrategy == 'localStorage') {
 					helpers.attemptWriteLocalStorage(idname, '');
 					helpers.attemptWriteLocalStorage(sesName, '');
-				} else {
+				} else if (configStateStorageStrategy == 'cookie' ||
+						configStateStorageStrategy == 'cookieAndLocalStorage') {
 					cookie.cookie(idname, '', -1, configCookiePath, configCookieDomain);
 					cookie.cookie(sesname, '', -1, configCookiePath, configCookieDomain);
 				}
@@ -731,7 +738,8 @@
 
 			// Update cookies
 			if (configUseCookies) {
-				setDomainUserIdCookie(_domainUserId, createTs, memorizedVisitCount, nowTs, lastVisitTs, memorizedSessionId);
+				setDomainUserIdCookie(_domainUserId, createTs, memorizedVisitCount, nowTs,
+					lastVisitTs, memorizedSessionId);
 				setSessionCookie();
 			}
 
@@ -1656,7 +1664,7 @@
 			* @param bool enable If false, turn off user fingerprinting
 			*/
 			enableUserFingerprint: function(enable) {
-			helpers.warn('enableUserFingerprintSeed is deprecated. Instead add a "userFingerprint" field to the argmap argument of newTracker.');
+				helpers.warn('enableUserFingerprintSeed is deprecated. Instead add a "userFingerprint" field to the argmap argument of newTracker.');
 				if (!enable) {
 					userFingerprint = '';
 				}

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -186,7 +186,11 @@
 			forceUnsecureTracker = !forceSecureTracker && argmap.hasOwnProperty('forceUnsecureTracker') ? (argmap.forceUnsecureTracker === true) : false,
 
 			// Whether to use localStorage to store events between sessions while offline
-			useLocalStorage = argmap.hasOwnProperty('useLocalStorage') ? argmap.useLocalStorage : true,
+			useLocalStorage = argmap.hasOwnProperty('useLocalStorage') ? (
+				helpers.warn('argmap.useLocalStorage is deprecated. ' +
+					'Use argmap.stateStorageStrategy instead.'),
+				argmap.useLocalStorage
+			) : true,
 
 			// Whether to use cookies
 			configUseCookies = argmap.hasOwnProperty('useCookies') ? (

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -138,6 +138,9 @@
 			// Maximum delay to wait for web bug image to be fetched (in milliseconds)
 			configTrackerPause = argmap.hasOwnProperty('pageUnloadTimer') ? argmap.pageUnloadTimer : 500,
 
+			// Whether appropriate values have been supplied to enableActivityTracking
+			activityTrackingEnabled = false,
+
 			// Minimum visit time after initial page view (in milliseconds)
 			configMinimumVisitTime,
 
@@ -1397,7 +1400,7 @@
 			
 			// Send ping (to log that user has stayed on page)
 			var now = new Date();
-			if (configMinimumVisitTime && configHeartBeatTimer && !activityTrackingInstalled) {
+			if (activityTrackingEnabled && !activityTrackingInstalled) {
 				activityTrackingInstalled = true;
 
 				// Capture our initial scroll points
@@ -1841,8 +1844,15 @@
 			 * @param int heartBeatDelay Seconds to wait between pings
 			 */
 			enableActivityTracking: function (minimumVisitLength, heartBeatDelay) {
-				configMinimumVisitTime = new Date().getTime() + minimumVisitLength * 1000;
-				configHeartBeatTimer = heartBeatDelay * 1000;
+				if (minimumVisitLength === parseInt(minimumVisitLength, 10) &&
+						heartBeatDelay === parseInt(heartBeatDelay, 10)) {
+					activityTrackingEnabled = true;
+					configMinimumVisitTime = new Date().getTime() + minimumVisitLength * 1000;
+					configHeartBeatTimer = heartBeatDelay * 1000;
+				} else {
+					helpers.warn("Activity tracking not enabled, please provide integer values " +
+						"for minimumVisitLength and heartBeatDelay.")
+				}
 			},
 
 			/**

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -819,7 +819,14 @@
 					combinedContexts.push(augurIdentityLiteContext);
 				}
 			}
-
+			
+			//Add Parrable Context
+			if (autoContexts.parrable) {
+				var parrableContext = getParrableContext();
+				if (parrableContext) {
+					combinedContexts.push(parrableContext);
+				}
+			}
 			return combinedContexts;
 		}
 
@@ -1168,6 +1175,25 @@
 			}
 		}
 
+		/**
+		 * Creates a context from the window['_hawk'] object
+		 *
+		 * @return object The Parrable context
+		 */
+		function getParrableContext() {
+			var parrable = window['_hawk'];
+			if (parrable) {
+				var context = { encryptedId: null, optout: null };
+				context['encryptedId'] = parrable.browserid;
+				var regex = new RegExp('(?:^|;)\\s?' + "_parrable_hawk_optout".replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1') + '=(.*?)(?:;|$)', 'i'), match = document.cookie.match(regex);
+				context['optout'] = (match && decodeURIComponent(match[1])) ? match && decodeURIComponent(match[1]) : "false";
+				return {
+					schema: 'iglu:com.parrable/encrypted_payload/jsonschema/1-0-0',
+					data: context
+				};
+			}
+		}
+		
 		/**
 		 * Attempts to create a context using the geolocation API and add it to commonContexts
 		 */

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -107,6 +107,9 @@
 			locationHrefAlias = locationArray[1],
 			configReferrerUrl = locationArray[2],
 
+			// Holder of the logPagePing interval
+			pagePingInterval,
+
 			customReferrer,
 
 			argmap = argmap || {},
@@ -1418,7 +1421,8 @@
 
 				// Periodic check for activity.
 				lastActivityTime = now.getTime();
-				setInterval(function heartBeat() {
+				clearInterval(pagePingInterval);
+				pagePingInterval = setInterval(function heartBeat() {
 					var now = new Date();
 
 					// There was activity during the heart beat period;

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1459,6 +1459,15 @@
 		return {
 
 			/**
+			 * Get the page view ID as generated or provided by mutSnowplowState.pageViewId.
+			 *
+			 * @return string Page view ID
+			 */
+			getPageViewId: function () {
+				return getPageViewId();
+			},
+
+			/**
 			 * Get the current user ID (as set previously
 			 * with setUserId()).
 			 *

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1581,6 +1581,15 @@
 		return {
 
 			/**
+			 * Get the domain session index also known as current memorized visit count.
+			 *
+			 * @return int Domain session index
+			 */
+			getDomainSessionIndex: function() {
+				return memorizedVisitCount;
+			},
+
+			/**
 			 * Get the page view ID as generated or provided by mutSnowplowState.pageViewId.
 			 *
 			 * @return string Page view ID

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1757,6 +1757,14 @@
 			},
 
 			/**
+			 * Triggers the activityHandler manually to allow external user defined
+			 * activity. i.e. While watching a video
+			 */
+			updatePageActivity: function () {
+				activityHandler();
+			},
+
+			/**
 			 * Enables automatic form tracking.
 			 * An event will be fired when a form field is changed or a form submitted.
 			 * This can be called multiple times: only forms not already tracked will be tracked.


### PR DESCRIPTION
- [x] readme (#561)
- [x] parable (PR: #518, issue: #525)
- [x] client session in local storage (#506)
- [x] external activity tracking (#559)
- [x] no tracking (#563)
- [x] deprecate `useCookies` (#565)
- [x] deprecate `useLocalStorage` (#566)
- [x] opt-out of state tracking (#459)
- [x] page view id bug (#500, fixed in 2.7.0)
- [x] wiki updates
- [x] optimizely X (reviewed, PR: #567, issue #551, depends on snowplow/iglu-central#495)
- [x] one setInterval (#571)
- [x] dnt password fields (PR: #570, issue #521)
- [x] guards against non-integers `heartBeatDelay` and `minimumVisitTime` (#572)
- [x] RO access to `domainSessionIndex` (#573)
- [x] RO access to `cookieName` (#574)
- [x] RO access to `pageViewId` (#575)
- [x] prep release
