### PR TITLE
Do not track password fields in change/submit_form events, fixes #521

### DIFF
--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -161,7 +161,7 @@ object.getFormTrackingManager = function (core, trackerId, contextAdder) {
 
 					lodash.forEach(innerElementTags, function (tagname) {
 						lodash.forEach(form.getElementsByTagName(tagname), function (innerElement) {
-							if (fieldFilter(innerElement) && !innerElement[trackingMarker] && innerElement.type !== 'password') {
+							if (fieldFilter(innerElement) && !innerElement[trackingMarker] && innerElement.type.toLowerCase() !== 'password') {
 								helpers.addEventListener(innerElement, 'change', getFormChangeListener(context), false);
 								innerElement[trackingMarker] = true;
 							}

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -161,7 +161,7 @@ object.getFormTrackingManager = function (core, trackerId, contextAdder) {
 
 					lodash.forEach(innerElementTags, function (tagname) {
 						lodash.forEach(form.getElementsByTagName(tagname), function (innerElement) {
-							if (fieldFilter(innerElement) && !innerElement[trackingMarker]) {
+							if (fieldFilter(innerElement) && !innerElement[trackingMarker] && innerElement.type !== 'password') {
 								helpers.addEventListener(innerElement, 'change', getFormChangeListener(context), false);
 								innerElement[trackingMarker] = true;
 							}


### PR DESCRIPTION
This removes password fields from being tracked in form events that have been triggered as part of the `enableFormTracking` feature. Fixes issue #521 