### PR TITLE
Allow dynamic context callbacks for link and form tracking

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -7,6 +7,7 @@
     "dts-generator": "^2.0.0",
     "grunt-ts": "5.5.1",
     "typescript": "2.0.6",
+    "@types/node": "^7.0.0",
     "@types/uuid": "^2.0.29"
   },
   "contributors": [

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -124,7 +124,7 @@ object.getFormTrackingManager = function (core, trackerId, contextAdder) {
 			var elt = e.target;
 			var type = (elt.nodeName && elt.nodeName.toUpperCase() === 'INPUT') ? elt.type : null;
 			var value = (elt.type === 'checkbox' && !elt.checked) ? null : elt.value;
-			core.trackFormChange(getParentFormName(elt), getFormElementName(elt), elt.nodeName, type, helpers.getCssClasses(elt), value, contextAdder(context));
+			core.trackFormChange(getParentFormName(elt), getFormElementName(elt), elt.nodeName, type, helpers.getCssClasses(elt), value, contextAdder(helpers.resolveDynamicContexts(context, elt, type, value)));
 		};
 	}
 
@@ -135,7 +135,7 @@ object.getFormTrackingManager = function (core, trackerId, contextAdder) {
 		return function (e) {
 			var elt = e.target;
 			var innerElements = getInnerFormElements(elt);
-			core.trackFormSubmission(getFormElementName(elt), helpers.getCssClasses(elt), innerElements, contextAdder(context));
+			core.trackFormSubmission(getFormElementName(elt), helpers.getCssClasses(elt), innerElements, contextAdder(helpers.resolveDynamicContexts(context, elt, innerElements)));
 		};
 	}
 

--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -150,6 +150,28 @@
 		return decodeURIComponent(match[1].replace(/\+/g, ' '));
 	};
 
+	/*
+	 * Find dynamic context generating functions and merge their results into the static contexts
+	 * Combine an array of unchanging contexts with the result of a context-creating function
+	 *
+	 * @param {(object|function(...*): ?object)[]} dynamicOrStaticContexts Array of custom context Objects or custom context generating functions
+	 * @param {...*} Parameters to pass to dynamic callbacks
+	 */
+	object.resolveDynamicContexts = function (dynamicOrStaticContexts) {
+		var params = Array.prototype.slice.call(arguments, 1);
+		return lodash.map(dynamicOrStaticContexts, function(context) {
+			if (typeof context === 'function') {
+				try {
+					return context.apply(null, params);
+				} catch (e) {
+					object.warn('Exception thrown in dynamic context generator: ' + e);
+				}
+			} else {
+				return context;
+			}
+		});
+	};
+
 	/**
 	 * Only log deprecation warnings if they won't cause an error
 	 */

--- a/src/js/links.js
+++ b/src/js/links.js
@@ -97,7 +97,7 @@ object.getLinkTrackingManager = function (core, trackerId, contextAdder) {
 
 				// decodeUrl %xx
 				sourceHref = unescape(sourceHref);
-				core.trackLinkClick(sourceHref, elementId, elementClasses, elementTarget, elementContent, contextAdder(context));
+				core.trackLinkClick(sourceHref, elementId, elementClasses, elementTarget, elementContent, contextAdder(helpers.resolveDynamicContexts(context, sourceElement)));
 			}
 		}
 	}


### PR DESCRIPTION
See #519 

Allows for more flexible contexts to be dynamically added to the events for link clicks, form changes, and form submissions. This works similarly to the context callbacks in pageviews/pagepings, just extended to these other types. Unlike in pageviews/pagepings, the Arrays of static and dynamic contexts are not kept separate, in order to maintain the public function interfaces' backward+forward compatibility. 

It lets you do things like the below, without having to update the core link click schema with your additional data:
```javascript
function dataAttributesContext(el) {
    if (el.getAttribute('data-product-id') && el.getAttribute('data-product-category')) return {
        'schema': 'iglu:com.example.snowplow/web_page/link_product_data/1-0-0',
        'data': {
            'productId': el.getAttribute('data-product-id'),
            'productCategory': el.getAttribute('data-product-category')
        }
    }
}

function cssPathContext(el){
    var path = [];

    while (el !== null && !el.isSameNode(document.body)) {
        var level = el.nodeName.toLowerCase();
        if (el.id) level += '#' + el.id;
        if (el.className) level += '.' + el.getAttribute('class').split(/\s+/g).join('.');

        if (!el.id && el.parentNode.childElementCount > 1) {
            level += ':nth-child(' + (Array.prototype.indexOf.call(el.parentNode.children, el) + 1) + ')';
        }

        el = el.parentNode;
        path.push(level);
    }

    return {'schema': 'iglu:com.finder.snowplow/web_page/element_position/1-0-0',
    'data': {cssPath: path.reverse().join('>')}};
}

snowplow('enableLinkClickTracking', null, true, true, [dataAttributesContext, cssPathContext]);
```