### PR TITLE
Support not stringifying context jsons

### DIFF
--- a/core/lib/core.ts
+++ b/core/lib/core.ts
@@ -67,11 +67,16 @@ function getTimestamp(tstamp?: Timestamp): TimestampPayload {
  * @param callback Function applied to every payload dictionary object
  * @return Tracker core
  */
-export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
+export function trackerCore(base64: boolean, stringifyJson?: boolean, callback?: (PayloadData) => void) {
 
 	// base 64 encoding should default to true
 	if (typeof base64 === 'undefined') {
 		base64 = true;
+	}
+
+	// stringify json should default to true
+	if (typeof stringifyJson === 'undefined') {
+		stringifyJson = true;
 	}
 
 	// Dictionary of key-value pairs which get added to every payload, e.g. tracker version
@@ -156,7 +161,7 @@ export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
 	 * @return Payload
 	 */
 	function trackSelfDescribingEvent(properties: Object, context?: Array<SelfDescribingJson>, tstamp?: Timestamp): PayloadData {
-		var sb = payload.payloadBuilder(base64);
+		var sb = payload.payloadBuilder(base64, stringifyJson);
 		var ueJson = {
 			schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
 			data: properties
@@ -177,6 +182,15 @@ export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
 		 */
 		setBase64Encoding: function (encode: boolean) {
 			base64 = encode;
+		},
+
+		/**
+		 * Turn stringify json on or off
+		 *
+		 * @param stringify Whether to stringify inner json payloads
+		 */
+		setStringifyJson: function (stringify: boolean) {
+			stringifyJson = stringify;
 		},
 
 		addPayloadPair: addPayloadPair,
@@ -325,7 +339,7 @@ export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
 			context?: Array<SelfDescribingJson>,
 			tstamp?: Timestamp): PayloadData {
 
-			var sb = payload.payloadBuilder(base64);
+			var sb = payload.payloadBuilder(base64, stringifyJson);
 			sb.add('e', 'pv'); // 'pv' for Page View
 			sb.add('url', pageUrl);
 			sb.add('page', pageTitle);
@@ -359,7 +373,7 @@ export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
 			context?: Array<SelfDescribingJson>,
 			tstamp?: Timestamp): PayloadData {
 
-			var sb = payload.payloadBuilder(base64);
+			var sb = payload.payloadBuilder(base64, stringifyJson);
 			sb.add('e', 'pp'); // 'pp' for Page Ping
 			sb.add('url', pageUrl);
 			sb.add('page', pageTitle);
@@ -392,7 +406,7 @@ export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
 			context?: Array<SelfDescribingJson>,
 			tstamp?: Timestamp): PayloadData {
 
-			var sb = payload.payloadBuilder(base64);
+			var sb = payload.payloadBuilder(base64, stringifyJson);
 			sb.add('e', 'se'); // 'se' for Structured Event
 			sb.add('se_ca', category);
 			sb.add('se_ac', action);
@@ -432,7 +446,7 @@ export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
 			context?: Array<SelfDescribingJson>,
 			tstamp?: Timestamp): PayloadData {
 
-			var sb = payload.payloadBuilder(base64);
+			var sb = payload.payloadBuilder(base64, stringifyJson);
 			sb.add('e', 'tr'); // 'tr' for Transaction
 			sb.add("tr_id", orderId);
 			sb.add("tr_af", affiliation);
@@ -472,7 +486,7 @@ export function trackerCore(base64: boolean, callback?: (PayloadData) => void) {
 			context?: Array<SelfDescribingJson>,
 			tstamp?: Timestamp): PayloadData {
 
-			var sb = payload.payloadBuilder(base64);
+			var sb = payload.payloadBuilder(base64, stringifyJson);
 			sb.add("e", "ti"); // 'tr' for Transaction Item
 			sb.add("ti_id", orderId);
 			sb.add("ti_sk", sku);

--- a/core/lib/payload.ts
+++ b/core/lib/payload.ts
@@ -73,7 +73,7 @@ export function isJson(property: Object): boolean {
  *
  * @return object The request string builder, with add, addRaw and build methods
  */
-export function payloadBuilder(base64Encode: boolean): PayloadData {
+export function payloadBuilder(base64Encode: boolean, stringifyJson: boolean): PayloadData {
 	var dict = {};
 
 	var add = function (key: string, value?: string): void {
@@ -92,11 +92,15 @@ export function payloadBuilder(base64Encode: boolean): PayloadData {
 
 	var addJson = function (keyIfEncoded: string, keyIfNotEncoded: string, json?: Object) {
 		if (isNonEmptyJson(json)) {
-			var str = JSON.stringify(json);
-			if (base64Encode) {
-				add(keyIfEncoded, base64urlencode(str));
+			if (stringifyJson) {
+				var str = JSON.stringify(json);
+				if (base64Encode) {
+					add(keyIfEncoded, base64urlencode(str));
+				} else {
+					add(keyIfNotEncoded, str);
+				}
 			} else {
-				add(keyIfNotEncoded, str);
+				dict[keyIfNotEncoded] = json;
 			}
 		}
 	};

--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -130,7 +130,11 @@
 		 */
 		function getBody(request) {
 			var cleanedRequest = lodash.mapValues(request, function (v) {
-				return v.toString();
+				if (typeof v === 'object') {
+					return v;
+				} else {
+					return v.toString();
+				}
 			});
 			return {
 				evt: cleanedRequest,

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -313,6 +313,9 @@
 		// Enable base 64 encoding for self-describing events and custom contexts
 		core.setBase64Encoding(argmap.hasOwnProperty('encodeBase64') ? argmap.encodeBase64 : true);
 
+		// Enable json stringify for self-describing events
+		core.setStringifyJson(argmap.hasOwnProperty('stringifyJson') ? argmap.stringifyJson : true);
+
 		// Set up unchanging name-value pairs
 		core.setTrackerVersion(version);
 		core.setTrackerNamespace(namespace);


### PR DESCRIPTION
Hi.

This pull request adds support to not stringify the JSONs of "attached" events, In that case, those attached events are not base 64 encoded too.

This works only in POST requests.

