### PR TITLE
Calling trackPageView multiple times will now update page ping context each time

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1460,27 +1460,29 @@
 
 			// Send ping (to log that user has stayed on page)
 			var now = new Date();
-			if (activityTrackingEnabled && !activityTrackingInstalled) {
-				activityTrackingInstalled = true;
+			if (activityTrackingEnabled) {
+				if (!activityTrackingInstalled) {
+					activityTrackingInstalled = true;
 
-				// Capture our initial scroll points
-				resetMaxScrolls();
+					// Capture our initial scroll points
+					resetMaxScrolls();
 
-				// Add event handlers; cross-browser compatibility here varies significantly
-				// @see http://quirksmode.org/dom/events
-				helpers.addEventListener(documentAlias, 'click', activityHandler);
-				helpers.addEventListener(documentAlias, 'mouseup', activityHandler);
-				helpers.addEventListener(documentAlias, 'mousedown', activityHandler);
-				helpers.addEventListener(documentAlias, 'mousemove', activityHandler);
-				helpers.addEventListener(documentAlias, 'mousewheel', activityHandler);
-				helpers.addEventListener(windowAlias, 'DOMMouseScroll', activityHandler);
-				helpers.addEventListener(windowAlias, 'scroll', scrollHandler); // Will updateMaxScrolls() for us
-				helpers.addEventListener(documentAlias, 'keypress', activityHandler);
-				helpers.addEventListener(documentAlias, 'keydown', activityHandler);
-				helpers.addEventListener(documentAlias, 'keyup', activityHandler);
-				helpers.addEventListener(windowAlias, 'resize', activityHandler);
-				helpers.addEventListener(windowAlias, 'focus', activityHandler);
-				helpers.addEventListener(windowAlias, 'blur', activityHandler);
+					// Add event handlers; cross-browser compatibility here varies significantly
+					// @see http://quirksmode.org/dom/events
+					helpers.addEventListener(documentAlias, 'click', activityHandler);
+					helpers.addEventListener(documentAlias, 'mouseup', activityHandler);
+					helpers.addEventListener(documentAlias, 'mousedown', activityHandler);
+					helpers.addEventListener(documentAlias, 'mousemove', activityHandler);
+					helpers.addEventListener(documentAlias, 'mousewheel', activityHandler);
+					helpers.addEventListener(windowAlias, 'DOMMouseScroll', activityHandler);
+					helpers.addEventListener(windowAlias, 'scroll', scrollHandler); // Will updateMaxScrolls() for us
+					helpers.addEventListener(documentAlias, 'keypress', activityHandler);
+					helpers.addEventListener(documentAlias, 'keydown', activityHandler);
+					helpers.addEventListener(documentAlias, 'keyup', activityHandler);
+					helpers.addEventListener(windowAlias, 'resize', activityHandler);
+					helpers.addEventListener(windowAlias, 'focus', activityHandler);
+					helpers.addEventListener(windowAlias, 'blur', activityHandler);
+				}
 
 				// Periodic check for activity.
 				lastActivityTime = now.getTime();


### PR DESCRIPTION
This PR fixes a bug where if you called `trackPageView` multiple times, the page ping context sent out by activity tracking would not get updated to the new context passed by the last call to `trackPageView`.

Previous Behavior: It was not possible to ever update the context of the page ping once it was initially set by `trackPageView`.
New Behavior: Whenever you call `trackPageView`, that context will also be the same context used by page pings.