### PR TITLE
sesname variable is used as sesName typo fix

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -713,7 +713,7 @@
 					configStateStorageStrategy != 'none') {
 				if (configStateStorageStrategy == 'localStorage') {
 					helpers.attemptWriteLocalStorage(idname, '');
-					helpers.attemptWriteLocalStorage(sesName, '');
+					helpers.attemptWriteLocalStorage(sesname, '');
 				} else if (configStateStorageStrategy == 'cookie' ||
 						configStateStorageStrategy == 'cookieAndLocalStorage') {
 					cookie.cookie(idname, '', -1, configCookiePath, configCookieDomain);


### PR DESCRIPTION
if we configure snowplow stateStrategy to `localStorage` we are getting Javascript runtime error. 

so fixing type variable name `sesName` to `sesname`
```
sp.js:formatted:3486 Uncaught ReferenceError: sesName is not defined
    at N (sp.js:formatted:3486)
    at sp.js:formatted:3246
    at i (sp.js:formatted:651)
    at Object.m (sp.js:formatted:663)
    at sp.js:formatted:4259
    at ad (sp.js:formatted:4058)
    at Object.trackUnstructEvent (sp.js:formatted:4258)
    at r (sp.js:formatted:1373)
    at new d.InQueueManager (sp.js:formatted:1378)
    at new e.Snowplow (sp.js:formatted:3218)
```