### PR TITLE
If configOptOutCookie don't look for a cookie with the name "undefined"

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -455,7 +455,12 @@
 			var now = new Date();
 
 			// Set to true if Opt-out cookie is defined
-			var toOptoutByCookie = !!cookie.cookie(configOptOutCookie);
+			var toOptoutByCookie;
+			if (configOptOutCookie) {
+				toOptoutByCookie = !!cookie.cookie(configOptOutCookie);
+			} else {
+				toOptoutByCookie = false;
+			}
 
 			if (!(configDoNotTrack || toOptoutByCookie)) {
 				outQueueManager.enqueueRequest(request.build(), configCollectorUrl);
@@ -707,7 +712,13 @@
 				lastVisitTs = id[5],
 				sessionIdFromCookie = id[6];
 
-			var toOptoutByCookie = !!cookie.cookie(configOptOutCookie);
+			var toOptoutByCookie;
+			if (configOptOutCookie) {
+				toOptoutByCookie = !!cookie.cookie(configOptOutCookie);
+			} else {
+				toOptoutByCookie = false;
+			}
+
 
 			if ((configDoNotTrack || toOptoutByCookie) &&
 					configStateStorageStrategy != 'none') {


### PR DESCRIPTION
`configOptOutCookie` defaults to value `undefined` and if there was a cookie with the name `undefined` it would signify DoNotTrack even though that is not the intention.

This change doesn't look for a cookie if `configOptOutCookie` is not set.