### PR TITLE
Beacon API option for sending events to collector

### DIFF
--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -61,7 +61,7 @@
 			configCollectorUrl,
 			outQueue;
 
-        useBeacon = useBeacon && navigator && navigator.sendBeacon;
+		useBeacon = useBeacon && navigator && navigator.sendBeacon;
 
 		// Fall back to GET for browsers which don't support CORS XMLHttpRequests (e.g. IE <= 9)
 		usePost = usePost && window.XMLHttpRequest && ('withCredentials' in new XMLHttpRequest());
@@ -274,11 +274,11 @@
 					var beaconStatus;
 
 					if (useBeacon) {
-                        beaconStatus = navigator.sendBeacon(configCollectorUrl, encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
+						beaconStatus = navigator.sendBeacon(configCollectorUrl, encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
 					}
 					if (!useBeacon || !beaconStatus) {
-                        xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
-                    }
+						xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
+					}
 				}
 
 			} else {

--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -276,7 +276,7 @@
 					if (useBeacon) {
                         beaconStatus = navigator.sendBeacon(configCollectorUrl, encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
 					}
-					if (!useBeacon || !! beaconStatus) {
+					if (!useBeacon || !beaconStatus) {
                         xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
                     }
 				}

--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -55,16 +55,18 @@
 	 * @param int maxPostBytes Maximum combined size in bytes of the event JSONs in a POST request
 	 * @return object OutQueueManager instance
 	 */
-	object.OutQueueManager = function (functionName, namespace, mutSnowplowState, useLocalStorage, usePost, bufferSize, maxPostBytes) {
+	object.OutQueueManager = function (functionName, namespace, mutSnowplowState, useLocalStorage, useBeacon, usePost, bufferSize, maxPostBytes) {
 		var	queueName,
 			executingQueue = false,
 			configCollectorUrl,
 			outQueue;
 
+        useBeacon = useBeacon && navigator && navigator.sendBeacon;
+
 		// Fall back to GET for browsers which don't support CORS XMLHttpRequests (e.g. IE <= 9)
 		usePost = usePost && window.XMLHttpRequest && ('withCredentials' in new XMLHttpRequest());
 
-		var path = usePost ? '/com.snowplowanalytics.snowplow/tp2' : '/i';
+		var path = useBeacon || usePost ? '/com.snowplowanalytics.snowplow/tp2' : '/i';
 
 		bufferSize = (localStorageAccessible() && useLocalStorage && usePost && bufferSize) || 1;
 
@@ -221,7 +223,7 @@
 
 			var nextRequest = outQueue[0];
 
-			if (usePost) {
+			if (usePost || useBeacon) {
 
 				var xhr = initializeXMLHttpRequest(configCollectorUrl);
 
@@ -269,7 +271,14 @@
 				});
 
 				if (batch.length > 0) {
-					xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
+					var beaconStatus;
+
+					if (useBeacon) {
+                        beaconStatus = navigator.sendBeacon(configCollectorUrl, encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
+					}
+					if (!useBeacon || !! beaconStatus) {
+                        xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
+                    }
 				}
 
 			} else {

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -74,13 +74,14 @@
 	 * 12. useCookies, true
 	 * 13. sessionCookieTimeout, 1800
 	 * 14. contexts, {}
-	 * 15. post, false
-	 * 16. bufferSize, 1
-	 * 17. crossDomainLinker, false
-	 * 18. maxPostBytes, 40000
-	 * 19. discoverRootDomain, false
-	 * 20. cookieLifetime, 63072000
-	 * 21. stateStorageStrategy, 'cookieAndLocalStorage'
+	 * 15. beacon, false
+	 * 16. post, false
+	 * 17. bufferSize, 1
+	 * 18. crossDomainLinker, false
+	 * 19. maxPostBytes, 40000
+	 * 20. discoverRootDomain, false
+	 * 21. cookieLifetime, 63072000
+	 * 22. stateStorageStrategy, 'cookieAndLocalStorage'
 	 */
 	object.Tracker = function Tracker(functionName, namespace, version, mutSnowplowState, argmap) {
 
@@ -277,6 +278,7 @@
 				mutSnowplowState,
 				configStateStorageStrategy == 'localStorage' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage',
+                argmap.beacon,
 				argmap.post,
 				argmap.bufferSize,
 				argmap.maxPostBytes || 40000),

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -278,7 +278,7 @@
 				mutSnowplowState,
 				configStateStorageStrategy == 'localStorage' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage',
-                argmap.beacon,
+				argmap.beacon,
 				argmap.post,
 				argmap.bufferSize,
 				argmap.maxPostBytes || 40000),


### PR DESCRIPTION
This pull request introduces the ability to send events using the Beacon API. Just like POST, one can define - using a config parameter - if she would like to send events using the Beacon API instead of POST or image beacons.