### PR TITLE
Add option to set a custom POST request path

### DIFF
--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -53,7 +53,7 @@
 	 * @param int bufferSize How many events to batch in localStorage before sending them all.
 	 *                       Only applies when sending POST requests and when localStorage is available.
 	 * @param int maxPostBytes Maximum combined size in bytes of the event JSONs in a POST request
-	 * @param string path The path
+	 * @param string postPath The path where events are to be posted
 	 * @return object OutQueueManager instance
 	 */
 	object.OutQueueManager = function (functionName, namespace, mutSnowplowState, useLocalStorage, usePost, postPath, bufferSize, maxPostBytes) {

--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -53,9 +53,10 @@
 	 * @param int bufferSize How many events to batch in localStorage before sending them all.
 	 *                       Only applies when sending POST requests and when localStorage is available.
 	 * @param int maxPostBytes Maximum combined size in bytes of the event JSONs in a POST request
+	 * @param string path The path
 	 * @return object OutQueueManager instance
 	 */
-	object.OutQueueManager = function (functionName, namespace, mutSnowplowState, useLocalStorage, usePost, bufferSize, maxPostBytes) {
+	object.OutQueueManager = function (functionName, namespace, mutSnowplowState, useLocalStorage, usePost, postPath, bufferSize, maxPostBytes) {
 		var	queueName,
 			executingQueue = false,
 			configCollectorUrl,
@@ -64,7 +65,7 @@
 		// Fall back to GET for browsers which don't support CORS XMLHttpRequests (e.g. IE <= 9)
 		usePost = usePost && window.XMLHttpRequest && ('withCredentials' in new XMLHttpRequest());
 
-		var path = usePost ? '/com.snowplowanalytics.snowplow/tp2' : '/i';
+		var path = usePost ? postPath : '/i';
 
 		bufferSize = (localStorageAccessible() && useLocalStorage && usePost && bufferSize) || 1;
 

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -121,6 +121,9 @@
 			// Snowplow collector URL
 			configCollectorUrl,
 
+			// Custom path for post requests (to get around adblockers)
+			configPostPath = argmap.hasOwnProperty('postPath') ? argmap.postPath : '/com.snowplowanalytics.snowplow/tp2',
+
 			// Site ID
 			configTrackerSiteId = argmap.hasOwnProperty('appId') ? argmap.appId : '', // Updated for Snowplow
 
@@ -278,6 +281,7 @@
 				configStateStorageStrategy == 'localStorage' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage',
 				argmap.post,
+				configPostPath,
 				argmap.bufferSize,
 				argmap.maxPostBytes || 40000),
 


### PR DESCRIPTION
uBlock Origin, one of the world's most popular adblockers, blocks Snowplow.

In particular, it blocks patterns like: `/snowplow/`, `/snowplow.js`, etc.

The path that the Snowplow JavaScript tracker hits -- `/com.snowplowanalytics.snowplow/tp2` -- is a pattern that gets matched. As a result, anyone relying on this tracker is likely losing a substantial amount of data. (On DataCamp.com, for example, we noticed that we were losing almost 10% of our front-end Snowplow data because of this.)

I propose adding the ability for users of the Snowplow JavaScript tracker to change that path. This would allow users to change it to something that will not be blocked by adblockers. Further, it would allow users to use more advanced techniques like cycling the path so that adblockers have a tougher time catching on.

Obviously, updating this path alone will not fix the problem -- in fact, it'll break most people's Snowplow implementations because the path they're setting does not actually exist on the other end. However, that's a separate problem. (Our plan is to use URL masking instead of fiddling with the server.)

Please note that this code hasn't been tested at all -- I just threw this together as quickly as I could to get a conversation going. Hopefully a maintainer can take it from here and get this into master ASAP. A lot of people are losing a lot of data in the meantime.