### PR TITLE
Consolidate request method API

### DIFF
--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -51,20 +51,28 @@
 	 * @param object mutSnowplowState Gives the pageUnloadGuard a reference to the outbound queue
 	 *                                so it can unload the page when all queues are empty
 	 * @param boolean useLocalStorage Whether to use localStorage at all
-	 * @param boolean usePost Whether to send events by POST or GET
+	 * @param string eventMethod if null will use 'beacon' otherwise can be set to 'post', 'get', or 'beacon' to force. 
 	 * @param int bufferSize How many events to batch in localStorage before sending them all.
 	 *                       Only applies when sending POST requests and when localStorage is available.
 	 * @param int maxPostBytes Maximum combined size in bytes of the event JSONs in a POST request
 	 * @return object OutQueueManager instance
 	 */
-	object.OutQueueManager = function (functionName, namespace, mutSnowplowState, useLocalStorage, useBeacon, usePost, bufferSize, maxPostBytes) {
+	object.OutQueueManager = function (functionName, namespace, mutSnowplowState, useLocalStorage, eventMethod, bufferSize, maxPostBytes) {
 		var	queueName,
 			executingQueue = false,
 			configCollectorUrl,
 			outQueue;
+		
+		//Force to lower case if its a string
+		eventMethod = eventMethod.toLowerCase ? eventMethod.toLowerCase() : eventMethod;
+		
+		//Use the Beacon API if eventMethod is set null, true, or 'beacon'. 
+		var enableBeacon = (eventMethod === null || eventMethod === true || eventMethod === "beacon" || eventMethod === "true") ? true : false;
+		// Fall back to POST or GET for browsers which don't support Beacon API
+		useBeacon = enableBeacon && navigator && navigator.sendBeacon;
 
-		useBeacon = useBeacon && navigator && navigator.sendBeacon;
-
+		//Use POST if specified, or beacon is unavailable. 
+		var usePost = (eventMethod === "post" || (enableBeacon && !useBeacon)) ? true : false;
 		// Fall back to GET for browsers which don't support CORS XMLHttpRequests (e.g. IE <= 9)
 		usePost = usePost && window.XMLHttpRequest && ('withCredentials' in new XMLHttpRequest());
 

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -76,8 +76,8 @@
 	 * 12. useCookies, true
 	 * 13. sessionCookieTimeout, 1800
 	 * 14. contexts, {}
-	 * 15. beacon, false
-	 * 16. post, false
+	 * 15. eventMethod, 'beacon'
+	 * 16. post, false *DEPRECATED use eventMethod instead*
 	 * 17. bufferSize, 1
 	 * 18. crossDomainLinker, false
 	 * 19. maxPostBytes, 40000
@@ -90,7 +90,17 @@
 		/************************************************************
 		 * Private members
 		 ************************************************************/
-		var
+		 
+		 var argmap = argmap || {};
+		 
+		 //use POST if that property is present on the argmap
+		 if(argmap.hasOwnProperty('post')) {
+			 argmap.eventMethod = argmap.post === true ? 'post' : 'get';
+		 } else {
+			 argmap.eventMethod = argmap.eventMethod || 'beacon'
+		 }
+
+		 var
 			// Tracker core
 			core = coreConstructor(true, function(payload) {
 				addBrowserData(payload);
@@ -126,8 +136,6 @@
 			pagePingInterval,
 
 			customReferrer,
-
-			argmap = argmap || {},
 
 			// Request method is always GET for Snowplow
 			configRequestMethod = 'GET',
@@ -294,8 +302,7 @@
 				mutSnowplowState,
 				configStateStorageStrategy == 'localStorage' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage',
-				argmap.beacon,
-				argmap.post,
+				argmap.eventMethod,
 				argmap.bufferSize,
 				argmap.maxPostBytes || 40000),
 


### PR DESCRIPTION
A PR to address the comment I made earlier. 

My concern in a nutshell is that its probably not a good idea to keep adding arguments to the argmap that might be confusing and/or contradictory. Having two options one for post, and one for beacon makes it unclear which one takes precedent, and makes it harder to maintain argmap backwards compatibility in the future. This PR creates an eventMethod (not 100% sold on this name) property on the argmap that is future proof, while still respecting the post setting for the time being.

