### PR TITLE
Fix global variables in optimizelyXSummary

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1095,10 +1095,10 @@
 			var visitor = getOptimizelyXData('visitor');
 
 			return map(experiment_ids, function(activeExperiment) {
-				variation = state.getVariationMap()[activeExperiment];
-				variationName = variation.name;
-				variationId = variation.id;
-				visitorId = visitor.visitorId;
+				var variation = state.getVariationMap()[activeExperiment];
+				var variationName = variation.name;
+				var variationId = variation.id;
+				var visitorId = visitor.visitorId;
 				return {
 					experimentId: parseInt(activeExperiment),
 					variationName: variationName,


### PR DESCRIPTION
The global vars seem to be confusing the minifier in some way in newer builds, and the uglified code throws an exception trying to assign to an undefined variable, which results in the events being discarded. Making the variables local resolves the issue.

Tested & fixed with v2.10.2