### PR TITLE
Round the device dimensions to prevent invalid inputs

### DIFF
--- a/src/js/lib/detectors.js
+++ b/src/js/lib/detectors.js
@@ -182,8 +182,8 @@
 
 			// document.body may not have rendered, so check whether be.offsetHeight is null
 			bodyHeight = be ? Math.max(be.offsetHeight, be.scrollHeight) : 0;
-		var w = Math.max(de.clientWidth, de.offsetWidth, de.scrollWidth);
-		var h = Math.max(de.clientHeight, de.offsetHeight, de.scrollHeight, bodyHeight);
+		var w = Math.round(Math.max(de.clientWidth, de.offsetWidth, de.scrollWidth));
+		var h = Math.round(Math.max(de.clientHeight, de.offsetHeight, de.scrollHeight, bodyHeight));
 		return isNaN(w) || isNaN(h) ? '' : w + 'x' + h;
 	};
 


### PR DESCRIPTION
## What
Round the the width and height values when calculating the screen dimensions.

## Why
Some browsers (IE 11, Safari 8, etc.) support subpixel rendering. This can cause invalid dimensions, like 1079.001240198 x 980.203980293840, for the document size to be sent. This ends up as an invalid event since the schema definition for document size expects whole numbers.

Fixes #587 

