### PR TITLE
Get some real integration testing on the go with snowplow micro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules
 **/lodash.js
 tests/pages/*.js
 tests/pages/integration.html
+tests/micro.js
 tests/local/serve/
 tags/tag.min.js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,14 @@ install:
 - rm -rf node_modules
 - npm install
 
+- docker run --mount type=bind,source=$(pwd)/micro-config,destination=/config -p 9090:9090 snowplow/snowplow-micro:latest --collector-config /config/micro.conf --iglu /config/iglu.json > /dev/null 2>&1  &
+
 # get ngrok
 - wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
 - unzip ./ngrok-stable-linux-amd64.zip
 before_script:
 - export SUBDOMAIN=$RANDOM$RANDOM
-- ./ngrok http -authtoken $NGROK_AUTH -subdomain $SUBDOMAIN -log=stdout 8500 > /dev/null &
+- ./ngrok http -authtoken $NGROK_AUTH -subdomain $SUBDOMAIN -log=stdout 9090 > /dev/null 2>&1 &
 script:
 - cd core && grunt intern && cd ..
 - grunt travis
@@ -53,7 +55,7 @@ env:
   global:
   # SAUCE_USERNAME
   - secure: S/6Ild1n9SmW8xYqarjkigDqmyFgWS4Hi0M07e/ryPeS1MNQdiS5+WuSmlSTevM/wU/oSCvzXnKhO9W/1tvz4qj/BMQYxYWFjwWAXJrkjJPvWoa5ogYkR3ETSYrqdhkT+8LVof8iLPlpHjS1y2fozyJbYf1YNSkcVCLxMdIwnk0=
-  # SAUCE_AUTH_KEY
+  # SAUCE_ACCESS_KEY
   - secure: bkmtL2PXFGdOB6YNfWw6thEyVAbX/l7Q99pfT2jHmfzhTDf4/FT1CprsAacf0JeYkwMg5UQDMqAcZSojjO6GeAY8rhC94Tor5hKoEwCL4wg5NatXBUUI+WWaoBSg2KWYG2MfkPxtGJyNk1LPQoV+nUUzwEGejV8lJvaHVxkBsqA=
   # NGROK_AUTH
   - secure: JwP5MuqZ6k8FlHg8AnzYTrCZByJLnlu0to2srEwfVOhW1efGTEmtWf/SLlplYHcdelsFakdiSbD3BkZyEqpe/2/AIb56KLAqtE2Ng3WS8Vz/80yknxII0xcSPzAZdhZYRUJlbIrA1Ua3XGgirBenjn7ILFXNX/qLgvwJ1uLKCPo=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,17 +128,21 @@ module.exports = function(grunt) {
         options: {
           'process': true
         },
-        src: ['tests/pages/integration-template.html'],
-        dest: 'tests/pages/integration.html'
+        files: {
+          'tests/pages/integration.html': 'tests/pages/integration-template.html',
+          'tests/micro.js': 'tests/micro-template.js'
+        }
       },
       local: {
         options: {
           'process': function(src, filepath) {
-            return src.replace(/'\<\%= subdomain \%\>' \+ '\.ngrok\.io'/g, '\'127.0.0.1:8000\'');
+            return src.replace(/'\<\%= subdomain \%\>' \+ '\.ngrok\.io'/g, '\'127.0.0.1:9090\'');
           }
         },
-        src: ['tests/pages/integration-template.html'],
-        dest: 'tests/local/serve/integration.html'
+        files: {
+          'tests/pages/integration.html': 'tests/pages/integration-template.html',
+          'tests/micro.js': 'tests/micro-template.js'
+        }
       }
     },
 
@@ -188,7 +192,7 @@ module.exports = function(grunt) {
           runType: 'runner',
           functionalSuites: [
             'tests/integration/setup.js',       // required prior to integration.js
-            'tests/integration/integration.js' 	// request_recorder and ngrok need to be running
+            'tests/integration/integration.js'	// request_recorder and ngrok need to be running
           ]
         }
       }
@@ -275,5 +279,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', 'Intern tests', ['browserify:test', 'babel:test', 'intern']);
   grunt.registerTask('travis', 'Intern tests for Travis CI',  ['concat:test', 'browserify:test', 'babel:test', 'intern']);
   grunt.registerTask('tags', 'Minifiy the Snowplow invocation tag', ['uglify:tag', 'concat:tag']);
-  grunt.registerTask('local', 'Builds and places files read to serve and test locally', ['browserify:test', 'concat:local', 'babel:local']);
+  grunt.registerTask('local', 'Builds and places files read to serve and test locally', ['browserify:test', 'babel:test',
+    'babel:local', 'concat:local']);
 };

--- a/micro-config/iglu.json
+++ b/micro-config/iglu.json
@@ -1,0 +1,18 @@
+{
+  "schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0",
+    "data": {
+      "cacheSize": 500,
+      "repositories": [
+        {
+          "name": "Iglu Central",
+          "priority": 0,
+          "vendorPrefixes": [ "com.snowplowanalytics" ],
+          "connection": {
+            "http": {
+              "uri": "http://iglucentral.com"
+            }
+          }
+        }
+      ]
+    }
+}

--- a/micro-config/micro.conf
+++ b/micro-config/micro.conf
@@ -1,0 +1,188 @@
+# Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+#
+# This program is licensed to you under the Apache License Version 2.0, and
+# you may not use this file except in compliance with the Apache License
+# Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License Version 2.0 is distributed on an "AS
+# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the Apache License Version 2.0 for the specific language
+# governing permissions and limitations there under.
+
+# This file (application.conf.example) contains a template with
+# configuration options for the Scala Stream Collector.
+#
+# To use, copy this to 'application.conf' and modify the configuration options.
+
+# 'collector' contains configuration options for the main Scala collector.
+collector {
+  # The collector runs as a web service specified on the following interface and port.
+  interface = "0.0.0.0"
+  port = "9090"
+
+  # Configure the P3P policy header.
+  p3p {
+    policyRef = "/w3c/p3p.xml"
+    CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"
+  }
+
+  # Cross domain policy configuration.
+  # If "enabled" is set to "false", the collector will respond with a 404 to the /crossdomain.xml
+  # route.
+  crossDomain {
+    enabled = false
+    # Domains that are granted access, *.acme.com will match http://acme.com and http://sub.acme.com
+    domains = [ "*" ]
+    # Whether to only grant access to HTTPS or both HTTPS and HTTP sources
+    secure = true
+  }
+
+  # The collector returns a cookie to clients for user identification
+  # with the following domain and expiration.
+  cookie {
+    enabled = true
+    expiration = "365 days" # e.g. "365 days"
+    # Network cookie name
+    name = "snowplow-micro"
+    # The domain is optional and will make the cookie accessible to other
+    # applications on the domain. Comment out this line to tie cookies to
+    # the collector's full domain
+    domain = ""
+  }
+
+  # If you have a do not track cookie in place, the Scala Stream Collector can respect it by
+  # completely bypassing the processing of an incoming request carrying this cookie, the collector
+  # will simply reply by a 200 saying "do not track".
+  # The cookie name and value must match the configuration below, where the names of the cookies must
+  # match entirely and the value could be a regular expression.
+  doNotTrackCookie {
+    enabled = false
+    name = ""
+    value = ""
+  }
+
+  # When enabled and the cookie specified above is missing, performs a redirect to itself to check
+  # if third-party cookies are blocked using the specified name. If they are indeed blocked,
+  # fallbackNetworkId is used instead of generating a new random one.
+  cookieBounce {
+    enabled = false
+    # The name of the request parameter which will be used on redirects checking that third-party
+    # cookies work.
+    name = "n3pc"
+    # Network user id to fallback to when third-party cookies are blocked.
+    fallbackNetworkUserId = ""
+    # Optionally, specify the name of the header containing the originating protocol for use in the
+    # bounce redirect location. Use this if behind a load balancer that performs SSL termination.
+    # The value of this header must be http or https. Example, if behind an AWS Classic ELB.
+    forwardedProtocolHeader = "X-Forwarded-Proto"
+  }
+
+  # When enabled, the redirect url passed via the `u` query parameter is scanned for a placeholder
+  # token. All instances of that token are replaced withe the network ID. If the placeholder isn't
+  # specified, the default value is `${SP_NUID}`.
+  redirectMacro {
+    enabled = false
+    # Optional custom placeholder token (defaults to the literal `${SP_NUID}`)
+    placeholder = "[TOKEN]"
+  }
+
+  # Customize response handling for requests for the root path ("/").
+  # Useful if you need to redirect to web content or privacy policies regarding the use of this collector.
+  rootResponse {
+    enabled = false
+    statusCode = 302
+    # Optional, defaults to empty map
+    headers = {
+      Location = "",
+      X-Custom = ""
+    }
+    # Optional, defaults to empty string
+    body = "302, redirecting"
+  }
+
+  # Configuration related to CORS preflight requests
+  cors {
+    # The Access-Control-Max-Age response header indicates how long the results of a preflight
+    # request can be cached. -1 seconds disables the cache. Chromium max is 10m, Firefox is 24h.
+    accessControlMaxAge = 5 seconds
+  }
+
+  # Configuration of prometheus http metrics
+  prometheusMetrics {
+    # If metrics are enabled then all requests will be logged as prometheus metrics
+    # and '/metrics' endpoint will return the report about the requests
+    enabled = false
+    # Custom buckets for http_request_duration_seconds_bucket duration metric
+    #durationBucketsInSeconds = [0.1, 3, 10]
+    #durationbucketsInSeconds = ${?COLLECTOR_PROMETHEUS_METRICS_DURATION_BUCKETS_IN_SECONDS}
+  }
+
+  # Configuration of prometheus http metrics
+  prometheusMetrics {
+    # If metrics are enabled then all requests will be logged as prometheus metrics
+    # and '/metrics' endpoint will return the report about the requests
+    enabled = false
+    # Custom buckets for http_request_duration_seconds_bucket duration metric
+    #durationBucketsInSeconds = [0.1, 3, 10]
+  }
+
+  streams {
+    # Events which have successfully been collected will be stored in the good stream/topic
+    good = ""
+
+    # Events that are too big (w.r.t Kinesis 1MB limit) will be stored in the bad stream/topic
+    bad = ""
+
+    # Whether to use the incoming event's ip as the partition key for the good stream/topic
+    # Note: Nsq does not make use of partition key.
+    useIpAddressAsPartitionKey = false
+
+    # Enable the chosen sink by uncommenting the appropriate configuration
+    sink {
+      # Choose between kinesis, googlepubsub, kafka, nsq, or stdout.
+      # To use stdout, comment or remove everything in the "collector.streams.sink" section except
+      # "enabled" which should be set to "stdout".
+      enabled = stdout
+    }
+
+    # Incoming events are stored in a buffer before being sent to Kinesis/Kafka.
+    # Note: Buffering is not supported by NSQ.
+    # The buffer is emptied whenever:
+    # - the number of stored records reaches record-limit or
+    # - the combined size of the stored records reaches byte-limit or
+    # - the time in milliseconds since the buffer was last emptied reaches time-limit
+    buffer {
+      byteLimit = 100000
+      recordLimit = 40
+      timeLimit = 1000
+    }
+  }
+}
+
+# Akka has a variety of possible configuration options defined at
+# http://doc.akka.io/docs/akka/current/scala/general/configuration.html
+akka {
+  loglevel = DEBUG # 'OFF' for no logging, 'DEBUG' for all logging.
+  loglevel = ${?AKKA_LOGLEVEL}
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loggers = [${?AKKA_LOGGERS}]
+
+  # akka-http is the server the Stream collector uses and has configurable options defined at
+  # http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html
+  http.server {
+    # To obtain the hostname in the collector, the 'remote-address' header
+    # should be set. By default, this is disabled, and enabling it
+    # adds the 'Remote-Address' header to every request automatically.
+    remote-address-header = on
+
+    raw-request-uri-header = on
+
+    # Define the maximum request length (the default is 2048)
+    parsing {
+      max-uri-length = 32768
+      uri-parsing-mode = relaxed
+    }
+  }
+}

--- a/tests/integration/setup.js
+++ b/tests/integration/setup.js
@@ -33,12 +33,15 @@
  */
 
 define([
-	'intern!object'
-], function(registerSuite) {
+	'intern!object',
+	'intern/dojo/node!../micro'
+], function(registerSuite, micro) {
 
 	registerSuite({
 
 		name: 'Integration setup',
+
+		setup: micro.reset,
 
 		'Set up the page and send some events to request_recorder': function() {
 

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -44,6 +44,7 @@ define({
 		{ browserName: 'internet explorer', version: '9', platform: 'Windows 7' },
 		{ browserName: 'firefox', version: '27', platform: [ 'Windows 7', 'Linux' ] },
 		{ browserName: 'chrome', version: '32', platform: [ 'Windows 7', 'Linux' ] },
+		{ browserName: 'MicrosoftEdge', platform: 'Windows 10' },
 		{ browserName: 'safari', version: '8', platform: 'OS X 10.10' },
 		{ browserName: 'safari', version: '10', platform: 'OS X 10.11' }
 	],

--- a/tests/micro-template.js
+++ b/tests/micro-template.js
@@ -1,0 +1,30 @@
+const http = require('http');
+
+const collectorEndpoint = '<%= subdomain %>' + '.ngrok.io';
+const microResetUrl = `http://${collectorEndpoint}/micro/reset`;
+const microGoodUrl = `http://${collectorEndpoint}/micro/good`;
+const microBadUrl = `http://${collectorEndpoint}/micro/bad`;
+
+const createMicroCall = url => () =>
+	new Promise((resolve, reject) => {
+		const req = http.request(url, res => {
+			let body = '';
+			res.on('data', chunk => {
+				body += chunk;
+			});
+			res.on('end', () => {
+				resolve(body);
+			});
+		});
+		req.on('error', reject);
+		req.end();
+	});
+
+const fetchResults = () =>
+	createMicroCall(microGoodUrl)()
+		.then(good => JSON.parse(good));
+
+module.exports = {
+	reset: createMicroCall(microResetUrl),
+	fetchResults
+};

--- a/tests/pages/integration-template.html
+++ b/tests/pages/integration-template.html
@@ -69,9 +69,9 @@
   window.snowplow('setUserId', 'Malcolm');
   window.snowplow('trackPageView', 'My Title', [ // Auto-set page title; add page context
     {
-      schema: "iglu:com.example_company/user/jsonschema/2-0-0",
+      schema: "iglu:org.schema/WebPage/jsonschema/1-0-0",
       data: {
-        userType: 'tester'
+        keywords: ['tester']
       }
     }
   ]);
@@ -81,9 +81,9 @@
 
   window.snowplow('trackStructEvent', 'Mixes', 'Play', 'MRC/fabric-0503-mix', '', '0.0');
   window.snowplow('trackUnstructEvent', {
-    schema: 'iglu:com.acme_company/viewed_product/jsonschema/5-0-0',
+    schema: 'iglu:com.snowplowanalytics.snowplow/ad_impression/jsonschema/1-0-0',
     data: {
-      productId: 'ASO01043'
+      bannerId: 'ASO01043'
     }
   }, [], {type: 'ttm', value: 1477401868});
 
@@ -118,19 +118,19 @@
   window.snowplow('trackTrans');
 
   var testAcceptRuleSet = {
-    accept: ['iglu:com.acme_company/*/jsonschema/*-*-*']
+    accept: ['iglu:com.snowplowanalytics.snowplow/ad_impression/jsonschema/*-*-*']
   };
   var testRejectRuleSet = {
-    reject: ['iglu:com.acme_company/*/jsonschema/*-*-*']
+    reject: ['iglu:com.snowplowanalytics.snowplow/ad_impression/jsonschema/*-*-*']
   };
 
   // test context rulesets
   window.snowplow('addGlobalContexts', [[testAcceptRuleSet, [eventTypeContextGenerator, geolocationContext]]]);
 
   window.snowplow('trackUnstructEvent', {
-    schema: 'iglu:com.acme_company/viewed_product/jsonschema/5-0-0',
+    schema: 'iglu:com.snowplowanalytics.snowplow/ad_impression/jsonschema/1-0-0',
     data: {
-      productId: 'ASO01042'
+      bannerId: 'ASO01042'
     }
   }, [], {type: 'ttm', value: 1477401869});
 
@@ -138,9 +138,9 @@
 
   window.snowplow('addGlobalContexts', [[testRejectRuleSet, [eventTypeContextGenerator, geolocationContext]]]);
   window.snowplow('trackUnstructEvent', {
-    schema: 'iglu:com.acme_company/viewed_product/jsonschema/5-0-0',
+    schema: 'iglu:com.snowplowanalytics.snowplow/ad_impression/jsonschema/1-0-0',
     data: {
-      productId: 'ASO01041'
+      bannerId: 'ASO01041'
     }
   }, [], {type: 'ttm', value: 1477401868});
 


### PR DESCRIPTION

This work is all around the integration testing setup.

The good:

I've replaced the mock collector with a snowplow micro instance fired up by travis (and locally by hand). This meant re-wiring a bunch of the integration tests to use valid schemas, I picked some at random from the list on iglucentral.

The bad:

The way we populate the tunnel endpoint via a search and replace in the build is pretty wonky. I've proliferated the wonkyness in `micro-template.js`. There has to be a better way, something around env vars im betting.

I attempted to add a few modern browsers to the testing setup but all I could manage was edge. It looks like we have some issues with intern/selenium/sauce versions. I'm going to hazard a guess updating everything might help.

The discussion point:

I've used `lodash/fp`. It comes as default in lodash these days and has some really nice bits. I'm not tied to it however, its just a preference. So feel free to have a problem with it.
