### PR TITLE
stateStorageStrategy localStorage does not increase session counters

### DIFF
--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -315,7 +315,14 @@
 	 */
 	object.attemptGetLocalStorage = function (key) {
 		try {
-			return localStorage.getItem(key);
+			const exp = localStorage.getItem(key + '.expires');
+			if (exp === null || +exp > Date.now()) {
+				return localStorage.getItem(key);
+			} else {
+				localStorage.removeItem(key);
+				localStorage.removeItem(key + '.expires');
+			}
+			return undefined;
 		} catch(e) {}
 	};
 
@@ -324,10 +331,13 @@
 	 *
 	 * @param string key
 	 * @param string value
+	 * @param number ttl Time to live in seconds, defaults to 2 years from Date.now()
 	 * @return boolean Whether the operation succeeded
 	 */
-	object.attemptWriteLocalStorage = function (key, value) {
+	object.attemptWriteLocalStorage = function (key, value, ttl = 63072000) {
 		try {
+			const t = Date.now() + ttl*1000;
+			localStorage.setItem(`${key}.expires`, t);
 			localStorage.setItem(key, value);
 			return true;
 		} catch(e) {

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -657,7 +657,7 @@
 		 */
 		function setCookie(name, value, timeout) {
 			if (configStateStorageStrategy == 'localStorage') {
-				helpers.attemptWriteLocalStorage(name, value);
+				helpers.attemptWriteLocalStorage(name, value, timeout);
 			} else if (configStateStorageStrategy == 'cookie' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage') {
 				cookie.cookie(name, value, timeout, configCookiePath, configCookieDomain);

--- a/tests/integration/sessionStorage.spec.js
+++ b/tests/integration/sessionStorage.spec.js
@@ -1,0 +1,126 @@
+/*
+ * JavaScript tracker for Snowplow: tests/functional/integration.spec.js
+ *
+ * Significant portions copyright 2010 Anthon Pang. Remainder copyright
+ * 2012-2016 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Anthon Pang nor Snowplow Analytics Ltd nor the
+ *   names of their contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import util from 'util'
+import F from 'lodash/fp'
+import { reset, fetchResults, start, stop } from '../micro'
+
+const dumpLog = log => console.log(util.inspect(log, true, null, true))
+
+const isMatchWithCB = F.isMatchWith((lt, rt) =>
+  F.isFunction(rt) ? rt(lt) : undefined
+)
+
+describe('Test that request_recorder logs meet expectations', () => {
+  let log = []
+  let container
+  let containerUrl
+
+  const logContains = ev => F.some(isMatchWithCB(ev), log)
+
+  beforeAll(() => {
+    browser.call(() => {
+      return start()
+        .then(e => {
+          container = e
+          return container.inspect()
+        })
+        .then(info => {
+          containerUrl =
+            'snowplow-js-tracker.local:' +
+            F.get('NetworkSettings.Ports["9090/tcp"][0].HostPort', info)
+        })
+    })
+    browser.url('/index.html')
+    browser.setCookies({ name: 'container', value: containerUrl })
+    browser.url('/session-integration.html')
+    browser.pause(15000) // Time for requests to get written
+    browser.call(() =>
+      fetchResults(containerUrl).then(r => {
+        log = r
+        return Promise.resolve()
+      })
+    )
+  })
+
+  afterAll(() => {
+    log = []
+    browser.call(() => {
+      return stop(container)
+    })
+  })
+
+  it('should count sessions using cookies', () => {
+    expect(
+      logContains({
+        event: {
+          parameters: {
+            e: 'pv',
+            tna: 'cookieSessionTracker',
+            vid: '2',
+          },
+        },
+      })
+    ).toBe(true)
+  })
+
+  it('should count sessions using local storage', () => {
+    expect(
+      logContains({
+        event: {
+          parameters: {
+            e: 'pv',
+            tna: 'localStorageSessionTracker',
+            vid: '2',
+          },
+        },
+      })
+    ).toBe(true)
+  })
+
+  it('should only increment vid outside of session timeout (local storage)', () => {
+    const withSingleVid = ev =>
+      F.get('event.parameters.tna', ev) === 'localStorageSessionTracker' &&
+      F.get('event.parameters.vid', ev) === '1'
+
+    expect(F.size(F.filter(withSingleVid, log))).toBe(2)
+  })
+
+  it('should only increment vid outside of session timeout (cookie storage)', () => {
+    const withSingleVid = ev =>
+      F.get('event.parameters.tna', ev) === 'cookieSessionTracker' &&
+      F.get('event.parameters.vid', ev) === '1'
+
+    expect(F.size(F.filter(withSingleVid, log))).toBe(2)
+  })
+})

--- a/tests/pages/session-integration.html
+++ b/tests/pages/session-integration.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Session integration test page</title>
+</head>
+<body>
+<p id="title">Page for sending requests to request_recorder</p>
+
+<script>
+  var collector_endpoint = document.cookie.split('container=')[1].split(';')[0]
+  document.body.className += ' loaded';
+</script>
+
+<script>
+  ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
+    p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
+    };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
+    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","./snowplow.js","snowplow"));
+
+  document.write(collector_endpoint)
+
+  window.snowplow('newTracker', 'cookieSessionTracker', collector_endpoint, {
+    sessionCookieTimeout: 1,
+  });
+  window.snowplow('trackPageView:cookieSessionTracker');
+  window.snowplow('trackPageView:cookieSessionTracker');
+
+  setTimeout(function() {
+    window.snowplow('trackPageView:cookieSessionTracker');
+  }, 5000)
+
+  window.snowplow('newTracker', 'localStorageSessionTracker', collector_endpoint, {
+    sessionCookieTimeout: 1,
+    stateStorageStrategy: 'localStorage',
+  });
+  window.snowplow('trackPageView:localStorageSessionTracker');
+  window.snowplow('trackPageView:localStorageSessionTracker');
+
+  setTimeout(function() {
+    window.snowplow('trackPageView:localStorageSessionTracker');
+  }, 5000)
+
+</script>
+
+</body>
+</html>

--- a/tests/unit/storage.spec.js
+++ b/tests/unit/storage.spec.js
@@ -1,0 +1,66 @@
+/*
+ * Significant portions copyright 2010 Anthon Pang. Remainder copyright
+ * 2012-2016 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Anthon Pang nor Snowplow Analytics Ltd nor the
+ *   names of their contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const {
+  attemptGetLocalStorage,
+  attemptWriteLocalStorage
+} = require('../../src/js/lib/helpers')
+
+describe('local storage', () => {
+
+  beforeAll(() => {
+    localStorage.clear()
+  })
+
+  it('should work for pre existing values with no expiry', () => {
+    const value = 'value'
+    localStorage.setItem('key', value)
+    const retrieved = attemptGetLocalStorage('key')
+    expect(retrieved).toBe(value)
+  })
+
+  it('should return values', () => {
+    const value = 'value'
+    const ttl = 1
+    attemptWriteLocalStorage('key', value, ttl)
+    const retrieved = attemptGetLocalStorage('key')
+    expect(retrieved).toBe(value)
+  })
+
+  it('should not return expired values', () => {
+    const value = 'value'
+    const ttl = -1
+    attemptWriteLocalStorage('key', value, ttl)
+    const retrieved = attemptGetLocalStorage('key')
+    expect(retrieved).toBeUndefined()
+  })
+})

--- a/tests/wdio.local.conf.js
+++ b/tests/wdio.local.conf.js
@@ -13,6 +13,7 @@ exports.config = {
     },
   ],
   logLevel: 'debug',
+  specFileRetries: 0,
   bail: 1,
   services: ['chromedriver', 'static-server'],
 }


### PR DESCRIPTION
fixes #718 

I have taken the approach that local storage should full fill the same interface as cookie storage does.

This approach doesn't end up involving itself in the main tracker logic at all. It does however mean we are double writing and reading from local storage. Not ideal but a still much faster than writing a cookie.