### PR TITLE
Fix osx+safari testing setup issues

### DIFF
--- a/tests/functional/detectors.spec.js
+++ b/tests/functional/detectors.spec.js
@@ -31,7 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+import F from 'lodash/fp'
 import moment from 'moment-timezone'
 
 describe('Detectors test', () => {
@@ -59,7 +59,8 @@ describe('Detectors test', () => {
   })
 
   it('Check localStorage availability', () => {
-    expect($('#localStorageAccessible').getText()).toBe('true')
+    const supportsLocalStorage = !F.isMatch( { version: '12603.3.8', browserName: 'safari' }, browser.capabilities)
+    expect($('#localStorageAccessible').getText()).toBe(String(supportsLocalStorage))
   })
 
   it('Check sessionStorage availability', () => {

--- a/tests/functional/helpers.spec.js
+++ b/tests/functional/helpers.spec.js
@@ -31,8 +31,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+import F from 'lodash/fp'
 
 describe('Helpers test', () => {
+  // I think failure on click handlers are related to the following, skipping on effected browser/os combo
+  // https://support.saucelabs.com/hc/en-us/articles/115003957233-Safari-11-with-Selenium-3-x-not-Handling-Click-Events-on-Option-Elements
+  if (
+    F.isMatch(
+      { browserVersion: '13.0.1', 'safari:platformVersion': '10.13.6' },
+      browser.capabilities
+    )
+  ) {
+    fit('skipping in safari 13 on osx 10.13 (webdriver issue)', () => {})
+  }
 
   it('Gets page title', () => {
     browser.url('/helpers.html')

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -66,6 +66,19 @@ const hasGeoContext = isMatchWithCB({
 })
 
 describe('Test that request_recorder logs meet expectations', () => {
+  if (
+    F.isMatch(
+      { version: '12603.3.8', browserName: 'safari' },
+      browser.capabilities
+    )
+  ) {
+    // the safari driver sauce uses for safari 10 doesnt support
+    // setting cookies, so this whole suite fails
+    // https://github.com/webdriverio/webdriverio/issues/2004
+    fit('skipping in safari 10', () => {})
+    return
+  }
+
   let log = []
   let container
   let containerUrl
@@ -86,7 +99,10 @@ describe('Test that request_recorder logs meet expectations', () => {
         })
     })
     browser.url('/index.html')
-    browser.setCookies({ name: 'container', value: containerUrl })
+    browser.setCookies({
+      name: 'container',
+      value: containerUrl,
+    })
     browser.url('/integration.html')
     browser.pause(15000) // Time for requests to get written
     browser.call(() =>

--- a/tests/wdio.sauce.conf.js
+++ b/tests/wdio.sauce.conf.js
@@ -52,29 +52,24 @@ exports.config = {
       platformName: 'macOS 10.14',
       'sauce:options': { seleniumVersion: '3.14.0' },
     },
-    /* this fails on a click handler in helpers.js
     {
       browserName: 'safari',
       browserVersion: '13.0',
       platformName: 'macOS 10.13',
       'sauce:options': { seleniumVersion: '3.14.0' },
     },
-    */
     {
       browserName: 'safari',
       browserVersion: '11.0',
       platformName: 'macOS 10.12',
       'sauce:options': { seleniumVersion: '3.14.0' },
     },
-    /* this combo seems to have a problem with the cookie
-     * approach to set collector endpoint. Might be one
-     * we want to drop anyway
     {
       browserName: 'safari',
       platformName: 'macOS 10.12',
       browserVersion: '10.1',
       'sauce:options': { seleniumVersion: '3.14.0' },
-    },*/
+    },
     // and back to platform again
     {
       browserName: 'safari',


### PR DESCRIPTION
It turns out there are a couple of bugs in some of the safari driver version and a couple of nuances in the sauce labs/selenium/safari chain.

I have taken the approach of disabling the suites that fail in those browser/os combinations. Not ideal but we get to run the rest of the suites through and increase our testing area.