### PR TITLE
Dynamic context callbacks sometimes return null

### DIFF
--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -34,6 +34,7 @@
 ;(function () {
 
 	var
+		filter = require('lodash/filter'),
 		isString = require('lodash/isString'),
 		isUndefined = require('lodash/isUndefined'),
 		isObject = require('lodash/isObject'),
@@ -162,17 +163,19 @@
 	 */
 	object.resolveDynamicContexts = function (dynamicOrStaticContexts) {
 		let params = Array.prototype.slice.call(arguments, 1);
-		return map(dynamicOrStaticContexts, function(context) {
-			if (typeof context === 'function') {
-				try {
-					return context.apply(null, params);
-				} catch (e) {
-					//TODO: provide warning
+		return filter(
+			map(dynamicOrStaticContexts, function(context) {
+				if (typeof context === 'function') {
+					try {
+						return context.apply(null, params);
+					} catch (e) {
+						//TODO: provide warning
+					}
+				} else {
+					return context;
 				}
-			} else {
-				return context;
-			}
-		});
+			})
+		);
 	};
 
 	/**

--- a/tests/unit/helpers.spec.js
+++ b/tests/unit/helpers.spec.js
@@ -153,4 +153,15 @@ describe('resolveDynamicContexts', () => {
     const actual = resolveDynamicContexts([contextGenerator], 1, 2)
     expect(actual).toEqual(expected)
   })
+
+  it('Context generators which return empty are ignored', () => {
+    const contextGenerator = () => null;
+    const staticContext = {
+      schema: 'iglu:com.acme.marketing/some_event/jsonschema/1-0-0',
+      data: { test: 1 },
+    }
+    const expected = [staticContext]
+    const actual = resolveDynamicContexts([contextGenerator, staticContext])
+    expect(actual).toEqual(expected)
+  })
 })


### PR DESCRIPTION
fixes #743 

Pulled in from the work @max-tgam did here https://github.com/snowplow/snowplow-javascript-tracker/pull/747

Just added a quick test to make sure it stays this way.

Thanks for the help and patience @max-tgam