### PR TITLE
Issue/750 reset page ping timer

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1609,19 +1609,31 @@
 				helpers.addEventListener(windowAlias, 'resize', activityHandler);
 				helpers.addEventListener(windowAlias, 'focus', activityHandler);
 				helpers.addEventListener(windowAlias, 'blur', activityHandler);
-
-				// Periodic check for activity.
-				lastActivityTime = now.getTime();
 			}
 
-			if (activityTrackingConfig.activityTrackingEnabled && pagePingInterval === null && activityTrackingInstalled) {
+			// Periodic check for activity.
+			lastActivityTime = now.getTime();
+
+			//Clear page ping heartbeat on new page view
+			if (pagePingInterval !== null) {
+				clearTimeout(pagePingInterval);
+				pagePingInterval = null;
+			}
+
+			if (activityTrackingConfig.activityTrackingEnabled && activityTrackingInstalled) {
 				pagePingInterval = activityInterval({
 					...activityTrackingConfig,
 					callback: args => logPagePing({ context: finalizeContexts(context, contextCallback), ...args }) // Grab the min/max globals
 				});
 			}
 
-			if (activityTrackingCallbackConfig.activityTrackingEnabled && pagePingCallbackInterval === null && activityTrackingInstalled) {
+			//Clear page ping heartbeat on new page view
+			if (pagePingCallbackInterval !== null) {
+				clearTimeout(pagePingCallbackInterval);
+				pagePingCallbackInterval = null;
+			}
+
+			if (activityTrackingCallbackConfig.activityTrackingEnabled && activityTrackingInstalled) {
 				pagePingCallbackInterval = activityInterval(activityTrackingCallbackConfig);
 			}
 		}

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -87,6 +87,7 @@
 	 * 23. cookieLifetime, 63072000
 	 * 24. stateStorageStrategy, 'cookieAndLocalStorage'
 	 * 25. maxLocalStorageQueueSize, 1000
+	 * 26. resetActivityTrackingOnPageView, true
 	 */
 	object.Tracker = function Tracker(functionName, namespace, version, mutSnowplowState, argmap) {
 
@@ -182,14 +183,8 @@
 			// Maximum delay to wait for web bug image to be fetched (in milliseconds)
 			configTrackerPause = argmap.hasOwnProperty('pageUnloadTimer') ? argmap.pageUnloadTimer : 500,
 
-			// Whether appropriate values have been supplied to enableActivityTracking
-			activityTrackingEnabled = false,
-
-			// Minimum visit time after initial page view (in milliseconds)
-			configMinimumVisitTime,
-
-			// Recurring heart beat after initial ping (in milliseconds)
-			configHeartBeatTimer,
+			// Controls whether activity tracking page ping event timers are reset on page view events
+			resetActivityTrackingOnPageView = argmap.hasOwnProperty('resetActivityTrackingOnPageView') ? argmap.resetActivityTrackingOnPageView : true,
 
 			// Disallow hash tags in URL. TODO: Should this be set to true by default?
 			configDiscardHashTag,
@@ -1554,9 +1549,11 @@
 
 			// Send ping (to log that user has stayed on page)
 			var now = new Date();
+			var installingActivityTracking = false;
 
 			if ((activityTrackingConfig.activityTrackingEnabled || activityTrackingCallbackConfig.activityTrackingEnabled) && !activityTrackingInstalled) {
 				activityTrackingInstalled = true;
+				installingActivityTracking = true;
 
 				// Add mousewheel event handler, detect passive event listeners for performance
 				var detectPassiveEvents = {
@@ -1611,36 +1608,42 @@
 				helpers.addEventListener(windowAlias, 'blur', activityHandler);
 			}
 
-			// Periodic check for activity.
-			lastActivityTime = now.getTime();
+			if (resetActivityTrackingOnPageView || ((activityTrackingConfig.activityTrackingEnabled || activityTrackingCallbackConfig.activityTrackingEnabled) && installingActivityTracking)) {
+				// Periodic check for activity.
+				lastActivityTime = now.getTime();
 
-			//Clear page ping heartbeat on new page view
-			if (pagePingInterval !== null) {
-				clearTimeout(pagePingInterval);
-				pagePingInterval = null;
-			}
+				//Clear page ping heartbeat on new page view
+				if (pagePingInterval !== null) {
+					clearTimeout(pagePingInterval);
+					pagePingInterval = null;
+				}
 
-			if (activityTrackingConfig.activityTrackingEnabled && activityTrackingInstalled) {
-				pagePingInterval = activityInterval({
-					...activityTrackingConfig,
-					callback: args => logPagePing({ context: finalizeContexts(context, contextCallback), ...args }) // Grab the min/max globals
-				});
-			}
+				if (activityTrackingConfig.activityTrackingEnabled && activityTrackingInstalled) {
+					pagePingInterval = activityInterval({
+						...activityTrackingConfig,
+						configMinimumVisitTime: lastActivityTime + activityTrackingConfig.configMinimumVisitLength * 1000,
+						callback: args => logPagePing({ context: finalizeContexts(context, contextCallback), ...args }) // Grab the min/max globals
+					});
+				}
 
-			//Clear page ping heartbeat on new page view
-			if (pagePingCallbackInterval !== null) {
-				clearTimeout(pagePingCallbackInterval);
-				pagePingCallbackInterval = null;
-			}
+				//Clear page ping heartbeat on new page view
+				if (pagePingCallbackInterval !== null) {
+					clearTimeout(pagePingCallbackInterval);
+					pagePingCallbackInterval = null;
+				}
 
-			if (activityTrackingCallbackConfig.activityTrackingEnabled && activityTrackingInstalled) {
-				pagePingCallbackInterval = activityInterval(activityTrackingCallbackConfig);
+				if (activityTrackingCallbackConfig.activityTrackingEnabled && activityTrackingInstalled) {
+					pagePingCallbackInterval = activityInterval({
+						...activityTrackingCallbackConfig,
+						configMinimumVisitTime: lastActivityTime + activityTrackingCallbackConfig.configMinimumVisitLength * 1000
+					});
+				}
 			}
 		}
 
 		function activityInterval({ activityTrackingEnabled, configHeartBeatTimer, configMinimumVisitTime, callback }) {
 			if (!activityTrackingEnabled) return;
-
+			
 			return setInterval(function heartBeat() {
 				var now = new Date();
 
@@ -2086,7 +2089,7 @@
 				heartBeatDelay === parseInt(heartBeatDelay, 10)) {
 				activityTrackingConfig = {
 					activityTrackingEnabled: true,
-					configMinimumVisitTime: new Date().getTime() + minimumVisitLength * 1000,
+					configMinimumVisitLength: minimumVisitLength,
 					configHeartBeatTimer: heartBeatDelay * 1000
 				}
 			} else {
@@ -2107,7 +2110,7 @@
 				heartBeatDelay === parseInt(heartBeatDelay, 10)) {
 				activityTrackingCallbackConfig = {
 					activityTrackingEnabled: true,
-					configMinimumVisitTime: new Date().getTime() + minimumVisitLength * 1000,
+					configMinimumVisitLength: minimumVisitLength,
 					configHeartBeatTimer: heartBeatDelay * 1000,
 					callback
 				}

--- a/tests/unit/tracker.spec.js
+++ b/tests/unit/tracker.spec.js
@@ -86,6 +86,7 @@ describe('Activity tracker behaviour', () => {
       '',
       { outQueues },
       {
+        resetActivityTrackingOnPageView: false,
         stateStorageStrategy: 'cookies',
         encodeBase64: false,
         contexts: {
@@ -164,7 +165,47 @@ describe('Activity tracker behaviour', () => {
     expect(countWithStaticValueEq(pageTwoTime)(outQueues)).toBe(0)
   })
 
-  it('does not reset activity tracking on pageview', () => {
+  it('does not reset activity tracking on pageview when resetActivityTrackingOnPageView: false,', () => {
+    const outQueues = []
+    const Tracker = require('../../src/js/tracker').Tracker
+    const t = new Tracker(
+      '',
+      '',
+      '',
+      { outQueues },
+      {
+        resetActivityTrackingOnPageView: false,
+        stateStorageStrategy: 'cookies',
+        encodeBase64: false,
+        contexts: {
+          webPage: true,
+        },
+      }
+    )
+    t.enableActivityTracking(0, 30)
+    t.trackPageView()
+
+    advanceBy(15000)
+    jest.advanceTimersByTime(15000)
+
+    // activity on page one
+    t.updatePageActivity()
+    advanceBy(1000)
+
+    // shift to page two and trigger tick
+    t.trackPageView()
+    advanceBy(14000)
+    jest.advanceTimersByTime(15000)
+
+    // Activity was triggered on the first page.
+    // Activity tracking is currently not reset per page view so it is reported as happening on the second page.
+
+    const pps = getPPEvents(outQueues)
+
+    expect(F.size(pps)).toBe(1)
+  })
+
+  it('does reset activity tracking on pageview by default', () => {
     const outQueues = []
     const Tracker = require('../../src/js/tracker').Tracker
     const t = new Tracker(
@@ -195,17 +236,83 @@ describe('Activity tracker behaviour', () => {
     advanceBy(14000)
     jest.advanceTimersByTime(15000)
 
-    // Activity was triggered on the first page.
-    // Activity tracking is currently not reset per page view so it is reported as happening on the second page.
+    // Activity began tracking on the first page but moved on before 30 seconds.
+    // Activity tracking should still not have fire despite being on site 30 seconds, as user has moved page.
 
     const pps = getPPEvents(outQueues)
 
-    expect(F.size(pps)).toBe(1)
+    expect(F.size(pps)).toBe(0)
+  })
 
-    const pp = F.head(pps)
+  it('fires initial delayed activity tracking on first pageview and second pageview', () => {
+    const outQueues = []
+    const Tracker = require('../../src/js/tracker').Tracker
+    const t = new Tracker(
+      '',
+      '',
+      '',
+      { outQueues },
+      {
+        stateStorageStrategy: 'cookies',
+        encodeBase64: false,
+        contexts: {
+          webPage: true,
+        },
+      }
+    )
+    t.enableActivityTracking(10, 5)
 
+    t.trackPageView()
+    const firstPageId = t.getPageViewId()
+    advanceBy(5000)
+    jest.advanceTimersByTime(5000)
+
+    // callback timer starts tracking
+    advanceBy(1000)
+    t.updatePageActivity()
+    advanceBy(4000)
+    jest.advanceTimersByTime(5000)
+
+    // page ping timer starts tracking
+    advanceBy(1000)
+    t.updatePageActivity()
+    advanceBy(4000)
+    jest.advanceTimersByTime(5000)
+
+    advanceBy(1000)
+    t.updatePageActivity()
+    advanceBy(4000)
+    jest.advanceTimersByTime(5000)
+
+    t.trackPageView()
     const secondPageId = t.getPageViewId()
+    advanceBy(5000)
+    jest.advanceTimersByTime(5000)
 
-    expect(secondPageId).toBe(extractPageId(pp))
+    // window for callbacks ticks
+    advanceBy(1000)
+    t.updatePageActivity()
+    advanceBy(4000)
+    jest.advanceTimersByTime(5000)
+
+    // window for page ping ticks
+    advanceBy(1000)
+    t.updatePageActivity()
+    advanceBy(4000)
+    jest.advanceTimersByTime(5000)
+
+    // Activity began tracking on the first page and tracked two page pings in 16 seconds.
+    // Activity tracking only fires one further event over next 11 seconds as a page view event occurs, resetting timer back to 10 seconds.
+
+    const pps = getPPEvents(outQueues)
+
+    expect(F.size(pps)).toBe(3)
+
+    const pph = F.head(pps)
+    const ppl = F.last(pps)
+
+    expect(firstPageId).toBe(extractPageId(pph))
+    expect(secondPageId).toBe(extractPageId(ppl))
+
   })
 })


### PR DESCRIPTION
Changed default behaviour to fix a bug, where in a Single Page Application if you track a new Page View event, the Page Ping timers do not reset back to 0 and continue pinging the collector.

Now if you send a Page View event, the Page Pings will reset back to as they would with the first Page View (maintaining both the initial page ping delayed event and then the heartbeat page ping events).

As this is a change in behaviour that has existed for a while, I have introduced a new config flag `resetActivityTrackingOnPageView` that can be used to maintain previous behaviour (in case anyone has built modelling steps around this 'bugged' logic).