### PR TITLE
Issue/549 remove fingerprinting

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5406,8 +5406,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5428,14 +5427,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5450,20 +5447,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5580,8 +5574,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5593,7 +5586,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5608,7 +5600,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5616,14 +5607,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5642,7 +5631,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5723,8 +5711,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5736,7 +5723,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5822,8 +5808,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5859,7 +5844,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5879,7 +5863,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5923,14 +5906,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9275,11 +9256,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "murmurhash": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-0.0.2.tgz",
-      "integrity": "sha1-bwe9ihEF5wnCb8iUIMtZMMJFhf4="
     },
     "mute-stream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "browser-cookie-lite": "^1.0.4",
     "jstimezonedetect": "1.0.5",
-    "murmurhash": "0.0.2",
     "sha1": "git://github.com/pvorb/node-sha1.git#910081c83f3661507d9d89e66e3f38d8b59d5559",
     "snowplow-tracker-core": "^0.7.2",
     "uuid": "^3.3.3"
@@ -69,6 +68,8 @@
     "test:e2e:local": "docker pull snowplow/snowplow-micro && wdio tests/wdio.local.conf.js"
   },
   "jest": {
-    "setupFiles": ["jest-date-mock"]
+    "setupFiles": [
+      "jest-date-mock"
+    ]
   }
 }

--- a/src/js/lib/detectors.js
+++ b/src/js/lib/detectors.js
@@ -37,7 +37,6 @@
 	var
 		isFunction = require('lodash/isFunction'),
 		isUndefined = require('lodash/isUndefined'),
-		murmurhash3_32_gc = require('murmurhash').v3,
 		tz = require('jstimezonedetect').jstz.determine(),
 		cookie = require('browser-cookie-lite'),
 
@@ -105,39 +104,6 @@
 		}
 
 		return navigatorAlias.cookieEnabled ? '1' : '0';
-	};
-
-	/**
-	 * JS Implementation for browser fingerprint.
-	 * Does not require any external resources.
-	 * Based on https://github.com/carlo/jquery-browser-fingerprint
-	 * @return {number} 32-bit positive integer hash 
-	 */
-	object.detectSignature = function(hashSeed) {
-
-		var fingerprint = [
-			navigatorAlias.userAgent,
-			[ screenAlias.height, screenAlias.width, screenAlias.colorDepth ].join("x"),
-			( new Date() ).getTimezoneOffset(),
-			object.hasSessionStorage(),
-			object.hasLocalStorage()
-		];
-
-		var plugins = [];
-		if (navigatorAlias.plugins)
-		{
-			for(var i = 0; i < navigatorAlias.plugins.length; i++)
-			{
-				if (navigatorAlias.plugins[i]) {
-					var mt = [];
-					for(var j = 0; j < navigatorAlias.plugins[i].length; j++) {
-						mt.push([navigatorAlias.plugins[i][j].type, navigatorAlias.plugins[i][j].suffixes]);
-					}
-					plugins.push([navigatorAlias.plugins[i].name + "::" + navigatorAlias.plugins[i].description, mt.join("~")]);
-				}
-			}
-		}
-		return murmurhash3_32_gc(fingerprint.join("###") + "###" + plugins.sort().join(";"), hashSeed);
 	};
 
 	/*

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -68,7 +68,6 @@
 	 * 4. appId, ''
 	 * 5. platform, 'web'
 	 * 6. respectDoNotTrack, false
-	 * 7. userFingerprintSeed, 123412414
 	 * 8. pageUnloadTimer, 500
 	 * 9. forceSecureTracker, false
 	 * 10. forceUnsecureTracker, false
@@ -226,9 +225,6 @@
 			// Life of the session cookie (in seconds)
 			configSessionCookieTimeout = argmap.hasOwnProperty('sessionCookieTimeout') ? argmap.sessionCookieTimeout : 1800, // 30 minutes
 
-			// Default hash seed for MurmurHash3 in detectors.detectSignature
-			configUserFingerprintHashSeed = argmap.hasOwnProperty('userFingerprintSeed') ? argmap.userFingerprintSeed : 123412414,
-
 			// Document character set
 			documentCharset = documentAlias.characterSet || documentAlias.charset,
 
@@ -266,9 +262,6 @@
 				configStateStorageStrategy == 'cookie' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage',
 				getSnowplowCookieName('testcookie')),
-
-			// Visitor fingerprint
-			userFingerprint = (argmap.userFingerprint === false) ? '' : detectors.detectSignature(configUserFingerprintHashSeed),
 
 			// Unique ID for the tracker instance used to mark links which are being tracked
 			trackerId = functionName + '_' + namespace,
@@ -672,7 +665,7 @@
 		}
 
 		/**
-		 * Generate a pseudo-unique ID to fingerprint this user
+		 * Generate a pseudo-unique ID to identify this user
 		 */
 		function createNewDomainUserId() {
 			return uuid.v4();
@@ -783,7 +776,6 @@
 				toOptoutByCookie = false;
 			}
 
-
 			if ((configDoNotTrack || toOptoutByCookie) &&
 					configStateStorageStrategy != 'none') {
 				if (configStateStorageStrategy == 'localStorage') {
@@ -827,7 +819,6 @@
 			sb.add('vid', memorizedVisitCount);
 			sb.add('sid', memorizedSessionId);
 			sb.add('duid', _domainUserId); // Set to our local variable
-			sb.add('fp', userFingerprint);
 			sb.add('uid', businessUserId);
 
 			refreshUrl();
@@ -955,14 +946,6 @@
 					for (var i = 0; i < dimensionContexts.length; i++) {
 						combinedContexts.push(dimensionContexts[i]);
 					}
-				}
-			}
-
-			// Add Augur Context
-			if (autoContexts.augurIdentityLite) {
-				var augurIdentityLiteContext = getAugurIdentityLiteContext();
-				if (augurIdentityLiteContext) {
-					combinedContexts.push(augurIdentityLiteContext);
 				}
 			}
 
@@ -1352,32 +1335,6 @@
 					data: experiment
 				};
 			});
-		}
-
-		/**
-		 * Creates a context from the window['augur'] object
-		 *
-		 * @return object The IdentityLite context
-		 */
-		function getAugurIdentityLiteContext() {
-			var augur = windowAlias.augur;
-			if (augur) {
-				var context = { consumer: {}, device: {} };
-				var consumer = augur.consumer || {};
-				context.consumer.UUID = consumer.UID;
-				var device = augur.device || {};
-				context.device.ID = device.ID;
-				context.device.isBot = device.isBot;
-				context.device.isProxied = device.isProxied;
-				context.device.isTor = device.isTor;
-				var fingerprint = device.fingerprint || {};
-				context.device.isIncognito = fingerprint.browserHasIncognitoEnabled;
-
-				return {
-					schema: 'iglu:io.augur.snowplow/identity_lite/jsonschema/1-0-0',
-					data: context
-				};
-			}
 		}
 
 		/**
@@ -1860,7 +1817,8 @@
 		 * @return string The user fingerprint
 		 */
 		apiMethods.getUserFingerprint = function () {
-			return userFingerprint;
+			helpers.warn('User Fingerprinting is no longer supported. This function will be removed in a future release.');
+			return 0;
 		};
 
 		/**
@@ -1974,21 +1932,15 @@
 		/**
 		 * @param number seed The seed used for MurmurHash3
 		 */
-		apiMethods.setUserFingerprintSeed = function(seed) {
-			helpers.warn('setUserFingerprintSeed is deprecated. Instead add a "userFingerprintSeed" field to the argmap argument of newTracker.');
-			configUserFingerprintHashSeed = seed;
-			userFingerprint = detectors.detectSignature(configUserFingerprintHashSeed);
+		apiMethods.setUserFingerprintSeed = function() {
+			helpers.warn('User Fingerprinting is no longer supported. This function will be removed in a future release.');
 		};
 
 		/**
 		 * Enable/disable user fingerprinting. User fingerprinting is enabled by default.
-		 * @param bool enable If false, turn off user fingerprinting
 		 */
-		apiMethods.enableUserFingerprint = function(enable) {
-			helpers.warn('enableUserFingerprintSeed is deprecated. Instead add a "userFingerprint" field to the argmap argument of newTracker.');
-			if (!enable) {
-				userFingerprint = '';
-			}
+		apiMethods.enableUserFingerprint = function() {
+			helpers.warn('User Fingerprinting is no longer supported. This function will be removed in a future release.');
 		};
 
 		/**

--- a/tests/functional/detectors.spec.js
+++ b/tests/functional/detectors.spec.js
@@ -40,10 +40,6 @@ describe('Detectors test', () => {
     $('body.loaded').waitForExist()
   })
 
-  it('Returns a value for user fingerprint', () => {
-    expect($('#detectSignature').getText()).toBeTruthy()
-  })
-
   it('Returns a value for document dimensions', () => {
     const value = $('#detectDocumentDimensions').getText()
     const [reportedWidth, reportedHeight] = value.split('x')

--- a/tests/pages/detectors.html
+++ b/tests/pages/detectors.html
@@ -10,8 +10,7 @@
 	<p id="hasSessionStorage">sessionStorage here</p>
 	<p id="hasCookies">hasCookies here</p>
 	<p id="detectTimezone">Timezone here</p>
-	<p id="detectSignature">User fingerprint here</p>
-	<p id="detectBrowserFeatures">User fingerprint here</p>
+	<p id="detectBrowserFeatures">Browser features here</p>
 
 	<script src="./detectors.js"></script>
 

--- a/tests/scripts/detectors.js
+++ b/tests/scripts/detectors.js
@@ -40,5 +40,4 @@ document.getElementById('localStorageAccessible').innerHTML = detectors.localSto
 document.getElementById('hasSessionStorage').innerHTML = detectors.hasSessionStorage();
 document.getElementById('hasCookies').innerHTML = detectors.hasCookies();
 document.getElementById('detectTimezone').innerHTML = detectors.detectTimezone();
-document.getElementById('detectSignature').innerHTML = detectors.detectSignature();
 document.getElementById('detectBrowserFeatures').innerHTML = JSON.stringify(detectors.detectBrowserFeatures(), undefined, 2);


### PR DESCRIPTION
#549 I've taken the approach to remove all capabilities of fingerprinting within the tracker itself, however the api method stubs are still present so this can go out in a MINOR release but produce a warning when used. I will remove the remaining stubs in version 3.0.0.
This means fp will not be sent with any tracker events, and user_fingerprint will not be populated when using this tracker. Users are still free to add their own context containing user fingerprinting if they wish but there is no specific fingerprinting capabilities any more.

I've also taken this opporuntity to remove the augur.io fingerprint capture we have as an autocontext. Again, users can manually add this as a context if they wish but as the goal here is to removing automatic fingerprinting from the tracker, it seems reasonable to remove the augur identity trackig too. Also augur.io does appear to be a dead project now from what I can tell.