### PR TITLE
Update beacon support to handle "gotchas" (close #716)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-Version 2.13.0 (2019-11-21)
+Version 2.13.0 (2019-01-16)
 ---------------------------
 Add activity tracking callback mechanism (#774)
+Update beacon support to handle "gotchas" (#716)
 
 Version 2.12.0 (2019-10-31)
 ---------------------------

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "2.13.0-M1",
+  "version": "2.13.0-M2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5406,8 +5406,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5428,14 +5427,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5450,20 +5447,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5580,8 +5574,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5593,7 +5586,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5608,7 +5600,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5616,14 +5607,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5642,7 +5631,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5723,8 +5711,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5736,7 +5723,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5822,8 +5808,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5859,7 +5844,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5879,7 +5863,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5923,14 +5906,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "2.13.0-M1",
+  "version": "2.13.0-M2",
   "dependencies": {
     "browser-cookie-lite": "^1.0.4",
     "jstimezonedetect": "1.0.5",
@@ -69,6 +69,8 @@
     "test:e2e:local": "docker pull snowplow/snowplow-micro && wdio tests/wdio.local.conf.js"
   },
   "jest": {
-    "setupFiles": ["jest-date-mock"]
+    "setupFiles": [
+      "jest-date-mock"
+    ]
   }
 }

--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -348,6 +348,37 @@
 		}
 	};
 
+		/**
+	 * Attempt to get a value from localStorage
+	 *
+	 * @param string key
+	 * @return string The value obtained from localStorage, or
+	 *                undefined if localStorage is inaccessible
+	 */
+	object.attemptGetSessionStorage = function (key) {
+		try {
+			return sessionStorage.getItem(key);
+		} catch(e) {
+			return null;
+		}
+	};
+
+	/**
+	 * Attempt to write a value to localStorage
+	 *
+	 * @param string key
+	 * @param string value
+	 * @return boolean Whether the operation succeeded
+	 */
+	object.attemptWriteSessionStorage = function (key, value) {
+		try {
+			sessionStorage.setItem(key, value);
+			return true;
+		} catch(e) {
+			return false;
+		}
+	};
+
 	/**
 	 * Finds the root domain
 	 */

--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -300,7 +300,7 @@
 				if (batch.length > 0) {
 					var beaconStatus;
 
-					if (useBeacon) {
+					if (useBeacon && helpers.attemptGetSessionStorage('sp_corsPreflight')) {
 						const headers = { type: 'application/json' };
 						const blob = new Blob([encloseInPayloadDataEnvelope(attachStmToEvent(batch))], headers);
 						try {
@@ -319,6 +319,7 @@
 
 					if (!useBeacon || !beaconStatus) {
 						xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
+						helpers.attemptWriteSessionStorage('sp_corsPreflight', true);
 					}
 				}
 


### PR DESCRIPTION
#716 #751 Now fires the first event with POST to ensure any CORS preflight requests have been sent by the browser before we start using Beacon. This does now require sessionStorage to be available for beacon to work, however we will gracefully fallback to Post if sessionStorage isn't available, this seems like a reasonable sacrifice to improve beacon events from Safari.

Having to send the preflight via POST is an unfortunate consequence of Safari's Beacon implementation that doesn't send preflight requests, where we potentially lose events if the beacon event is sent to a url that the browser has never visited before.
This won't fix beacon events on Chromium based browsers but they successfully fallback to POST until the Chromium team fix sending Blobs via Beacon API.