### PR TITLE
Issue/716 update beacon support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-Version 2.13.0 (2019-11-21)
+Version 2.13.0 (2019-01-16)
 ---------------------------
 Add activity tracking callback mechanism (#774)
+Update beacon support to handle "gotchas" (#716)
 
 Version 2.12.0 (2019-10-31)
 ---------------------------

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "2.13.0-M1",
+  "version": "2.13.0-M2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "2.13.0-M1",
+  "version": "2.13.0-M2",
   "dependencies": {
     "browser-cookie-lite": "^1.0.4",
     "jstimezonedetect": "1.0.5",

--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -348,6 +348,37 @@
 		}
 	};
 
+		/**
+	 * Attempt to get a value from localStorage
+	 *
+	 * @param string key
+	 * @return string The value obtained from localStorage, or
+	 *                undefined if localStorage is inaccessible
+	 */
+	object.attemptGetSessionStorage = function (key) {
+		try {
+			return sessionStorage.getItem(key);
+		} catch(e) {
+			return null;
+		}
+	};
+
+	/**
+	 * Attempt to write a value to localStorage
+	 *
+	 * @param string key
+	 * @param string value
+	 * @return boolean Whether the operation succeeded
+	 */
+	object.attemptWriteSessionStorage = function (key, value) {
+		try {
+			sessionStorage.setItem(key, value);
+			return true;
+		} catch(e) {
+			return false;
+		}
+	};
+
 	/**
 	 * Finds the root domain
 	 */

--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -300,7 +300,7 @@
 				if (batch.length > 0) {
 					var beaconStatus;
 
-					if (useBeacon) {
+					if (useBeacon && helpers.attemptGetSessionStorage('sp_corsPreflight')) {
 						const headers = { type: 'application/json' };
 						const blob = new Blob([encloseInPayloadDataEnvelope(attachStmToEvent(batch))], headers);
 						try {
@@ -319,6 +319,7 @@
 
 					if (!useBeacon || !beaconStatus) {
 						xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(batch)));
+						helpers.attemptWriteSessionStorage('sp_corsPreflight', true);
 					}
 				}
 


### PR DESCRIPTION
#716 #751 Now fires the first event with POST to ensure any CORS preflight requests have been sent by the browser before we start using Beacon. This does now require sessionStorage to be available for beacon to work, however we will gracefully fallback to Post if sessionStorage isn't available, this seems like a reasonable sacrifice to improve beacon events from Safari.

Having to send the preflight via POST is an unfortunate consequence of Safari's Beacon implementation that doesn't send preflight requests, where we potentially lose events if the beacon event is sent to a url that the browser has never visited before.
This won't fix beacon events on Chromium based browsers but they successfully fallback to POST until the Chromium team fix sending Blobs via Beacon API.