### PR TITLE
Fix SameSite cookie warning for storage Cookies (close #795)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2885,11 +2885,6 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
-    "browser-cookie-lite": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/browser-cookie-lite/-/browser-cookie-lite-1.0.4.tgz",
-      "integrity": "sha1-JFUm+YH6/sZbjfIb7Cl3H1RsAWA="
-    },
     "browser-pack": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "snowplow-tracker",
   "version": "2.13.0",
   "dependencies": {
-    "browser-cookie-lite": "^1.0.4",
     "jstimezonedetect": "1.0.5",
     "sha1": "git://github.com/pvorb/node-sha1.git#910081c83f3661507d9d89e66e3f38d8b59d5559",
     "snowplow-tracker-core": "^0.7.2",

--- a/src/js/lib/detectors.js
+++ b/src/js/lib/detectors.js
@@ -38,7 +38,7 @@
 		isFunction = require('lodash/isFunction'),
 		isUndefined = require('lodash/isUndefined'),
 		tz = require('jstimezonedetect').jstz.determine(),
-		cookie = require('browser-cookie-lite'),
+		helpers = require('./helpers'),
 
 		object = typeof exports !== 'undefined' ? exports : this, // For eventual node.js environment support
 		
@@ -99,8 +99,8 @@
 		var cookieName = testCookieName || 'testcookie';
 
 		if (isUndefined(navigatorAlias.cookieEnabled)) {
-			cookie.cookie(cookieName, '1');
-			return cookie.cookie(cookieName) === '1' ? '1' : '0';
+			helpers.cookie(cookieName, '1');
+			return helpers.cookie(cookieName) === '1' ? '1' : '0';
 		}
 
 		return navigatorAlias.cookieEnabled ? '1' : '0';

--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -39,7 +39,6 @@
 		isUndefined = require('lodash/isUndefined'),
 		isObject = require('lodash/isObject'),
 		map = require('lodash/map'),
-		cookie = require('browser-cookie-lite'),
 
 		object = typeof exports !== 'undefined' ? exports : this; // For eventual node.js environment support
 
@@ -391,8 +390,8 @@
 		var position = split.length - 1;
 		while (position >= 0) {
 			var currentDomain = split.slice(position, split.length).join('.');
-			cookie.cookie(cookieName, cookieValue, 0, '/', currentDomain);
-			if (cookie.cookie(cookieName) === cookieValue) {
+			object.cookie(cookieName, cookieValue, 0, '/', currentDomain);
+			if (object.cookie(cookieName) === cookieValue) {
 
 				// Clean up created cookie(s)
 				object.deleteCookie(cookieName, currentDomain);
@@ -433,7 +432,7 @@
 	 * @param domainName The domain the cookie is in
 	 */
 	object.deleteCookie = function (cookieName, domainName) {
-		cookie.cookie(cookieName, '', -1, '/', domainName);
+		object.cookie(cookieName, '', -1, '/', domainName);
 	};
 
 	/**
@@ -452,6 +451,33 @@
 		}
 		return cookieNames;
 	};
+
+	/**
+	 * Get and set the cookies associated with the current document in browser
+	 * This implementation always returns a string, returns the cookie value if only name is specified
+	 *
+	 * @param name The cookie name (required)
+	 * @param value The cookie value
+	 * @param ttl The cookie Time To Live (seconds)
+	 * @param path The cookies path
+	 * @param domain The cookies domain
+	 * @param samesite The cookies samesite attribute
+	 * @param secure Boolean to specify if cookie should be secure
+	 * @return string The cookies value
+	 */
+	object.cookie = function(name, value, ttl, path, domain, samesite, secure) {
+
+		if (arguments.length > 1) {
+			return document.cookie = name + "=" + encodeURIComponent(value) +
+				(ttl ? "; Expires=" + new Date(+new Date()+(ttl*1000)).toUTCString() : "") +
+				(path   ? "; Path=" + path : "") +
+				(domain ? "; Domain=" + domain : "") +
+				(samesite ? "; SameSite=" + samesite : "") +
+				(secure ? "; Secure" : "");
+		}
+	
+		return decodeURIComponent((("; "+document.cookie).split("; "+name+"=")[1]||"").split(";")[0]);
+	}
 
 	/**
 	 * Parses an object and returns either the

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -39,7 +39,6 @@
 		map = require('lodash/map'),
 		helpers = require('./lib/helpers'),
 		proxies = require('./lib/proxies'),
-		cookie = require('browser-cookie-lite'),
 		detectors = require('./lib/detectors'),
 		sha1 = require('sha1'),
 		links = require('./links'),
@@ -201,6 +200,12 @@
 			// First-party cookie path
 			// Default is user agent defined.
 			configCookiePath = '/',
+
+			// First-party cookie samesite attribute
+			configCookieSameSite = argmap.hasOwnProperty('cookieSameSite') ? argmap.cookieSameSite : 'None',
+
+			// First-party cookie secure attribute
+			configCookieSecure = argmap.hasOwnProperty('cookieSecure') ? argmap.cookieSecure : true,
 
 			// Do Not Track browser feature
 			dnt = navigatorAlias.doNotTrack || navigatorAlias.msDoNotTrack || windowAlias.doNotTrack,
@@ -509,7 +514,7 @@
 			// Set to true if Opt-out cookie is defined
 			var toOptoutByCookie;
 			if (configOptOutCookie) {
-				toOptoutByCookie = !!cookie.cookie(configOptOutCookie);
+				toOptoutByCookie = !!helpers.cookie(configOptOutCookie);
 			} else {
 				toOptoutByCookie = false;
 			}
@@ -536,7 +541,7 @@
 				return helpers.attemptGetLocalStorage(fullName);
 			} else if (configStateStorageStrategy == 'cookie' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage') {
-				return cookie.cookie(fullName);
+				return helpers.cookie(fullName);
 			}
 		}
 
@@ -655,7 +660,7 @@
 				helpers.attemptWriteLocalStorage(name, value, timeout);
 			} else if (configStateStorageStrategy == 'cookie' ||
 					configStateStorageStrategy == 'cookieAndLocalStorage') {
-				cookie.cookie(name, value, timeout, configCookiePath, configCookieDomain);
+				helpers.cookie(name, value, timeout, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
 			}
 		}
 
@@ -766,7 +771,7 @@
 
 			var toOptoutByCookie;
 			if (configOptOutCookie) {
-				toOptoutByCookie = !!cookie.cookie(configOptOutCookie);
+				toOptoutByCookie = !!helpers.cookie(configOptOutCookie);
 			} else {
 				toOptoutByCookie = false;
 			}
@@ -778,8 +783,8 @@
 					helpers.attemptWriteLocalStorage(sesname, '');
 				} else if (configStateStorageStrategy == 'cookie' ||
 						configStateStorageStrategy == 'cookieAndLocalStorage') {
-					cookie.cookie(idname, '', -1, configCookiePath, configCookieDomain);
-					cookie.cookie(sesname, '', -1, configCookiePath, configCookieDomain);
+					helpers.cookie(idname, '', -1, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
+					helpers.cookie(sesname, '', -1, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
 				}
 				return;
 			}
@@ -1452,7 +1457,7 @@
 		function getGaCookiesContext() {
 			var gaCookieData = {};
 			forEach(['__utma', '__utmb', '__utmc', '__utmv', '__utmz', '_ga'], function (cookieType) {
-				var value = cookie.cookie(cookieType);
+				var value = helpers.cookie(cookieType);
 				if (value) {
 					gaCookieData[cookieType] = value;
 				}
@@ -2176,7 +2181,7 @@
 		 * @param string cookieName Name of the cookie whose value will be assigned to businessUserId
 		 */
 		apiMethods.setUserIdFromCookie = function(cookieName) {
-			businessUserId = cookie.cookie(cookieName);
+			businessUserId = helpers.cookie(cookieName);
 		};
 
 		/**


### PR DESCRIPTION
This feature now sets the two cookies which are set by the JavaScript tracker to `SameSite=None; Secure` by default. This has no impact on the behaviour of the cookie from the point of view of the JavaScript tracker, it simply reads and writes this cookie as a storage target to be added to the JSON payload - it does not need to be sent to the collector as a header.

It does however, remove the warning in Chrome when these cookies are included in requests to collectors (due to the cookie being set on the same domain as the collector).

Also, the default needs to be `SameSite=None; Secure` rather than `SameSite=Lax` so that the tracker continues to work in iframes with the default settings. The only change to the defaults here, are that cookies will only work on HTTPS now. If that is a problem for users then they can set `cookieSecure: false` on tracker initialisation. 

Old behaviour (with Chrome warning and not working in third party iframes) can be achieved with `cookieSameSite: null` and `cookieSecure: false`.

Users can also choose to go with `cookieSameSite` parameter of `None` (default), `Lax` or `Strict` if they wish, I'll ensure to document this and mention it in the upgrading section of the blog post.