### PR TITLE
Upgrade UUID to ^3.3.3

### DIFF
--- a/core/npm-shrinkwrap.json
+++ b/core/npm-shrinkwrap.json
@@ -13,15 +13,13 @@
     "@types/node": {
       "version": "9.6.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.55.tgz",
-      "integrity": "sha512-e/5tg8Ok0gSrN6pvHphnwTK0/CD9VPZrtZqpvvpEFAtfs+ZntusgGaWkf2lSEq1OFe2EDPeUMiMVpy4nZpJ4AQ=="
+      "integrity": "sha512-e/5tg8Ok0gSrN6pvHphnwTK0/CD9VPZrtZqpvvpEFAtfs+ZntusgGaWkf2lSEq1OFe2EDPeUMiMVpy4nZpJ4AQ==",
+      "dev": true
     },
     "@types/uuid": {
-      "version": "2.0.31",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-2.0.31.tgz",
-      "integrity": "sha512-ZAaSLKWhe39IIiDKsXyAEVZ53aa3oYzgVFdN8Yqn4Xu8XGyWqKY64P0aHhpj0r0d84qzCmJmeNdHXub7lC6TOQ==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
+      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -264,6 +262,12 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
         }
       }
     },
@@ -2690,9 +2694,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "vali-date": {
       "version": "1.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -11,9 +11,9 @@
     "typescript": "2.2.2"
   },
   "dependencies": {
-    "@types/uuid": "^2.0.29",
+    "@types/uuid": "^3.4.6",
     "lodash": "^4.17.11",
-    "uuid": "2.0.3"
+    "uuid": "^3.3.3"
   },
   "contributors": [
     "Alex Dean",


### PR DESCRIPTION
This matches the version used in the snowplow-javascript-tracker. This
will help utilizing just _one_ version of uuid and should reduce build
size of the resulting javascript.

[0]: https://github.com/snowplow/snowplow-javascript-tracker/blob/8b846ba/package.json