### PR TITLE
Don't overwrite custom user defined event id

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -782,8 +782,8 @@ export function trackerCore(base64: boolean, callback?: (PayloadData: PayloadDat
     tstamp?: Timestamp,
     afterTrack?: (Payload: PayloadDictionary) => void
   ): PayloadData => {
-    sb.addDict(payloadPairs);
     sb.add('eid', v4());
+    sb.addDict(payloadPairs);
     const timestamp = getTimestamp(tstamp);
     sb.add(timestamp.type, timestamp.value.toString());
     const allContexts = attachGlobalContexts(sb, context);


### PR DESCRIPTION
In some cases, we already set an event id provided via `payloadPairs` and it's important for us to keep that event id. However, currently in the core tracker the event id is overwritten no matter what. One very simple solution to this issue is to switch the order of adding the event id and the `payloadPairs`. In the normal way of using the tracker without providing an own event id, nothing changes.