### PR TITLE
Release/2.17.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 2.17.1 (2020-02-03)
+---------------------------
+Prevent samesite cookie warning from triggering (#886)
+Remove server side anonymisation headers on Beacon (#887)
+
 Version 2.17.0 (2020-12-15)
 ---------------------------
 Upgrade typescript to 4.1 (#870)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19792,9 +19792,9 @@
           }
         },
         "tslib": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         },
         "tsutils": {
           "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "scripts": {
     "build": "gulp build",
     "build:all": "(cd core && npm run build) && npm run build",

--- a/src/js/lib/detectors.js
+++ b/src/js/lib/detectors.js
@@ -34,7 +34,7 @@
 
 import isUndefined from 'lodash/isUndefined';
 import { jstz } from 'jstimezonedetect';
-import { isFunction, cookie } from '../lib/helpers'
+import { isFunction } from '../lib/helpers'
 
 var windowAlias = window,
   navigatorAlias = navigator,
@@ -89,14 +89,7 @@ export function localStorageAccessible() {
 /*
  * Does browser have cookies enabled (for this site)?
  */
-export function hasCookies(testCookieName) {
-  var cookieName = testCookieName || 'testcookie';
-
-  if (isUndefined(navigatorAlias.cookieEnabled)) {
-    cookie(cookieName, '1');
-    return cookie(cookieName) === '1' ? '1' : '0';
-  }
-
+export function hasCookies() {
   return navigatorAlias.cookieEnabled ? '1' : '0';
 }
 
@@ -154,7 +147,7 @@ export function detectDocumentSize() {
  * @param string testCookieName Name to use for the test cookie
  * @return Object containing browser features
  */
-export function detectBrowserFeatures(useCookies, testCookieName) {
+export function detectBrowserFeatures() {
   var i,
     mimeType,
     pluginMap = {
@@ -206,9 +199,7 @@ export function detectBrowserFeatures(useCookies, testCookieName) {
   // Other browser features
   features.res = screenAlias.width + 'x' + screenAlias.height;
   features.cd = screenAlias.colorDepth;
-  if (useCookies) {
-    features.cookie = hasCookies(testCookieName);
-  }
+  features.cookie = hasCookies();
 
   return features;
 }

--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -401,7 +401,7 @@ export function attemptWriteSessionStorage(key, value) {
 /**
  * Finds the root domain
  */
-export function findRootDomain() {
+export function findRootDomain(sameSite, secure) {
   var cookiePrefix = '_sp_root_domain_test_';
   var cookieName = cookiePrefix + new Date().getTime();
   var cookieValue = '_test_value_' + new Date().getTime();
@@ -410,13 +410,13 @@ export function findRootDomain() {
   var position = split.length - 1;
   while (position >= 0) {
     var currentDomain = split.slice(position, split.length).join('.');
-    cookie(cookieName, cookieValue, 0, '/', currentDomain);
+    cookie(cookieName, cookieValue, 0, '/', currentDomain, sameSite, secure);
     if (cookie(cookieName) === cookieValue) {
       // Clean up created cookie(s)
-      deleteCookie(cookieName, currentDomain);
+      deleteCookie(cookieName, currentDomain, sameSite, secure);
       var cookieNames = getCookiesWithPrefix(cookiePrefix);
       for (var i = 0; i < cookieNames.length; i++) {
-        deleteCookie(cookieNames[i], currentDomain);
+        deleteCookie(cookieNames[i], currentDomain, sameSite, secure);
       }
 
       return currentDomain;
@@ -450,8 +450,8 @@ export function isValueInArray(val, array) {
  * @param cookieName The name of the cookie to delete
  * @param domainName The domain the cookie is in
  */
-export function deleteCookie(cookieName, domainName) {
-  cookie(cookieName, '', -1, '/', domainName);
+export function deleteCookie(cookieName, domainName, sameSite, secure) {
+  cookie(cookieName, '', -1, '/', domainName, sameSite, secure);
 }
 
 /**

--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -332,11 +332,7 @@ export function OutQueueManager(
           });
 
           if (beaconPreflight) {
-            const headers = { type: 'application/json' };
-            if (anonymousTracking) {
-              header['SP-Anonymous'] = '*';
-            }
-            const blob = new Blob([encloseInPayloadDataEnvelope(attachStmToEvent(eventBatch))], headers);
+            const blob = new Blob([encloseInPayloadDataEnvelope(attachStmToEvent(eventBatch))], { type: 'application/json' });
             try {
               beaconStatus = navigator.sendBeacon(url, blob);
             } catch (error) {

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -256,10 +256,7 @@ export function Tracker(functionName, namespace, version, mutSnowplowState, argm
     // Browser language (or Windows language for IE). Imperfect but CloudFront doesn't log the Accept-Language header
     browserLanguage = navigatorAlias.userLanguage || navigatorAlias.language,
     // Browser features via client-side data collection
-    browserFeatures = detectBrowserFeatures(
-      configStateStorageStrategy == 'cookie' || configStateStorageStrategy == 'cookieAndLocalStorage',
-      getSnowplowCookieName('testcookie')
-    ),
+    browserFeatures = detectBrowserFeatures(),
     // Unique ID for the tracker instance used to mark links which are being tracked
     trackerId = functionName + '_' + namespace,
     // Last activity timestamp
@@ -353,7 +350,7 @@ export function Tracker(functionName, namespace, version, mutSnowplowState, argm
   let gdprBasisData = {};
 
   if (argmap.hasOwnProperty('discoverRootDomain') && argmap.discoverRootDomain) {
-    configCookieDomain = findRootDomain();
+    configCookieDomain = findRootDomain(configCookieSameSite, configCookieSecure);
   }
 
   if (autoContexts.gaCookies) {
@@ -691,8 +688,8 @@ export function Tracker(functionName, namespace, version, mutSnowplowState, argm
     const sesname = getSnowplowCookieName('ses');
     attemptDeleteLocalStorage(idname);
     attemptDeleteLocalStorage(sesname);
-    deleteCookie(idname);
-    deleteCookie(sesname);
+    deleteCookie(idname, configCookieDomain, configCookieSameSite, configCookieSecure);
+    deleteCookie(sesname, configCookieDomain, configCookieSameSite, configCookieSecure);
   }
 
   /*


### PR DESCRIPTION
Removed the use of cookies which don't have any samesite attributes. Also removed the physical cookie check in `hasCookies` for the detectors as `navigator.cookieEnabled` has been supported since IE4 so this code never fires.

Also removed the anonymous headers on beacon requests as they have no effect. Server Side Anonymous tracking doesn't actually work when using Beacon, will add a note to the docs to make this clear.