### PR TITLE
#fix #890 by disabling buffering after it has been flushed on `beforeunload`

### DIFF
--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -128,6 +128,9 @@ export function OutQueueManager(
       if (!executingQueue) {
         executeQueue();
       }
+
+      // We've flushed the buffers, but if bufferSize > 1; we'll just buffer any following events...
+      bufferSize = 1; // ...So force bufferSize to 1 to force any subsequent events to send out immediately and not buffer
     });
   }
 


### PR DESCRIPTION
https://github.com/snowplow/snowplow-javascript-tracker/issues/890

Disable buffering once the tracker has cleared the buffer during `beforeUnload` by forcing bufferSize to be 1 so any subsequent events get sent out immediately