### PR TITLE
Release/3.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,11 @@ jobs:
         run: node common/scripts/install-run-rush.js install
 
       - name: Setup git
-        uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        uses: oleksiyrudenko/gha-git-credentials@v2.1
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
+          name: github-actions[bot]
+          email: 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Rush Version
         run: node common/scripts/install-run-rush.js version --bump --target-branch master
@@ -60,19 +62,25 @@ jobs:
       - name: Rush Publish
         run: node common/scripts/install-run-rush.js publish --apply --include-all --publish --target-branch master --set-access-level public
 
-      - name: Push tag
+      - name: Generate Release Information
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.3
+        uses: mathieudutour/github-tag-action@v5.4
         with:
+          dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: ''
           default_bump: false
           custom_tag: ${{ github.event.inputs.version }}
 
+      - name: Tag release
+        run: |
+          git tag -a ${{ steps.tag_version.outputs.new_tag }} -m "Version ${{ steps.tag_version.outputs.new_tag }}"
+          git push --tags
+
       - name: Zip plugins
         run: zip -r plugins.umd.zip ./plugins/*/dist/*.umd*.js*
 
-      - name: Release
+      - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:
           name: Version ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The release tag'
+        description: 'The prerelease tag'
         required: true
 
 jobs:
@@ -34,9 +34,11 @@ jobs:
         run: node common/scripts/install-run-rush.js install
 
       - name: Setup git
-        uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        uses: oleksiyrudenko/gha-git-credentials@v2.1
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
+          name: github-actions[bot]
+          email: 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Rush Version
         run: node common/scripts/install-run-rush.js version --bump
@@ -60,14 +62,20 @@ jobs:
       - name: Rush Publish
         run: node common/scripts/install-run-rush.js publish --apply --include-all --publish --tag next --set-access-level public
 
-      - name: Push tag
+      - name: Generate Release Information
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.3
+        uses: mathieudutour/github-tag-action@v5.4
         with:
+          dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: ''
           default_bump: false
           custom_tag: ${{ github.event.inputs.version }}
+
+      - name: Tag release
+        run: |
+          git tag -a ${{ steps.tag_version.outputs.new_tag }} -m "Version ${{ steps.tag_version.outputs.new_tag }}"
+          git push --tags
 
       - name: Zip plugins
         run: zip -r plugins.umd.zip ./plugins/*/dist/*.umd*.js*

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add analytics to your websites, web apps and Node.js applications with the [Snow
 With these trackers you can collect user event data (page views, e-commerce transactions etc) from the
 client-side and server-side tiers of your websites and web apps.
 
-**Technical documentation can be found for each tracker in our [Documentation](docs).**
+**Technical documentation can be found for each tracker in our [Documentation][docs].**
 
 ### @snowplow/browser-tracker (npm)
 
@@ -41,7 +41,7 @@ client-side and server-side tiers of your websites and web apps.
 | Contributing                         |
 |--------------------------------------|
 | ![i7][contributing-image]            |
-| [Contributing](Contributing.md)      |
+| [Contributing](CONTRIBUTING.md)      |
 
 ### Contributing quick start
 

--- a/common/changes/@snowplow/browser-plugin-ad-tracking/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-ad-tracking/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ad-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ad-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ad-tracking/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-ad-tracking/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ad-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ad-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ad-tracking/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-ad-tracking/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ad-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ad-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-browser-features/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-browser-features/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-browser-features"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-browser-features",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-browser-features/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-browser-features/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-browser-features"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-browser-features",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-browser-features/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-browser-features/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-browser-features"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-browser-features",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-client-hints/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-client-hints"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-client-hints",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-client-hints/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-client-hints"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-client-hints",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-client-hints/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-client-hints"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-client-hints",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-consent/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-consent/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-consent"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-consent",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-consent/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-consent/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-consent"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-consent",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-consent/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-consent/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-consent"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-consent",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-debugger/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-debugger/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-debugger"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-debugger",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-debugger/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-debugger/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-debugger"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-debugger",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-debugger/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-debugger/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-debugger"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-debugger",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ecommerce/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-ecommerce/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ecommerce",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ecommerce/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-ecommerce/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ecommerce",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ecommerce/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-ecommerce/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ecommerce",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-error-tracking/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-error-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-error-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-error-tracking/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-error-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-error-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-error-tracking/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-error-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-error-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-form-tracking/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-form-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-form-tracking/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-form-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-form-tracking/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-form-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ga-cookies/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-ga-cookies/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ga-cookies"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ga-cookies",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ga-cookies/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-ga-cookies/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ga-cookies"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ga-cookies",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ga-cookies/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-ga-cookies/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ga-cookies"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ga-cookies",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-geolocation/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-geolocation/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-geolocation"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-geolocation",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-geolocation/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-geolocation/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-geolocation"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-geolocation",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-geolocation/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-geolocation/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-geolocation"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-geolocation",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/946_2021-04-14-08-06.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/946_2021-04-14-08-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix typo in link-click-tracking plugin (#946)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-link-click-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-link-click-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-link-click-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-link-click-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely-x/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely-x"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely-x",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely-x/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely-x"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely-x",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely-x/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely-x"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely-x",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-performance-timing/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-performance-timing/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-performance-timing"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-performance-timing",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-performance-timing/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-performance-timing/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-performance-timing"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-performance-timing",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-performance-timing/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-performance-timing/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-performance-timing"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-performance-timing",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-site-tracking/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-site-tracking/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-site-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-site-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-site-tracking/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-site-tracking/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-site-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-site-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-site-tracking/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-site-tracking/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-site-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-site-tracking",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-timezone/950_2021-04-14-08-10.json
+++ b/common/changes/@snowplow/browser-plugin-timezone/950_2021-04-14-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add peerDependencies to plugins (#950)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-timezone"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-timezone",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-timezone/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-plugin-timezone/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-timezone"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-timezone",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-timezone/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-plugin-timezone/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-timezone"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-timezone",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-tracker-core/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-tracker-core/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-tracker-core/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-tracker-core/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-tracker/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/browser-tracker/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-tracker/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/browser-tracker/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/javascript-tracker/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/javascript-tracker/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/javascript-tracker"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/node-tracker/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/node-tracker/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/node-tracker"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/node-tracker/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/node-tracker/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/node-tracker"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/tracker-core/947_2021-04-14-08-08.json
+++ b/common/changes/@snowplow/tracker-core/947_2021-04-14-08-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix types on buildPageView in tracker-core (#947)",
+      "type": "none",
+      "packageName": "@snowplow/tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/tracker-core/951_2021-04-14-08-12.json
+++ b/common/changes/@snowplow/tracker-core/951_2021-04-14-08-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Mark packages as sideEffect: false (#951)",
+      "type": "none",
+      "packageName": "@snowplow/tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/tracker-core/954_2021-04-14-08-20.json
+++ b/common/changes/@snowplow/tracker-core/954_2021-04-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add unit tests to plugin track* functions (#954)",
+      "type": "none",
+      "packageName": "@snowplow/tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -112,7 +112,7 @@
     },
     {
       "name": "@snowplow/browser-tracker",
-      "allowedCategories": [ "trackers" ]
+      "allowedCategories": [ "plugins", "trackers" ]
     },
     {
       "name": "@snowplow/browser-tracker-core",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -106,12 +106,14 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/lodash': 4.14.168
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
       eslint: 7.16.0
       jest: 26.6.3
       jest-standard-reporter: 2.0.0
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -124,12 +126,14 @@ importers:
       '@snowplow/browser-tracker-core': workspace:*
       '@snowplow/tracker-core': workspace:*
       '@types/jest': ^26.0.20
+      '@types/lodash': ^4.14.168
       '@typescript-eslint/eslint-plugin': ^4.9.0
       '@typescript-eslint/parser': ^4.9.0
       '@wessberg/rollup-plugin-ts': ^1.3.10
       eslint: ^7.7.0
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -230,12 +234,14 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/lodash': 4.14.168
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
       eslint: 7.16.0
       jest: 26.6.3
       jest-standard-reporter: 2.0.0
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -248,12 +254,14 @@ importers:
       '@snowplow/browser-tracker-core': workspace:*
       '@snowplow/tracker-core': workspace:*
       '@types/jest': ^26.0.20
+      '@types/lodash': ^4.14.168
       '@typescript-eslint/eslint-plugin': ^4.9.0
       '@typescript-eslint/parser': ^4.9.0
       '@wessberg/rollup-plugin-ts': ^1.3.10
       eslint: ^7.7.0
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -314,12 +322,14 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/lodash': 4.14.168
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
       eslint: 7.16.0
       jest: 26.6.3
       jest-standard-reporter: 2.0.0
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -332,12 +342,14 @@ importers:
       '@snowplow/browser-tracker-core': workspace:*
       '@snowplow/tracker-core': workspace:*
       '@types/jest': ^26.0.20
+      '@types/lodash': ^4.14.168
       '@typescript-eslint/eslint-plugin': ^4.9.0
       '@typescript-eslint/parser': ^4.9.0
       '@wessberg/rollup-plugin-ts': ^1.3.10
       eslint: ^7.7.0
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -398,12 +410,14 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/lodash': 4.14.168
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
       eslint: 7.16.0
       jest: 26.6.3
       jest-standard-reporter: 2.0.0
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -416,12 +430,14 @@ importers:
       '@snowplow/browser-tracker-core': workspace:*
       '@snowplow/tracker-core': workspace:*
       '@types/jest': ^26.0.20
+      '@types/lodash': ^4.14.168
       '@typescript-eslint/eslint-plugin': ^4.9.0
       '@typescript-eslint/parser': ^4.9.0
       '@wessberg/rollup-plugin-ts': ^1.3.10
       eslint: ^7.7.0
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -558,12 +574,14 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/lodash': 4.14.168
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
       eslint: 7.16.0
       jest: 26.6.3
       jest-standard-reporter: 2.0.0
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -576,12 +594,14 @@ importers:
       '@snowplow/browser-tracker-core': workspace:*
       '@snowplow/tracker-core': workspace:*
       '@types/jest': ^26.0.20
+      '@types/lodash': ^4.14.168
       '@typescript-eslint/eslint-plugin': ^4.9.0
       '@typescript-eslint/parser': ^4.9.0
       '@wessberg/rollup-plugin-ts': ^1.3.10
       eslint: ^7.7.0
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -678,11 +698,14 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/jsdom': 16.2.6
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
       eslint: 7.16.0
       jest: 26.6.3
+      jest-environment-jsdom: 26.6.2
+      jest-environment-jsdom-global: 2.0.4_jest-environment-jsdom@26.6.2
       jest-standard-reporter: 2.0.0
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
@@ -696,11 +719,14 @@ importers:
       '@snowplow/browser-tracker-core': workspace:*
       '@snowplow/tracker-core': workspace:*
       '@types/jest': ^26.0.20
+      '@types/jsdom': ^16.2.6
       '@typescript-eslint/eslint-plugin': ^4.9.0
       '@typescript-eslint/parser': ^4.9.0
       '@wessberg/rollup-plugin-ts': ^1.3.10
       eslint: ^7.7.0
       jest: ^26.6.3
+      jest-environment-jsdom: ^26.6.2
+      jest-environment-jsdom-global: ^2.0.4
       jest-standard-reporter: ^2.0.0
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
@@ -718,12 +744,14 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/lodash': 4.14.168
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
       eslint: 7.16.0
       jest: 26.6.3
       jest-standard-reporter: 2.0.0
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -736,12 +764,14 @@ importers:
       '@snowplow/browser-tracker-core': workspace:*
       '@snowplow/tracker-core': workspace:*
       '@types/jest': ^26.0.20
+      '@types/lodash': ^4.14.168
       '@typescript-eslint/eslint-plugin': ^4.9.0
       '@typescript-eslint/parser': ^4.9.0
       '@wessberg/rollup-plugin-ts': ^1.3.10
       eslint: ^7.7.0
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -892,7 +922,7 @@ importers:
       chromedriver: 88.0.0
       dockerode: 3.2.1
       gulp: 4.0.2
-      jest: 26.6.3_ts-node@9.1.1
+      jest: 26.6.3
       jest-standard-reporter: 2.0.0
       lodash: 4.17.21
       npm-run-all: 4.1.5
@@ -2360,43 +2390,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.25
-      ansi-escapes: 4.3.1
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_ts-node@9.1.1
-      jest-runtime: 26.6.3_ts-node@9.1.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.2
-      p-each-series: 2.2.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/environment/26.6.2:
     dependencies:
       '@jest/fake-timers': 26.6.2
@@ -2495,20 +2488,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.4
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_ts-node@9.1.1
-      jest-runtime: 26.6.3_ts-node@9.1.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.6.2:
@@ -8164,29 +8143,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.1.1
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      import-local: 3.0.2
-      is-ci: 2.0.0
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.4.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.6.3:
     dependencies:
       '@babel/core': 7.12.10
@@ -8207,37 +8163,6 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@babel/core': 7.12.10
-      '@jest/test-sequencer': 26.6.3_ts-node@9.1.1
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.12.10
-      chalk: 4.1.0
-      deepmerge: 4.2.2
-      glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.6.2
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_ts-node@9.1.1
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.2
-      pretty-format: 26.6.2
-      ts-node: 9.1.1_typescript@4.2.3
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -8367,33 +8292,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@babel/traverse': 7.12.10
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.25
-      chalk: 4.1.0
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.1.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-leak-detector/26.6.2:
     dependencies:
       jest-get-type: 26.3.0
@@ -8510,35 +8408,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.25
-      chalk: 4.1.0
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.1.1
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.19
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -8572,43 +8441,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.12
-      chalk: 4.1.0
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.6.2:
@@ -8713,19 +8545,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jest/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.1.1
-      import-local: 3.0.2
-      jest-cli: 26.6.3_ts-node@9.1.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /js-cleanup/1.2.0:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -265,13 +265,13 @@ importers:
     dependencies:
       '@snowplow/browser-tracker-core': link:../../libraries/browser-tracker-core
       '@snowplow/tracker-core': link:../../libraries/tracker-core
-      '@types/randomcolor': 0.5.5
       randomcolor: 0.6.2
       tslib: 2.1.0
     devDependencies:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
+      '@types/randomcolor': 0.5.5
       '@typescript-eslint/eslint-plugin': 4.11.0_3261e8a6d4b016dd957834f001de0f18
       '@typescript-eslint/parser': 4.11.0_eslint@7.16.0+typescript@4.2.3
       '@wessberg/rollup-plugin-ts': 1.3.10_rollup@2.41.1+typescript@4.2.3
@@ -361,7 +361,7 @@ importers:
       eslint: 7.16.0
       jest: 26.6.3
       jest-standard-reporter: 2.0.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -381,7 +381,7 @@ importers:
       eslint: ^7.7.0
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
-      lodash: ^4.17.20
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -817,7 +817,7 @@ importers:
       jest-environment-jsdom: 26.6.2
       jest-environment-jsdom-global: 2.0.4_jest-environment-jsdom@26.6.2
       jest-standard-reporter: 2.0.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
       rollup-plugin-license: 2.2.0_rollup@2.41.1
@@ -841,7 +841,7 @@ importers:
       jest-environment-jsdom: ^26.6.2
       jest-environment-jsdom-global: ^2.0.4
       jest-standard-reporter: ^2.0.0
-      lodash: ^4.17.20
+      lodash: ^4.17.21
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
       rollup-plugin-license: ^2.2.0
@@ -892,9 +892,9 @@ importers:
       chromedriver: 88.0.0
       dockerode: 3.2.1
       gulp: 4.0.2
-      jest: 26.6.3
+      jest: 26.6.3_ts-node@9.1.1
       jest-standard-reporter: 2.0.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       npm-run-all: 4.1.5
       rollup: 2.41.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.41.1
@@ -949,7 +949,7 @@ importers:
       gulp: ^4.0.2
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
-      lodash: ^4.17.20
+      lodash: ^4.17.21
       npm-run-all: ^4.1.5
       rollup: ^2.41.1
       rollup-plugin-cleanup: ^3.2.1
@@ -1061,7 +1061,7 @@ packages:
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.1.3
-      lodash: 4.17.20
+      lodash: 4.17.21
       semver: 5.7.1
       source-map: 0.5.7
     dev: true
@@ -1084,7 +1084,7 @@ packages:
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.1.3
-      lodash: 4.17.20
+      lodash: 4.17.21
       semver: 6.3.0
       source-map: 0.5.7
     dev: true
@@ -1247,7 +1247,7 @@ packages:
       '@babel/template': 7.12.7
       '@babel/traverse': 7.12.10
       '@babel/types': 7.12.11
-      lodash: 4.17.20
+      lodash: 4.17.21
     dev: true
     resolution:
       integrity: sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
@@ -2221,7 +2221,7 @@ packages:
       '@babel/types': 7.12.11
       debug: 4.3.1
       globals: 11.12.0
-      lodash: 4.17.20
+      lodash: 4.17.21
     dev: true
     resolution:
       integrity: sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==
@@ -2235,14 +2235,14 @@ packages:
       '@babel/types': 7.13.12
       debug: 4.3.1
       globals: 11.12.0
-      lodash: 4.17.20
+      lodash: 4.17.21
     dev: true
     resolution:
       integrity: sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
   /@babel/types/7.12.11:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
-      lodash: 4.17.20
+      lodash: 4.17.21
       to-fast-properties: 2.0.0
     dev: true
     resolution:
@@ -2250,7 +2250,7 @@ packages:
   /@babel/types/7.13.12:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
-      lodash: 4.17.20
+      lodash: 4.17.21
       to-fast-properties: 2.0.0
     dev: true
     resolution:
@@ -2286,7 +2286,7 @@ packages:
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
-      lodash: 4.17.20
+      lodash: 4.17.21
       minimatch: 3.0.4
       strip-json-comments: 3.1.1
     dev: true
@@ -2358,6 +2358,43 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
+  /@jest/core/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/reporters': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 14.14.25
+      ansi-escapes: 4.3.1
+      chalk: 4.1.0
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      jest-changed-files: 26.6.2
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-resolve-dependencies: 26.6.3
+      jest-runner: 26.6.3_ts-node@9.1.1
+      jest-runtime: 26.6.3_ts-node@9.1.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      jest-watcher: 26.6.2
+      micromatch: 4.0.2
+      p-each-series: 2.2.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/environment/26.6.2:
@@ -2458,6 +2495,20 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
+  /@jest/test-sequencer/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/test-result': 26.6.2
+      graceful-fs: 4.2.4
+      jest-haste-map: 26.6.2
+      jest-runner: 26.6.3_ts-node@9.1.1
+      jest-runtime: 26.6.3_ts-node@9.1.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.6.2:
@@ -2976,7 +3027,7 @@ packages:
     resolution:
       integrity: sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
   /@types/randomcolor/0.5.5:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-PywdYff3F8lGO3BggkCXaPFH0Ue/2Y7xliihoQNkxCGPJ4w7VTMfgcmSMIE6gOVAEu9Wx42JRSuRREVG3AUrtg==
   /@types/range-parser/1.2.3:
@@ -3154,7 +3205,7 @@ packages:
       debug: 4.3.1
       globby: 11.0.1
       is-glob: 4.0.1
-      lodash: 4.17.20
+      lodash: 4.17.21
       semver: 7.3.4
       tsutils: 3.17.1_typescript@4.2.3
       typescript: 4.2.3
@@ -3950,7 +4001,7 @@ packages:
       is-error: 2.2.2
       is-plain-object: 5.0.0
       is-promise: 4.0.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       matcher: 3.0.0
       md5-hex: 3.0.1
       mem: 8.0.0
@@ -5000,7 +5051,7 @@ packages:
       esutils: 2.0.3
       fast-diff: 1.2.0
       js-string-escape: 1.0.1
-      lodash: 4.17.20
+      lodash: 4.17.21
       md5-hex: 3.0.1
       semver: 7.3.4
       well-known-symbols: 2.0.0
@@ -5718,7 +5769,7 @@ packages:
       integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   /enhance-visitors/1.0.0:
     dependencies:
-      lodash: 4.17.20
+      lodash: 4.17.21
     dev: true
     engines:
       node: '>=4.0.0'
@@ -5940,7 +5991,7 @@ packages:
       js-yaml: 3.14.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
-      lodash: 4.17.20
+      lodash: 4.17.21
       minimatch: 3.0.4
       natural-compare: 1.4.0
       optionator: 0.9.1
@@ -7511,7 +7562,7 @@ packages:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       mute-stream: 0.0.8
       run-async: 2.4.1
       rxjs: 6.6.3
@@ -8113,6 +8164,29 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
+  /jest-cli/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/core': 26.6.3_ts-node@9.1.1
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      chalk: 4.1.0
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      import-local: 3.0.2
+      is-ci: 2.0.0
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      prompts: 2.4.0
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+    resolution:
+      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.6.3:
     dependencies:
       '@babel/core': 7.12.10
@@ -8133,6 +8207,37 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    resolution:
+      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
+  /jest-config/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@babel/core': 7.12.10
+      '@jest/test-sequencer': 26.6.3_ts-node@9.1.1
+      '@jest/types': 26.6.2
+      babel-jest: 26.6.3_@babel+core@7.12.10
+      chalk: 4.1.0
+      deepmerge: 4.2.2
+      glob: 7.1.6
+      graceful-fs: 4.2.4
+      jest-environment-jsdom: 26.6.2
+      jest-environment-node: 26.6.2
+      jest-get-type: 26.3.0
+      jest-jasmine2: 26.6.3_ts-node@9.1.1
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      micromatch: 4.0.2
+      pretty-format: 26.6.2
+      ts-node: 9.1.1_typescript@4.2.3
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -8262,6 +8367,33 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
+  /jest-jasmine2/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@babel/traverse': 7.12.10
+      '@jest/environment': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 14.14.25
+      chalk: 4.1.0
+      co: 4.6.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runtime: 26.6.3_ts-node@9.1.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      pretty-format: 26.6.2
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
+    resolution:
+      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-leak-detector/26.6.2:
     dependencies:
       jest-get-type: 26.3.0
@@ -8378,6 +8510,35 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
+  /jest-runner/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 14.14.25
+      chalk: 4.1.0
+      emittery: 0.7.2
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-docblock: 26.0.0
+      jest-haste-map: 26.6.2
+      jest-leak-detector: 26.6.2
+      jest-message-util: 26.6.2
+      jest-resolve: 26.6.2
+      jest-runtime: 26.6.3_ts-node@9.1.1
+      jest-util: 26.6.2
+      jest-worker: 26.6.2
+      source-map-support: 0.5.19
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
+    resolution:
+      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -8411,6 +8572,43 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
+  /jest-runtime/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/fake-timers': 26.6.2
+      '@jest/globals': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/yargs': 15.0.12
+      chalk: 4.1.0
+      cjs-module-lexer: 0.6.0
+      collect-v8-coverage: 1.0.1
+      exit: 0.1.2
+      glob: 7.1.6
+      graceful-fs: 4.2.4
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-mock: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      slash: 3.0.0
+      strip-bom: 4.0.0
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.6.2:
@@ -8515,6 +8713,19 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  /jest/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/core': 26.6.3_ts-node@9.1.1
+      import-local: 3.0.2
+      jest-cli: 26.6.3_ts-node@9.1.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /js-cleanup/1.2.0:
@@ -8938,6 +9149,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+  /lodash/4.17.21:
+    dev: true
+    resolution:
+      integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
   /log-symbols/4.0.0:
     dependencies:
       chalk: 4.1.0
@@ -10847,7 +11062,7 @@ packages:
       integrity: sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=
   /request-promise-core/1.1.4_request@2.88.2:
     dependencies:
-      lodash: 4.17.20
+      lodash: 4.17.21
       request: 2.88.2
     dev: true
     engines:
@@ -11949,7 +12164,7 @@ packages:
   /table/6.0.4:
     dependencies:
       ajv: 6.12.6
-      lodash: 4.17.20
+      lodash: 4.17.21
       slice-ansi: 4.0.0
       string-width: 4.2.0
     dev: true
@@ -12244,7 +12459,7 @@ packages:
       jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.1.3
-      lodash: 4.17.20
+      lodash: 4.17.21
       make-error: 1.3.6
       mkdirp: 1.0.4
       semver: 7.3.4

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "7739f55cdb4f3f5489819bab2658ba8f6bffcf1b",
+  "pnpmShrinkwrapHash": "66aa9b173f8699eaa9af70d94e48a4bb4155749b",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
-// DO NOT MODIFY THIS FILE. It is generated and used by Rush.
+// DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f5aa575e102cd797cf44223e31706ac0ff605a87",
+  "pnpmShrinkwrapHash": "7739f55cdb4f3f5489819bab2658ba8f6bffcf1b",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -33,7 +33,7 @@
      * in the current branch.  When bumping versions, Rush uses this to determine the next version.
      * (The "version" field in package.json is NOT considered.)
      */
-    "version": "3.0.0",
+    "version": "3.0.1-beta.0",
   
     /**
      * (Required) The type of bump that will be performed when publishing the next release.
@@ -42,6 +42,6 @@
      *
      * Valid values are: "prerelease", "release", "minor", "patch", "major"
      */
-    "nextBump": "major"
+    "nextBump": "prerelease"
   }
 ]

--- a/common/scripts/install-run-rush.js
+++ b/common/scripts/install-run-rush.js
@@ -16,7 +16,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -16,7 +16,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/libraries/browser-tracker-core/package.json
+++ b/libraries/browser-tracker-core/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/libraries/tracker-core/package.json
+++ b/libraries/tracker-core/package.json
@@ -21,6 +21,7 @@
     "Fred Blundun",
     "Paul Boocock"
   ],
+  "sideEffects": false,
   "main": "./dist/index.js",
   "umd:main": "./dist/index.js",
   "jsdelivr": "./dist/index.umd.js",

--- a/libraries/tracker-core/src/core.ts
+++ b/libraries/tracker-core/src/core.ts
@@ -585,11 +585,11 @@ export function buildSelfDescribingEvent(event: SelfDescribingEvent): PayloadBui
  */
 export interface PageViewEvent {
   /** The current URL visible in the users browser */
-  pageUrl: string | null;
+  pageUrl?: string | null;
   /** The current page title in the users browser */
-  pageTitle: string | null;
+  pageTitle?: string | null;
   /** The URL of the referring page */
-  referrer: string | null;
+  referrer?: string | null;
 }
 
 /**

--- a/plugins/browser-plugin-ad-tracking/jest.config.js
+++ b/plugins/browser-plugin-ad-tracking/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+};

--- a/plugins/browser-plugin-ad-tracking/package.json
+++ b/plugins/browser-plugin-ad-tracking/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-ad-tracking/package.json
+++ b/plugins/browser-plugin-ad-tracking/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
@@ -30,12 +30,14 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@wessberg/rollup-plugin-ts": "^1.3.10",
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/plugins/browser-plugin-ad-tracking/package.json
+++ b/plugins/browser-plugin-ad-tracking/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-ad-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-ad-tracking/test/events.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
+import F from 'lodash/fp';
+import { AdTrackingPlugin, trackAdClick, trackAdConversion, trackAdImpression } from '../src';
+
+const getUEEvents = F.compose(F.filter(F.compose(F.eq('ue'), F.get('evt.e'))));
+const extractEventProperties = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.ue_pr')));
+const extractUeEvent = (schema: string) => {
+  return {
+    from: F.compose(
+      F.first,
+      F.filter(F.compose(F.eq(schema), F.get('schema'))),
+      F.flatten,
+      extractEventProperties,
+      getUEEvents
+    ),
+  };
+};
+
+describe('AdTrackingPlugin', () => {
+  const state = new SharedState();
+  addTracker('sp1', 'sp1', 'js-3.0.0', '', state, {
+    stateStorageStrategy: 'cookie',
+    encodeBase64: false,
+    plugins: [AdTrackingPlugin()],
+  });
+
+  it('trackAdClick adds the expected ad click event to the queue', () => {
+    trackAdClick({
+      targetUrl: 'https://www.snowplowanalytics.com',
+      bannerId: 'banner-1',
+      advertiserId: 'advertiser-1',
+      campaignId: 'campaign-1',
+      clickId: 'click-1',
+      impressionId: 'impression-1',
+      cost: 0.01,
+      costModel: 'cpa',
+      zoneId: 'zone-1',
+    });
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/ad_click/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/ad_click/jsonschema/1-0-0',
+      data: {
+        targetUrl: 'https://www.snowplowanalytics.com',
+        bannerId: 'banner-1',
+        advertiserId: 'advertiser-1',
+        campaignId: 'campaign-1',
+        clickId: 'click-1',
+        impressionId: 'impression-1',
+        cost: 0.01,
+        costModel: 'cpa',
+        zoneId: 'zone-1',
+      },
+    });
+  });
+
+  it('trackAdConversion adds the expected ad conversion event to the queue', () => {
+    trackAdConversion({
+      action: 'action',
+      advertiserId: 'advertiser-1',
+      campaignId: 'campaign-1',
+      category: 'category',
+      conversionId: 'conversion-1',
+      cost: 0.02,
+      costModel: 'cpc',
+      initialValue: 10,
+      property: 'property',
+    });
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/ad_conversion/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/ad_conversion/jsonschema/1-0-0',
+      data: {
+        action: 'action',
+        advertiserId: 'advertiser-1',
+        campaignId: 'campaign-1',
+        category: 'category',
+        conversionId: 'conversion-1',
+        cost: 0.02,
+        costModel: 'cpc',
+        initialValue: 10,
+        property: 'property',
+      },
+    });
+  });
+
+  it('trackAdImpression adds the expected ad impression event to the queue', () => {
+    trackAdImpression({
+      advertiserId: 'advrtiser-1',
+      bannerId: 'banner-1',
+      campaignId: 'campaign-1',
+      cost: 0.03,
+      costModel: 'cpm',
+      impressionId: 'impression-1',
+      targetUrl: 'https://snowplowanalytics.com',
+      zoneId: 'zone-1',
+    });
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/ad_impression/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/ad_impression/jsonschema/1-0-0',
+      data: {
+        advertiserId: 'advrtiser-1',
+        bannerId: 'banner-1',
+        campaignId: 'campaign-1',
+        cost: 0.03,
+        costModel: 'cpm',
+        impressionId: 'impression-1',
+        targetUrl: 'https://snowplowanalytics.com',
+        zoneId: 'zone-1',
+      },
+    });
+  });
+});

--- a/plugins/browser-plugin-browser-features/package.json
+++ b/plugins/browser-plugin-browser-features/package.json
@@ -44,5 +44,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-browser-features/package.json
+++ b/plugins/browser-plugin-browser-features/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-client-hints/package.json
+++ b/plugins/browser-plugin-client-hints/package.json
@@ -40,5 +40,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-client-hints/package.json
+++ b/plugins/browser-plugin-client-hints/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-consent/jest.config.js
+++ b/plugins/browser-plugin-consent/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+};

--- a/plugins/browser-plugin-consent/package.json
+++ b/plugins/browser-plugin-consent/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-consent/package.json
+++ b/plugins/browser-plugin-consent/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
@@ -30,12 +30,14 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@wessberg/rollup-plugin-ts": "^1.3.10",
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/plugins/browser-plugin-consent/package.json
+++ b/plugins/browser-plugin-consent/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-consent/test/events.test.ts
+++ b/plugins/browser-plugin-consent/test/events.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
+import F from 'lodash/fp';
+import { ConsentPlugin, trackConsentWithdrawn, trackConsentGranted, enableGdprContext } from '../src';
+
+const getUEEvents = F.compose(F.filter(F.compose(F.eq('ue'), F.get('evt.e'))));
+const extractEventProperties = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.ue_pr')));
+const extractEventContext = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.co')));
+const extractUeEvent = (schema: string) => {
+  return {
+    from: F.compose(
+      F.first,
+      F.filter(F.compose(F.eq(schema), F.get('schema'))),
+      F.flatten,
+      extractEventProperties,
+      getUEEvents
+    ),
+  };
+};
+const extractContext = (schema: string) => {
+  return {
+    from: F.compose(
+      F.first,
+      F.filter(F.compose(F.eq(schema), F.get('schema'))),
+      F.flatten,
+      extractEventContext,
+      getUEEvents
+    ),
+  };
+};
+
+describe('AdTrackingPlugin', () => {
+  const state = new SharedState();
+  addTracker('sp1', 'sp1', 'js-3.0.0', '', state, {
+    stateStorageStrategy: 'cookie',
+    encodeBase64: false,
+    plugins: [ConsentPlugin()],
+  });
+  addTracker('sp2', 'sp2', 'js-3.0.0', '', state, {
+    stateStorageStrategy: 'cookie',
+    encodeBase64: false,
+    plugins: [ConsentPlugin()],
+  });
+
+  enableGdprContext({
+    basisForProcessing: 'legalObligation',
+    documentDescription: 'doc-desc-1',
+    documentId: 'doc-id-1',
+    documentVersion: 'doc-ver-1',
+  });
+
+  trackConsentWithdrawn(
+    {
+      all: true,
+      description: 'desc-1',
+      id: 'id-1',
+      name: 'name-1',
+      version: '1.1.0',
+    },
+    ['sp1']
+  );
+
+  trackConsentGranted(
+    {
+      description: 'desc-2',
+      id: 'id-2',
+      name: 'name-2',
+      version: '1.2.0',
+      expiry: '2020-01-01T00:00:00Z',
+    },
+    ['sp2']
+  );
+
+  it('trackConsentWithdrawn adds the expected consent withdrawn event to the queue', () => {
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/consent_withdrawn/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/consent_withdrawn/jsonschema/1-0-0',
+      data: {
+        all: true,
+      },
+    });
+
+    expect(
+      extractContext('iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0',
+      data: {
+        description: 'desc-1',
+        id: 'id-1',
+        name: 'name-1',
+        version: '1.1.0',
+      },
+    });
+  });
+
+  it('trackConsentGranted adds the expected consent granted event to the queue', () => {
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/consent_granted/jsonschema/1-0-0').from(state.outQueues[1])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/consent_granted/jsonschema/1-0-0',
+      data: {
+        expiry: '2020-01-01T00:00:00Z',
+      },
+    });
+
+    expect(
+      extractContext('iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0').from(state.outQueues[1])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0',
+      data: {
+        description: 'desc-2',
+        id: 'id-2',
+        name: 'name-2',
+        version: '1.2.0',
+      },
+    });
+  });
+
+  it('events contain the GDPR context', () => {
+    expect(
+      extractContext('iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0',
+      data: {
+        basisForProcessing: 'legal_obligation',
+        documentDescription: 'doc-desc-1',
+        documentId: 'doc-id-1',
+        documentVersion: 'doc-ver-1',
+      },
+    });
+
+    expect(
+      extractContext('iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0').from(state.outQueues[1])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0',
+      data: {
+        basisForProcessing: 'legal_obligation',
+        documentDescription: 'doc-desc-1',
+        documentId: 'doc-id-1',
+        documentVersion: 'doc-ver-1',
+      },
+    });
+  });
+});

--- a/plugins/browser-plugin-debugger/package.json
+++ b/plugins/browser-plugin-debugger/package.json
@@ -43,5 +43,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-debugger/package.json
+++ b/plugins/browser-plugin-debugger/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",
@@ -23,8 +24,8 @@
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
-    "tslib": "^2.1.0",
-    "randomcolor": "^0.6.2"
+    "randomcolor": "^0.6.2",
+    "tslib": "^2.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",

--- a/plugins/browser-plugin-ecommerce/jest.config.js
+++ b/plugins/browser-plugin-ecommerce/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+};

--- a/plugins/browser-plugin-ecommerce/package.json
+++ b/plugins/browser-plugin-ecommerce/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-ecommerce/package.json
+++ b/plugins/browser-plugin-ecommerce/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
@@ -30,12 +30,14 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@wessberg/rollup-plugin-ts": "^1.3.10",
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/plugins/browser-plugin-ecommerce/package.json
+++ b/plugins/browser-plugin-ecommerce/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-ecommerce/test/events.test.ts
+++ b/plugins/browser-plugin-ecommerce/test/events.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { addTracker, BrowserTracker, SharedState } from '@snowplow/browser-tracker-core';
+import { trackerCore } from '@snowplow/tracker-core';
+import F from 'lodash/fp';
+import { EcommercePlugin, trackAddToCart, trackRemoveFromCart, addItem, addTrans, trackTrans } from '../src';
+
+const getUEEvents = F.compose(F.filter(F.compose(F.eq('ue'), F.get('evt.e'))));
+const extractEventProperties = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.ue_pr')));
+const extractUeEvent = (schema: string) => {
+  return {
+    from: F.compose(
+      F.first,
+      F.filter(F.compose(F.eq(schema), F.get('schema'))),
+      F.flatten,
+      extractEventProperties,
+      getUEEvents
+    ),
+  };
+};
+
+describe('EcommercePlugin', () => {
+  const state = new SharedState();
+  addTracker('sp1', 'sp1', 'js-3.0.0', '', state, {
+    stateStorageStrategy: 'cookie',
+    encodeBase64: false,
+    plugins: [EcommercePlugin()],
+  });
+
+  it('trackAddToCart adds the expected add to cart event to the queue', () => {
+    trackAddToCart(
+      {
+        quantity: 1,
+        sku: '12345-1234',
+        category: 'category-1',
+        currency: 'currency-1',
+        name: 'name-1',
+        unitPrice: 10.99,
+      },
+      ['sp1']
+    );
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/add_to_cart/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/add_to_cart/jsonschema/1-0-0',
+      data: {
+        quantity: 1,
+        sku: '12345-1234',
+        category: 'category-1',
+        currency: 'currency-1',
+        name: 'name-1',
+        unitPrice: 10.99,
+      },
+    });
+  });
+
+  it('trackRemoveFromCart adds the expected remove from cart event to the queue', () => {
+    trackRemoveFromCart(
+      {
+        quantity: 1,
+        sku: '12345-1234',
+        category: 'category-1',
+        currency: 'currency-1',
+        name: 'name-1',
+        unitPrice: 10.99,
+      },
+      ['sp1']
+    );
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/remove_from_cart/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/remove_from_cart/jsonschema/1-0-0',
+      data: {
+        quantity: 1,
+        sku: '12345-1234',
+        category: 'category-1',
+        currency: 'currency-1',
+        name: 'name-1',
+        unitPrice: 10.99,
+      },
+    });
+  });
+
+  it('trackTrans adds the expected transaction event to the queue', (done) => {
+    let eventCount = 0;
+    const plugin = EcommercePlugin();
+    const core = trackerCore({
+      corePlugins: [plugin],
+      base64: false,
+      callback: (payloadBuilder) => {
+        eventCount++;
+        const payload = payloadBuilder.build();
+        if (payload['e'] === 'tr') {
+          expect(payload['tr_id']).toBe('1234');
+          expect(payload['tr_af']).toBe('aff');
+          expect(payload['tr_tt']).toBe(420);
+          expect(payload['tr_tx']).toBe(4.2);
+          expect(payload['tr_sh']).toBe(10.69);
+          expect(payload['tr_ci']).toBe('city');
+          expect(payload['tr_st']).toBe('texas');
+          expect(payload['tr_co']).toBe('country');
+          expect(payload['tr_cu']).toBe('usd');
+        }
+
+        if (payload['e'] === 'ti') {
+          expect(payload['ti_id']).toBe('1234');
+          expect(payload['ti_sk']).toBe('12345-1111');
+          expect(payload['ti_nm']).toBe('name-1');
+          expect(payload['ti_ca']).toBe('category-1');
+          expect(payload['ti_pr']).toBe(10.99);
+          expect(payload['ti_qu']).toBe(2);
+          expect(payload['ti_cu']).toBe('usd');
+        }
+
+        if (eventCount === 2) {
+          done();
+        }
+      },
+    });
+
+    plugin.activateBrowserPlugin?.({ id: 'sp2', core } as BrowserTracker);
+
+    addTrans(
+      {
+        orderId: '1234',
+        total: 420,
+        affiliation: 'aff',
+        city: 'city',
+        country: 'country',
+        currency: 'usd',
+        shipping: 10.69,
+        state: 'texas',
+        tax: 4.2,
+      },
+      ['sp2']
+    );
+
+    addItem(
+      {
+        orderId: '1234',
+        price: 10.99,
+        sku: '12345-1111',
+        category: 'category-1',
+        currency: 'usd',
+        name: 'name-1',
+        quantity: 2,
+      },
+      ['sp2']
+    );
+
+    trackTrans(['sp2']);
+  });
+});

--- a/plugins/browser-plugin-enhanced-ecommerce/package.json
+++ b/plugins/browser-plugin-enhanced-ecommerce/package.json
@@ -43,5 +43,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-enhanced-ecommerce/package.json
+++ b/plugins/browser-plugin-enhanced-ecommerce/package.json
@@ -37,7 +37,7 @@
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/plugins/browser-plugin-enhanced-ecommerce/package.json
+++ b/plugins/browser-plugin-enhanced-ecommerce/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-error-tracking/jest.config.js
+++ b/plugins/browser-plugin-error-tracking/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+};

--- a/plugins/browser-plugin-error-tracking/package.json
+++ b/plugins/browser-plugin-error-tracking/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-error-tracking/package.json
+++ b/plugins/browser-plugin-error-tracking/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
@@ -30,12 +30,14 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@wessberg/rollup-plugin-ts": "^1.3.10",
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/plugins/browser-plugin-error-tracking/package.json
+++ b/plugins/browser-plugin-error-tracking/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-error-tracking/src/index.ts
+++ b/plugins/browser-plugin-error-tracking/src/index.ts
@@ -83,7 +83,7 @@ export function trackError(
           schema: 'iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1',
           data: {
             programmingLanguage: 'JAVASCRIPT',
-            message: message || "JS Exception. Browser doesn't support ErrorEvent API",
+            message: message ?? "JS Exception. Browser doesn't support ErrorEvent API",
             stackTrace: stack,
             lineNumber: lineno,
             lineColumn: colno,

--- a/plugins/browser-plugin-error-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-error-tracking/test/events.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
+import F from 'lodash/fp';
+import { ErrorTrackingPlugin, trackError } from '../src';
+
+const getUEEvents = F.compose(F.filter(F.compose(F.eq('ue'), F.get('evt.e'))));
+const extractEventProperties = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.ue_pr')));
+const extractUeEvent = (schema: string) => {
+  return {
+    from: F.compose(
+      F.first,
+      F.filter(F.compose(F.eq(schema), F.get('schema'))),
+      F.flatten,
+      extractEventProperties,
+      getUEEvents
+    ),
+  };
+};
+
+describe('AdTrackingPlugin', () => {
+  const state = new SharedState();
+  addTracker('sp1', 'sp1', 'js-3.0.0', '', state, {
+    encodeBase64: false,
+    plugins: [ErrorTrackingPlugin()],
+  });
+  addTracker('sp2', 'sp2', 'js-3.0.0', '', state, {
+    encodeBase64: false,
+    plugins: [ErrorTrackingPlugin()],
+  });
+  addTracker('sp3', 'sp3', 'js-3.0.0', '', state, {
+    encodeBase64: false,
+    plugins: [ErrorTrackingPlugin()],
+  });
+
+  const error = new Error('this is an error');
+  error.stack = 'stacktrace-1';
+
+  trackError(
+    {
+      message: 'message-1',
+      colno: 1,
+      lineno: 10,
+      filename: 'index.js',
+      error: error,
+    },
+    ['sp1']
+  );
+
+  trackError(
+    {
+      message: '',
+    },
+    ['sp2']
+  );
+
+  trackError(
+    {
+      message: <any>undefined,
+    },
+    ['sp3']
+  );
+
+  it('trackError adds the expected application error event to the queue', () => {
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1',
+      data: {
+        programmingLanguage: 'JAVASCRIPT',
+        message: 'message-1',
+        stackTrace: 'stacktrace-1',
+        lineNumber: 10,
+        lineColumn: 1,
+        fileName: 'index.js',
+      },
+    });
+  });
+
+  it('trackError accepts empty error messages', () => {
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1').from(state.outQueues[1])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1',
+      data: {
+        message: '',
+      },
+    });
+  });
+
+  it('trackError replaces undefined messages with placeholder', () => {
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1').from(state.outQueues[2])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1',
+      data: {
+        message: "JS Exception. Browser doesn't support ErrorEvent API",
+      },
+    });
+  });
+});

--- a/plugins/browser-plugin-form-tracking/package.json
+++ b/plugins/browser-plugin-form-tracking/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-form-tracking/package.json
+++ b/plugins/browser-plugin-form-tracking/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-ga-cookies/package.json
+++ b/plugins/browser-plugin-ga-cookies/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-ga-cookies/package.json
+++ b/plugins/browser-plugin-ga-cookies/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-geolocation/package.json
+++ b/plugins/browser-plugin-geolocation/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-geolocation/package.json
+++ b/plugins/browser-plugin-geolocation/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-link-click-tracking/README.md
+++ b/plugins/browser-plugin-link-click-tracking/README.md
@@ -25,7 +25,7 @@ $ rush update
 With npm:
 
 ```bash
-npm install @snowplow/browser-plugin-lick-click-tracking
+npm install @snowplow/browser-plugin-link-click-tracking
 ```
 
 ## Usage
@@ -34,7 +34,7 @@ Initialize your tracker with the LinkClickTrackingPlugin:
 
 ```js
 import { newTracker } from '@snowplow/browser-tracker';
-import { LinkClickTrackingPlugin } from '@snowplow/browser-plugin-lick-click-tracking';
+import { LinkClickTrackingPlugin } from '@snowplow/browser-plugin-link-click-tracking';
 
 newTracker('sp1', '{{collector}}', { plugins: [ LinkClickTrackingPlugin() ] }); // Also stores reference at module level
 ```
@@ -42,7 +42,7 @@ newTracker('sp1', '{{collector}}', { plugins: [ LinkClickTrackingPlugin() ] }); 
 Then use the available functions from this package to track to all trackers which have been initialized with this plugin:
 
 ```js
-import { enableLinkClickTracking, refreshLinkClickTracking } from '@snowplow/browser-plugin-lick-click-tracking';
+import { enableLinkClickTracking, refreshLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 
 enableLinkClickTracking({ options: { ... }, psuedoClicks: true });
 

--- a/plugins/browser-plugin-link-click-tracking/jest.config.js
+++ b/plugins/browser-plugin-link-click-tracking/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+};

--- a/plugins/browser-plugin-link-click-tracking/package.json
+++ b/plugins/browser-plugin-link-click-tracking/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-link-click-tracking/package.json
+++ b/plugins/browser-plugin-link-click-tracking/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
@@ -30,12 +30,14 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@wessberg/rollup-plugin-ts": "^1.3.10",
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/plugins/browser-plugin-link-click-tracking/package.json
+++ b/plugins/browser-plugin-link-click-tracking/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -149,7 +149,7 @@ export function refreshLinkClickTracking(trackers: Array<string> = Object.keys(_
  */
 export function trackLinkClick(
   event: LinkClickEvent & CommonEventProperties,
-  trackers: Array<string> = Object.keys(_configuration)
+  trackers: Array<string> = Object.keys(_trackers)
 ) {
   dispatchToTrackersInCollection(trackers, _trackers, (t) => {
     t.core.track(buildLinkClick(event), event.context, event.timestamp);

--- a/plugins/browser-plugin-link-click-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-link-click-tracking/test/events.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
+import F from 'lodash/fp';
+import { LinkClickTrackingPlugin, trackLinkClick } from '../src';
+
+const getUEEvents = F.compose(F.filter(F.compose(F.eq('ue'), F.get('evt.e'))));
+const extractEventProperties = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.ue_pr')));
+const extractUeEvent = (schema: string) => {
+  return {
+    from: F.compose(
+      F.first,
+      F.filter(F.compose(F.eq(schema), F.get('schema'))),
+      F.flatten,
+      extractEventProperties,
+      getUEEvents
+    ),
+  };
+};
+
+describe('AdTrackingPlugin', () => {
+  const state = new SharedState();
+  addTracker('sp1', 'sp1', 'js-3.0.0', '', state, {
+    stateStorageStrategy: 'cookie',
+    encodeBase64: false,
+    plugins: [LinkClickTrackingPlugin()],
+  });
+
+  it('trackLinkClick adds the expected link click event to the queue', () => {
+    trackLinkClick({
+      targetUrl: 'https://www.example.com',
+      elementClasses: ['class-1', 'class-2'],
+      elementContent: 'content-1',
+      elementId: 'id-1234',
+      elementTarget: '_blank',
+    });
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+      data: {
+        targetUrl: 'https://www.example.com',
+        elementClasses: ['class-1', 'class-2'],
+        elementContent: 'content-1',
+        elementId: 'id-1234',
+        elementTarget: '_blank',
+      },
+    });
+  });
+});

--- a/plugins/browser-plugin-optimizely-x/package.json
+++ b/plugins/browser-plugin-optimizely-x/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-optimizely-x/package.json
+++ b/plugins/browser-plugin-optimizely-x/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-optimizely/package.json
+++ b/plugins/browser-plugin-optimizely/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-optimizely/package.json
+++ b/plugins/browser-plugin-optimizely/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-performance-timing/jest.config.js
+++ b/plugins/browser-plugin-performance-timing/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+  testEnvironment: 'jest-environment-jsdom-global',
+};

--- a/plugins/browser-plugin-performance-timing/package.json
+++ b/plugins/browser-plugin-performance-timing/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-performance-timing/package.json
+++ b/plugins/browser-plugin-performance-timing/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-performance-timing/package.json
+++ b/plugins/browser-plugin-performance-timing/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
@@ -30,11 +30,14 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@types/jsdom": "^16.2.6",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@wessberg/rollup-plugin-ts": "^1.3.10",
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
+    "jest-environment-jsdom": "^26.6.2",
+    "jest-environment-jsdom-global": "^2.0.4",
     "jest-standard-reporter": "^2.0.0",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",

--- a/plugins/browser-plugin-performance-timing/test/performance-timing.test.ts
+++ b/plugins/browser-plugin-performance-timing/test/performance-timing.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { buildLinkClick, trackerCore } from '@snowplow/tracker-core';
+import { JSDOM } from 'jsdom';
+import { PerformanceTimingPlugin } from '../src';
+
+declare var jsdom: JSDOM;
+
+describe('Performance Timing plugin', () => {
+  it('Returns values for Performance Timing properties', (done) => {
+    Object.defineProperty(jsdom.window.performance, 'timing', {
+      value: {
+        navigationStart: 1,
+        redirectStart: 2,
+        redirectEnd: 3,
+        fetchStart: 4,
+        domainLookupStart: 5,
+        domainLookupEnd: 6,
+        connectStart: 7,
+        secureConnectionStart: 8,
+        connectEnd: 9,
+        requestStart: 10,
+        responseStart: 11,
+        responseEnd: 12,
+        unloadEventStart: 13,
+        unloadEventEnd: 14,
+        domLoading: 15,
+        domInteractive: 16,
+        domContentLoadedEventStart: 17,
+        domContentLoadedEventEnd: 18,
+        domComplete: 19,
+        loadEventStart: 20,
+        loadEventEnd: 21,
+        msFirstPaint: 22,
+        chromeFirstPaint: 23,
+        requestEnd: 24,
+        proxyStart: 25,
+        proxyEnd: 26,
+      },
+      configurable: true,
+    });
+
+    const core = trackerCore({
+      corePlugins: [PerformanceTimingPlugin()],
+      callback: (payloadBuilder) => {
+        const json = payloadBuilder.getJson().filter((e) => e.keyIfEncoded === 'cx');
+        expect(json[0].json).toMatchObject({
+          data: [
+            {
+              schema: 'iglu:org.w3/PerformanceTiming/jsonschema/1-0-0',
+              data: {
+                navigationStart: 1,
+                redirectStart: 2,
+                redirectEnd: 3,
+                fetchStart: 4,
+                domainLookupStart: 5,
+                domainLookupEnd: 6,
+                connectStart: 7,
+                secureConnectionStart: 8,
+                connectEnd: 9,
+                requestStart: 10,
+                responseStart: 11,
+                responseEnd: 12,
+                unloadEventStart: 13,
+                unloadEventEnd: 14,
+                domLoading: 15,
+                domInteractive: 16,
+                domContentLoadedEventStart: 17,
+                domContentLoadedEventEnd: 18,
+                domComplete: 19,
+                loadEventStart: 20,
+                loadEventEnd: 21,
+                msFirstPaint: 22,
+                chromeFirstPaint: 23,
+                requestEnd: 24,
+                proxyStart: 25,
+                proxyEnd: 26,
+              },
+            },
+          ],
+        });
+        done();
+      },
+    });
+
+    core.track(buildLinkClick({ targetUrl: 'https://example.com' }));
+  });
+});

--- a/plugins/browser-plugin-site-tracking/jest.config.js
+++ b/plugins/browser-plugin-site-tracking/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+};

--- a/plugins/browser-plugin-site-tracking/package.json
+++ b/plugins/browser-plugin-site-tracking/package.json
@@ -41,5 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-site-tracking/package.json
+++ b/plugins/browser-plugin-site-tracking/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",
@@ -30,12 +30,14 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@wessberg/rollup-plugin-ts": "^1.3.10",
     "eslint": "^7.7.0",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/plugins/browser-plugin-site-tracking/package.json
+++ b/plugins/browser-plugin-site-tracking/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/plugins/browser-plugin-site-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-site-tracking/test/events.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
+import F from 'lodash/fp';
+import { SiteTrackingPlugin, trackTiming, trackSiteSearch, trackSocialInteraction } from '../src';
+
+const getUEEvents = F.compose(F.filter(F.compose(F.eq('ue'), F.get('evt.e'))));
+const extractEventProperties = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.ue_pr')));
+const extractUeEvent = (schema: string) => {
+  return {
+    from: F.compose(
+      F.first,
+      F.filter(F.compose(F.eq(schema), F.get('schema'))),
+      F.flatten,
+      extractEventProperties,
+      getUEEvents
+    ),
+  };
+};
+
+describe('AdTrackingPlugin', () => {
+  const state = new SharedState();
+  addTracker('sp1', 'sp1', 'js-3.0.0', '', state, {
+    stateStorageStrategy: 'cookie',
+    encodeBase64: false,
+    plugins: [SiteTrackingPlugin()],
+  });
+
+  it('trackTiming adds the expected timing click event to the queue', () => {
+    trackTiming({
+      category: 'category-1',
+      timing: 200,
+      variable: 'var-1',
+      label: 'label-1',
+    });
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0',
+      data: {
+        category: 'category-1',
+        timing: 200,
+        variable: 'var-1',
+        label: 'label-1',
+      },
+    });
+  });
+
+  it('trackSiteSearch adds the expected site search event to the queue', () => {
+    trackSiteSearch({
+      terms: ['term-1', 'term-2'],
+      filters: { key: 'value' },
+      pageResults: 10,
+      totalResults: 100,
+    });
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/site_search/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/site_search/jsonschema/1-0-0',
+      data: {
+        terms: ['term-1', 'term-2'],
+        filters: { key: 'value' },
+        pageResults: 10,
+        totalResults: 100,
+      },
+    });
+  });
+
+  it('trackSocialInteraction adds the expected social interaction event to the queue', () => {
+    trackSocialInteraction({
+      action: 'action-1',
+      network: 'network-1',
+      target: 'target-1',
+    });
+
+    expect(
+      extractUeEvent('iglu:com.snowplowanalytics.snowplow/social_interaction/jsonschema/1-0-0').from(state.outQueues[0])
+    ).toMatchObject({
+      schema: 'iglu:com.snowplowanalytics.snowplow/social_interaction/jsonschema/1-0-0',
+      data: {
+        action: 'action-1',
+        network: 'network-1',
+        target: 'target-1',
+      },
+    });
+  });
+});

--- a/plugins/browser-plugin-timezone/package.json
+++ b/plugins/browser-plugin-timezone/package.json
@@ -45,5 +45,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.3"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.0"
   }
 }

--- a/plugins/browser-plugin-timezone/package.json
+++ b/plugins/browser-plugin-timezone/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "Paul Boocock",
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/rush.json
+++ b/rush.json
@@ -246,7 +246,7 @@
      * The default branch name. This tells "rush change" which remote branch to compare against.
      * The default value is "master"
      */
-    "defaultBranch": "release/3.0.0"
+    "defaultBranch": "master"
 
     /**
      * The default remote. This tells "rush change" which remote to compare against if the remote URL is

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.41.0",
+  "rushVersion": "5.43.0",
 
   /**
    * The next field selects which package manager should be installed and determines its version.
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "5.18.8",
+  "pnpmVersion": "5.18.9",
 
   // "npmVersion": "4.5.0",
   // "yarnVersion": "1.9.4",

--- a/trackers/browser-tracker/package.json
+++ b/trackers/browser-tracker/package.json
@@ -24,6 +24,7 @@
     "Michael Hadam",
     "Paul Boocock"
   ],
+  "sideEffects": false,
   "main": "./dist/index.umd.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",

--- a/trackers/browser-tracker/package.json
+++ b/trackers/browser-tracker/package.json
@@ -55,7 +55,7 @@
     "jest-environment-jsdom": "^26.6.2",
     "jest-environment-jsdom-global": "^2.0.4",
     "jest-standard-reporter": "^2.0.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^2.2.0",

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -80,7 +80,7 @@
     "gulp": "^4.0.2",
     "jest": "^26.6.3",
     "jest-standard-reporter": "^2.0.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.41.1",
     "rollup-plugin-cleanup": "^3.2.1",

--- a/trackers/node-tracker/package.json
+++ b/trackers/node-tracker/package.json
@@ -21,6 +21,7 @@
     "Anton Parkhomenko",
     "Paul Boocock"
   ],
+  "sideEffects": false,
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.module.js",
   "types": "./dist/index.module.d.ts",


### PR DESCRIPTION
This PR contains only minor changes to v3. 

Couple of tiny bugs here:
1. Broken types on buildPageView
2. trackLinkClick only worked if you'd initialised auto link click tracking first (fixed in #954 by using `_trackers` instead of `_configuration`).

Other commits are quality of life improvements and fixes for the release process. I've decided to keep `mathieudutour/github-tag-action` for now although it's not doing much now, in dry run mode it still generates a new compare link (e.g https://github.com/snowplow/snowplow-javascript-tracker/compare/2.17.3...3.0.0) for the release changelog for between the last two releases. We should likely improve the changelog/release automation in the future but this is good enough for now.