### PR TITLE
check for sandbox SecurityErrors so snowplow clients can run in sandboxed environments

### DIFF
--- a/libraries/browser-tracker-core/src/detectors.ts
+++ b/libraries/browser-tracker-core/src/detectors.ts
@@ -35,7 +35,7 @@
  */
 export function hasSessionStorage() {
   try {
-    return !!window.sessionStorage;
+    return window && !!window.sessionStorage;
   } catch (e) {
     return true; // SecurityError when referencing it means it exists
   }
@@ -48,7 +48,7 @@ export function hasSessionStorage() {
  */
 export function hasLocalStorage() {
   try {
-    return !!window.localStorage;
+    return window && !!window.localStorage;
   } catch (e) {
     return true; // SecurityError when referencing it means it exists
   }

--- a/libraries/browser-tracker-core/src/detectors.ts
+++ b/libraries/browser-tracker-core/src/detectors.ts
@@ -28,6 +28,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+const isSandboxedError = (error: Error): boolean => {
+  if (error.name === 'SecurityError') {
+    if (!error.message) {
+      return false;
+    }
+    const matches = error.message.match(/sandboxed/);
+    if (matches && matches.length === 1) {
+      return false;
+    }
+  }
+  return false;
+};
+
 /*
  * Checks whether sessionStorage is available, in a way that
  * does not throw a SecurityError in Firefox if "always ask"
@@ -37,7 +50,10 @@ export function hasSessionStorage() {
   try {
     return window && !!window.sessionStorage;
   } catch (e) {
-    return true; // SecurityError when referencing it means it exists
+    // SecurityError when referencing it means it exists
+    // SecurityError can also be a sandbox error:
+    // if this is the case, session storage is not available.
+    return !isSandboxedError(e);
   }
 }
 
@@ -50,7 +66,10 @@ export function hasLocalStorage() {
   try {
     return window && !!window.localStorage;
   } catch (e) {
-    return true; // SecurityError when referencing it means it exists
+    // SecurityError when referencing it means it exists
+    // SecurityError can also be a sandbox error:
+    // if this is the case, session storage is not available.
+    return !isSandboxedError(e);
   }
 }
 


### PR DESCRIPTION
My use-case is that the client I work for is using a low-code rapid app development solution called [Retool](https://retool.com/).
I have been building support apps with this to get around long-lasting tech debt and legacy issues, and, in all honesty:
it's pretty good! (even though it's not a long-term solution to any of those problems)
We want to track app usage and other things, however, Retool doesn't offer a tracking solution to our liking.
So we started implementing Snowplow using the javascript tracker.
This is possible, however, since Retool-built apps operate within a 'sandbox' mode (I have yet to figure out how this works - I expect CSP headers), session- and local Storage checks fail, due to javascript not being allowed to access anything on the `window` scope.
This causes the snowplow client to not want to even start, with the following error (visible from within Retool in the screenshot I will post in a reply)

`startSnowplough: Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.`

I have made a very crude PR to what I think might be a solution to this problem, but it's pretty rough and probably there are better ways to do this.