### PR TITLE
Fix linkDecorationHandler targeting (close #1002)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/release-3.1.4_2021-09-21-13-51.json
+++ b/common/changes/@snowplow/browser-tracker-core/release-3.1.4_2021-09-21-13-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix linkDecorationHandler targeting (closes #1002)",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -324,7 +324,7 @@ export function Tracker(
      */
     function linkDecorationHandler(evt: Event) {
       var timestamp = new Date().getTime();
-      let elt = evt.target as HTMLAnchorElement | HTMLAreaElement | null;
+      let elt = evt.currentTarget as HTMLAnchorElement | HTMLAreaElement | null;
       if (elt?.href) {
         elt.href = decorateQuerystring(elt.href, '_sp', domainUserId + '.' + timestamp);
       }


### PR DESCRIPTION
Fix linkDecorationHandler targeting (close #1002) which affects the cross domain linker functionality as described in the issue.