### PR TITLE
Allows `enableFormTracking` to track field changes within already tracked forms.

### DIFF
--- a/plugins/browser-plugin-form-tracking/src/helpers.ts
+++ b/plugins/browser-plugin-form-tracking/src/helpers.ts
@@ -93,7 +93,7 @@ export function addFormListeners(tracker: BrowserTracker, configuration: FormTra
     config = getConfigurationForOptions(options);
 
   Array.prototype.slice.call(document.getElementsByTagName('form')).forEach(function (form) {
-    if (config.formFilter(form) && !form[trackingMarker]) {
+    if (config.formFilter(form)) {
       Array.prototype.slice.call(innerElementTags).forEach(function (tagname) {
         Array.prototype.slice.call(form.getElementsByTagName(tagname)).forEach(function (innerElement) {
           if (
@@ -118,8 +118,10 @@ export function addFormListeners(tracker: BrowserTracker, configuration: FormTra
         });
       });
 
-      addEventListener(form, 'submit', getFormSubmissionListener(tracker, config, trackingMarker, context));
-      form[trackingMarker] = true;
+      if (!form[trackingMarker]) {
+        addEventListener(form, 'submit', getFormSubmissionListener(tracker, config, trackingMarker, context));
+        form[trackingMarker] = true;
+      }
     }
   });
 }


### PR DESCRIPTION
Fixes #748

Allows `enableFormTracking` to track field changes within already tracked forms.

Works by:
- Moving the forms boolean marker check to wrap the event listener rather than the entire check of the form.
- Allows form fields to be checked even if the form was already being "tracked", will not duplicate event listeners.
- Form fields will not duplicate listeners as they also have a boolean flag check.

