### PR TITLE
Fix failing build on ARM Macs (closes #1012)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-ad-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-ad-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-ad-tracking",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ad-tracking"
+}

--- a/common/changes/@snowplow/browser-plugin-browser-features/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-browser-features/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-browser-features",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-browser-features"
+}

--- a/common/changes/@snowplow/browser-plugin-client-hints/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-client-hints",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-client-hints"
+}

--- a/common/changes/@snowplow/browser-plugin-consent/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-consent/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-consent",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-consent"
+}

--- a/common/changes/@snowplow/browser-plugin-debugger/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-debugger/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-debugger",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-debugger"
+}

--- a/common/changes/@snowplow/browser-plugin-ecommerce/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-ecommerce/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-ecommerce",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ecommerce"
+}

--- a/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-enhanced-ecommerce",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
+}

--- a/common/changes/@snowplow/browser-plugin-error-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-error-tracking",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-error-tracking"
+}

--- a/common/changes/@snowplow/browser-plugin-form-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-form-tracking",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking"
+}

--- a/common/changes/@snowplow/browser-plugin-ga-cookies/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-ga-cookies/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-ga-cookies",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ga-cookies"
+}

--- a/common/changes/@snowplow/browser-plugin-geolocation/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-geolocation/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-geolocation",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-geolocation"
+}

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-link-click-tracking",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely-x/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-optimizely-x",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely-x"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-optimizely",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely"
+}

--- a/common/changes/@snowplow/browser-plugin-performance-timing/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-performance-timing/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-performance-timing",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-performance-timing"
+}

--- a/common/changes/@snowplow/browser-plugin-site-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-site-tracking/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-site-tracking",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-site-tracking"
+}

--- a/common/changes/@snowplow/browser-plugin-timezone/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-plugin-timezone/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-timezone",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-timezone"
+}

--- a/common/changes/@snowplow/browser-tracker-core/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/changes/@snowplow/tracker-core/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
+++ b/common/changes/@snowplow/tracker-core/issue-1012-fix_build_arm_macs_2021-10-12-12-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Fix failing build on ARM Macs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -4,7 +4,7 @@
   "packages": [
     {
       "name": "@ampproject/rollup-plugin-closure-compiler",
-      "allowedCategories": [ "libraries", "trackers" ]
+      "allowedCategories": [ "libraries", "plugins", "trackers" ]
     },
     {
       "name": "@rollup/plugin-alias",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   ../../libraries/browser-tracker-core:
     specifiers:
-      '@ampproject/rollup-plugin-closure-compiler': ^0.26.0
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/tracker-core': workspace:*
@@ -38,7 +38,7 @@ importers:
       tslib: 2.3.0
       uuid: 3.4.0
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler': 0.26.0_rollup@2.41.1
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -62,6 +62,7 @@ importers:
 
   ../../libraries/tracker-core:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-json': ^4.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
@@ -85,6 +86,7 @@ importers:
       tslib: 2.3.0
       uuid: 3.4.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-json': 4.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
@@ -105,6 +107,7 @@ importers:
 
   ../../plugins/browser-plugin-ad-tracking:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -130,6 +133,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -150,6 +154,7 @@ importers:
 
   ../../plugins/browser-plugin-browser-features:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -175,6 +180,7 @@ importers:
       '@snowplow/browser-tracker-core': link:../../libraries/browser-tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@snowplow/tracker-core': link:../../libraries/tracker-core
@@ -197,6 +203,7 @@ importers:
 
   ../../plugins/browser-plugin-client-hints:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -218,6 +225,7 @@ importers:
       '@snowplow/browser-tracker-core': link:../../libraries/browser-tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -236,6 +244,7 @@ importers:
 
   ../../plugins/browser-plugin-consent:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -261,6 +270,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -281,6 +291,7 @@ importers:
 
   ../../plugins/browser-plugin-debugger:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -307,6 +318,7 @@ importers:
       randomcolor: 0.6.2
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -326,6 +338,7 @@ importers:
 
   ../../plugins/browser-plugin-ecommerce:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -351,6 +364,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -371,6 +385,7 @@ importers:
 
   ../../plugins/browser-plugin-enhanced-ecommerce:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -396,6 +411,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -416,6 +432,7 @@ importers:
 
   ../../plugins/browser-plugin-error-tracking:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -441,6 +458,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -461,6 +479,7 @@ importers:
 
   ../../plugins/browser-plugin-form-tracking:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -484,6 +503,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -502,6 +522,7 @@ importers:
 
   ../../plugins/browser-plugin-ga-cookies:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -525,6 +546,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -543,6 +565,7 @@ importers:
 
   ../../plugins/browser-plugin-geolocation:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -566,6 +589,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -584,6 +608,7 @@ importers:
 
   ../../plugins/browser-plugin-link-click-tracking:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -609,6 +634,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -629,6 +655,7 @@ importers:
 
   ../../plugins/browser-plugin-optimizely:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -652,6 +679,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -670,6 +698,7 @@ importers:
 
   ../../plugins/browser-plugin-optimizely-x:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -693,6 +722,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -711,6 +741,7 @@ importers:
 
   ../../plugins/browser-plugin-performance-timing:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -737,6 +768,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -758,6 +790,7 @@ importers:
 
   ../../plugins/browser-plugin-site-tracking:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -783,6 +816,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -803,6 +837,7 @@ importers:
 
   ../../plugins/browser-plugin-timezone:
     specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -831,6 +866,7 @@ importers:
       jstimezonedetect: 1.0.7
       tslib: 2.3.0
     devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -852,7 +888,7 @@ importers:
 
   ../../trackers/browser-tracker:
     specifiers:
-      '@ampproject/rollup-plugin-closure-compiler': ^0.26.0
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-node-resolve': ^11.2.0
       '@snowplow/browser-tracker-core': workspace:*
@@ -881,7 +917,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler': 0.26.0_rollup@2.41.1
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.1
       '@types/jest': 26.0.20
@@ -905,7 +941,7 @@ importers:
 
   ../../trackers/javascript-tracker:
     specifiers:
-      '@ampproject/rollup-plugin-closure-compiler': ^0.26.0
+      '@ampproject/rollup-plugin-closure-compiler': ^0.27.0
       '@rollup/plugin-alias': ^3.1.2
       '@rollup/plugin-commonjs': ^17.1.0
       '@rollup/plugin-json': ^4.1.0
@@ -981,7 +1017,7 @@ importers:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
       tslib: 2.3.0
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler': 0.26.0_rollup@2.41.1
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.41.1
       '@rollup/plugin-alias': 3.1.2_rollup@2.41.1
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.1
       '@rollup/plugin-json': 4.1.0_rollup@2.41.1
@@ -1067,17 +1103,17 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /@ampproject/rollup-plugin-closure-compiler/0.26.0_rollup@2.41.1:
-    resolution: {integrity: sha512-wuHzGE6BDhDR0L7nUPlpQDPGiGnMw+b0B+cDPG0S5TatOmFNQva8KSNdBHan3L9RbvNyYXOXicuCrZtSoBfrBg==}
+  /@ampproject/rollup-plugin-closure-compiler/0.27.0_rollup@2.41.1:
+    resolution: {integrity: sha512-stpAOn2ZZEJuAV39HFw9cnKJYNhEeHtcsoa83orpLDhSxsxSbVEKwHaWlFBaQYpQRSOdapC4eJhJnCzocZxnqg==}
     engines: {node: '>=10'}
     peerDependencies:
       rollup: '>=1.27'
     dependencies:
       '@ampproject/remapping': 0.2.0
-      acorn: 7.2.0
+      acorn: 7.3.1
       acorn-walk: 7.1.1
       estree-walker: 2.0.1
-      google-closure-compiler: 20200517.0.0
+      google-closure-compiler: 20210808.0.0
       magic-string: 0.25.7
       rollup: 2.41.1
       uuid: 8.1.0
@@ -3724,8 +3760,8 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn/7.2.0:
-    resolution: {integrity: sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==}
+  /acorn/7.3.1:
+    resolution: {integrity: sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -6572,50 +6608,45 @@ packages:
       minimatch: 3.0.4
     dev: true
 
-  /google-closure-compiler-java/20200517.0.0:
-    resolution: {integrity: sha512-JVZBiyyXwcYi6Yc3lO6dF2hMLJA4OzPm4/mgsem/tF1vk2HsWTnL3GTaBsPB2ENVZp0hoqsd4KgpPiG9ssNWxw==}
+  /google-closure-compiler-java/20210808.0.0:
+    resolution: {integrity: sha512-7dEQfBzOdwdjwa/Pq8VAypNBKyWRrOcKjnNYOO9gEg2hjh8XVMeQzTqw4uANfVvvANGdE/JjD+HF6zHVgLRwjg==}
     dev: true
 
-  /google-closure-compiler-js/20200517.0.0:
-    resolution: {integrity: sha512-dz6dOUHx5nhdIqMRXacAYS8aJfLvw4IKxGg28Hq/zeeDPHlX3P3iBK20NgFDfT8zdushThymtMqChSy7C5eyfA==}
-    dev: true
-
-  /google-closure-compiler-linux/20200517.0.0:
-    resolution: {integrity: sha512-S5xPh6TtP+ESzZrmQLcDDqtZAsCVTbdI4VS98wQlN6IMZTd94nAnOCg9mrxQNAgop2t4sdsv/KuH0BGPUWEZ+w==}
+  /google-closure-compiler-linux/20210808.0.0:
+    resolution: {integrity: sha512-byKi5ITUiWRvEIcQo76i1siVnOwrTmG+GNcBG4cJ7x8IE6+4ki9rG5pUe4+DOYHkfk52XU6XHt9aAAgCcFDKpg==}
     cpu: [x64, x86]
     os: [linux]
     dev: true
     optional: true
 
-  /google-closure-compiler-osx/20200517.0.0:
-    resolution: {integrity: sha512-FWIcsKqLllLjdOBZd7azijVaObydgRd0obVNi63eUfC5MX6T4qxKumGCyor2UCNY6by2ESz+PlGqCFzFhZ6b2g==}
-    cpu: [x64, x86]
+  /google-closure-compiler-osx/20210808.0.0:
+    resolution: {integrity: sha512-iwyAY6dGj1FrrBdmfwKXkjtTGJnqe8F+9WZbfXxiBjkWLtIsJt2dD1+q7g/sw3w8mdHrGQAdxtDZP/usMwj/Rg==}
+    cpu: [x64, x86, arm64]
     os: [darwin]
     dev: true
     optional: true
 
-  /google-closure-compiler-windows/20200517.0.0:
-    resolution: {integrity: sha512-UXhjRGwS8deTkRla/riyVq3psscgMuw78lepEPtq5NgbumgJzY2+IQP9q+4MVOfJW58Rv0JUWKAFOnBBSZWcAQ==}
-    cpu: [x64, x86]
+  /google-closure-compiler-windows/20210808.0.0:
+    resolution: {integrity: sha512-VI+UUYwtGWDYwpiixrWRD8EklHgl6PMbiEaHxQSrQbH8PDXytwaOKqmsaH2lWYd5Y/BOZie2MzjY7F5JI69q1w==}
+    cpu: [x64]
     os: [win32]
     dev: true
     optional: true
 
-  /google-closure-compiler/20200517.0.0:
-    resolution: {integrity: sha512-80W9zBS9Ajk1T5InWCfsoPohDmo5T1AAyw1rHh5+dgb/jPgwC65KhY+oJozTncf+/7tyQHJXozTARwhSlBUcMg==}
-    engines: {node: '>=8'}
+  /google-closure-compiler/20210808.0.0:
+    resolution: {integrity: sha512-+R2+P1tT1lEnDDGk8b+WXfyVZgWjcCK9n1mmZe8pMEzPaPWxqK7GMetLVWnqfTDJ5Q+LRspOiFBv3Is+0yuhCA==}
+    engines: {node: '>=10'}
     hasBin: true
     dependencies:
       chalk: 2.4.2
-      google-closure-compiler-java: 20200517.0.0
-      google-closure-compiler-js: 20200517.0.0
+      google-closure-compiler-java: 20210808.0.0
       minimist: 1.2.5
       vinyl: 2.2.1
       vinyl-sourcemaps-apply: 0.2.1
     optionalDependencies:
-      google-closure-compiler-linux: 20200517.0.0
-      google-closure-compiler-osx: 20200517.0.0
-      google-closure-compiler-windows: 20200517.0.0
+      google-closure-compiler-linux: 20210808.0.0
+      google-closure-compiler-osx: 20210808.0.0
+      google-closure-compiler-windows: 20210808.0.0
     dev: true
 
   /got/11.8.1:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "410df3ec068961159c06e6d9956be4852d071f28",
+  "pnpmShrinkwrapHash": "42a8258d87b6908622c307febeb387666d00a459",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/browser-tracker-core/package.json
+++ b/libraries/browser-tracker-core/package.json
@@ -28,7 +28,7 @@
     "uuid": "^3.4.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "^0.26.0",
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/libraries/tracker-core/package.json
+++ b/libraries/tracker-core/package.json
@@ -48,6 +48,7 @@
     "uuid": "^3.4.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",

--- a/plugins/browser-plugin-ad-tracking/package.json
+++ b/plugins/browser-plugin-ad-tracking/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-browser-features/package.json
+++ b/plugins/browser-plugin-browser-features/package.json
@@ -26,6 +26,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@snowplow/tracker-core": "workspace:*",

--- a/plugins/browser-plugin-client-hints/package.json
+++ b/plugins/browser-plugin-client-hints/package.json
@@ -26,6 +26,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-consent/package.json
+++ b/plugins/browser-plugin-consent/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-debugger/package.json
+++ b/plugins/browser-plugin-debugger/package.json
@@ -28,6 +28,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-ecommerce/package.json
+++ b/plugins/browser-plugin-ecommerce/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-enhanced-ecommerce/package.json
+++ b/plugins/browser-plugin-enhanced-ecommerce/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-error-tracking/package.json
+++ b/plugins/browser-plugin-error-tracking/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-form-tracking/package.json
+++ b/plugins/browser-plugin-form-tracking/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-ga-cookies/package.json
+++ b/plugins/browser-plugin-ga-cookies/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-geolocation/package.json
+++ b/plugins/browser-plugin-geolocation/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-link-click-tracking/package.json
+++ b/plugins/browser-plugin-link-click-tracking/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-optimizely-x/package.json
+++ b/plugins/browser-plugin-optimizely-x/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-optimizely/package.json
+++ b/plugins/browser-plugin-optimizely/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-performance-timing/package.json
+++ b/plugins/browser-plugin-performance-timing/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-site-tracking/package.json
+++ b/plugins/browser-plugin-site-tracking/package.json
@@ -27,6 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/plugins/browser-plugin-timezone/package.json
+++ b/plugins/browser-plugin-timezone/package.json
@@ -28,6 +28,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/trackers/browser-tracker/package.json
+++ b/trackers/browser-tracker/package.json
@@ -41,7 +41,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "^0.26.0",
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -58,7 +58,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "^0.26.0",
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",


### PR DESCRIPTION
Bumps version requirement for @ampproject/rollup-plugin-closure-compiler package which fixes build issues on ARM Macs.

Issue #1012 