### PR TITLE
Fix issues importing some plugins in Next SSR (close #1015)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-client-hints/issue-1015_2021-10-18-13-33.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/issue-1015_2021-10-18-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix issues importing some plugins in Next SSR (#1015)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-client-hints"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-client-hints",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-geolocation/issue-1015_2021-10-18-13-33.json
+++ b/common/changes/@snowplow/browser-plugin-geolocation/issue-1015_2021-10-18-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix issues importing some plugins in Next SSR (#1015)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-geolocation"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-geolocation",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely-x/issue-1015_2021-10-18-13-33.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/issue-1015_2021-10-18-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix issues importing some plugins in Next SSR (#1015)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely-x"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely-x",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely/issue-1015_2021-10-18-13-33.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely/issue-1015_2021-10-18-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix issues importing some plugins in Next SSR (#1015)",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely",
+  "email": "paul@snowplowanalytics.com"
+}

--- a/plugins/browser-plugin-client-hints/src/index.ts
+++ b/plugins/browser-plugin-client-hints/src/index.ts
@@ -54,34 +54,41 @@ declare global {
   }
 }
 
-const navigatorAlias = navigator;
+let uaClientHints: HttpClientHints;
 
 /**
  * Attaches Client Hint information where available
  * @param includeHighEntropy - Should high entropy values be included
  */
 export function ClientHintsPlugin(includeHighEntropy?: boolean): BrowserPlugin {
-  let uaClientHints: HttpClientHints;
+  const populateClientHints = () => {
+    const navigatorAlias = navigator;
 
-  if (navigatorAlias.userAgentData) {
-    uaClientHints = {
-      isMobile: navigatorAlias.userAgentData.mobile,
-      brands: navigatorAlias.userAgentData.brands,
-    };
-    if (includeHighEntropy && navigatorAlias.userAgentData.getHighEntropyValues) {
-      navigatorAlias.userAgentData
-        .getHighEntropyValues(['platform', 'platformVersion', 'architecture', 'model', 'uaFullVersion'])
-        .then((res) => {
-          uaClientHints.architecture = res.architecture;
-          uaClientHints.model = res.model;
-          uaClientHints.platform = res.platform;
-          uaClientHints.uaFullVersion = res.uaFullVersion;
-          uaClientHints.platformVersion = res.platformVersion;
-        });
+    if (navigatorAlias.userAgentData) {
+      uaClientHints = {
+        isMobile: navigatorAlias.userAgentData.mobile,
+        brands: navigatorAlias.userAgentData.brands,
+      };
+      if (includeHighEntropy && navigatorAlias.userAgentData.getHighEntropyValues) {
+        navigatorAlias.userAgentData
+          .getHighEntropyValues(['platform', 'platformVersion', 'architecture', 'model', 'uaFullVersion'])
+          .then((res) => {
+            uaClientHints.architecture = res.architecture;
+            uaClientHints.model = res.model;
+            uaClientHints.platform = res.platform;
+            uaClientHints.uaFullVersion = res.uaFullVersion;
+            uaClientHints.platformVersion = res.platformVersion;
+          });
+      }
     }
-  }
+  };
 
   return {
+    activateBrowserPlugin: () => {
+      if (!uaClientHints) {
+        populateClientHints();
+      }
+    },
     contexts: () => {
       if (uaClientHints) {
         return [

--- a/plugins/browser-plugin-geolocation/src/index.ts
+++ b/plugins/browser-plugin-geolocation/src/index.ts
@@ -32,8 +32,7 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 import { BrowserPlugin } from '@snowplow/browser-tracker-core';
 import { Geolocation } from './contexts';
 
-const navigatorAlias = navigator,
-  _trackers: Record<string, [boolean, SelfDescribingJson<Geolocation> | undefined]> = {};
+const _trackers: Record<string, [boolean, SelfDescribingJson<Geolocation> | undefined]> = {};
 
 let geolocation: SelfDescribingJson<Geolocation>,
   geolocationContextAdded = false;
@@ -75,6 +74,8 @@ export function GeolocationPlugin(enableAtLoad: boolean = false): BrowserPlugin 
  * @param trackers - The tracker identifiers which the context will be sent to
  */
 export function enableGeolocationContext(trackers: Array<string> = Object.keys(_trackers)) {
+  const navigatorAlias = navigator;
+
   trackers.forEach((t) => {
     //Mark as enabled
     _trackers[t] = [true, geolocation]; // Geolocation might still be undefined but it could also be set already

--- a/plugins/browser-plugin-optimizely-x/src/index.ts
+++ b/plugins/browser-plugin-optimizely-x/src/index.ts
@@ -43,7 +43,6 @@ declare global {
  * Adds Opimizely X context to events
  */
 export function OptimizelyXPlugin(): BrowserPlugin {
-  const windowOptimizelyAlias = window.optimizely;
   /**
    * Check that *both* optimizely and optimizely.get exist
    *
@@ -51,6 +50,7 @@ export function OptimizelyXPlugin(): BrowserPlugin {
    * @param snd - optional nested property
    */
   function getOptimizelyXData(property: string, snd?: string) {
+    const windowOptimizelyAlias = window.optimizely;
     let data;
     if (windowOptimizelyAlias && typeof windowOptimizelyAlias.get === 'function') {
       data = windowOptimizelyAlias.get(property);
@@ -104,7 +104,7 @@ export function OptimizelyXPlugin(): BrowserPlugin {
   return {
     contexts: () => {
       // Add Optimizely Contexts
-      if (windowOptimizelyAlias) {
+      if (window.optimizely) {
         return getOptimizelyXSummaryContexts();
       }
 

--- a/plugins/browser-plugin-optimizely/src/index.ts
+++ b/plugins/browser-plugin-optimizely/src/index.ts
@@ -67,8 +67,6 @@ export function OptimizelyPlugin(
   audiences: boolean = true,
   dimensions: boolean = true
 ): BrowserPlugin {
-  const windowOptimizelyAlias = window.optimizely;
-
   /**
    * Check that *both* optimizely and optimizely.data exist and return
    * optimizely.data.property
@@ -77,6 +75,7 @@ export function OptimizelyPlugin(
    * @param snd - optional nested property
    */
   function getOptimizelyData(property: string, snd?: string) {
+    const windowOptimizelyAlias = window.optimizely;
     let data;
     if (windowOptimizelyAlias && windowOptimizelyAlias.data) {
       data = windowOptimizelyAlias.data[property];
@@ -325,7 +324,7 @@ export function OptimizelyPlugin(
       const combinedContexts = [];
 
       // Add Optimizely Contexts
-      if (windowOptimizelyAlias) {
+      if (window.optimizely) {
         if (summary) {
           combinedContexts.push(...getOptimizelySummaryContexts());
         }


### PR DESCRIPTION
This moves any `window` or `navigator` usages in plugins to within functions rather than at the module or plugin constructor level. This enables the tracker to be imported and initialised when using Next SSR

Example of issue: [with-snowplow.zip](https://github.com/snowplow/snowplow-javascript-tracker/files/7365680/with-snowplow.zip) (See README for instructions, requires `yarn`).

Using build artifacts from the PR to update `yarn add file:/path/to/tarball.tgz` for the Geolocation and Client Hints plugins.