### PR TITLE
Add support for custom headers

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-1010_custom_headers_2021-11-26-16-12.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1010_custom_headers_2021-11-26-16-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add support for custom headers (#1010)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-1010_custom_headers_2021-11-26-16-12.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1010_custom_headers_2021-11-26-16-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add support for custom headers (#1010)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1010_custom_headers_2021-11-26-16-12.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1010_custom_headers_2021-11-26-16-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Add support for custom headers (#1010)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -261,7 +261,8 @@ export function Tracker(
         trackerConfiguration.useStm ?? true,
         trackerConfiguration.maxLocalStorageQueueSize ?? 1000,
         trackerConfiguration.connectionTimeout ?? 5000,
-        configAnonymousServerTracking
+        configAnonymousServerTracking,
+        trackerConfiguration.customHeaders ?? {}
       ),
       // Whether pageViewId should be regenerated after each trackPageView. Affect web_page context
       preservePageViewId = false,

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -63,7 +63,7 @@ export function OutQueueManager(
   id: string,
   sharedSate: SharedState,
   useLocalStorage: boolean,
-  eventMethod: string | boolean | null,
+  eventMethod: string | boolean,
   postPath: string,
   bufferSize: number,
   maxPostBytes: number,
@@ -85,9 +85,8 @@ export function OutQueueManager(
   //Force to lower case if its a string
   eventMethod = typeof eventMethod === 'string' ? eventMethod.toLowerCase() : eventMethod;
 
-  // Use the Beacon API if eventMethod is set null, true, or 'beacon'.
-  const isBeaconRequested =
-      eventMethod === null || eventMethod === true || eventMethod === 'beacon' || eventMethod === 'true',
+  // Use the Beacon API if eventMethod is set true, 'true', or 'beacon'.
+  const isBeaconRequested = eventMethod === true || eventMethod === 'beacon' || eventMethod === 'true',
     // Fall back to POST or GET for browsers which don't support Beacon API
     isBeaconAvailable = Boolean(
       isBeaconRequested &&
@@ -106,6 +105,10 @@ export function OutQueueManager(
     path = usePost ? postPath : '/i',
     // Different queue names for GET and POST since they are stored differently
     queueName = `snowplowOutQueue_${id}_${usePost ? 'post2' : 'get'}`;
+
+  // Ensure we don't set headers when beacon is the requested eventMethod as we might fallback to POST
+  // and end up sending them in older browsers which don't support beacon leading to inconsistencies
+  if (isBeaconRequested) customHeaders = {};
 
   // Get buffer size or set 1 if unable to buffer
   bufferSize = (useLocalStorage && localStorageAccessible() && usePost && bufferSize) || 1;

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -70,7 +70,8 @@ export function OutQueueManager(
   useStm: boolean,
   maxLocalStorageQueueSize: number,
   connectionTimeout: number,
-  anonymousTracking: boolean
+  anonymousTracking: boolean,
+  customHeaders: Record<string, string>
 ): OutQueue {
   type PostEvent = {
     evt: Record<string, unknown>;
@@ -404,6 +405,11 @@ export function OutQueueManager(
     xhr.withCredentials = true;
     if (anonymousTracking) {
       xhr.setRequestHeader('SP-Anonymous', '*');
+    }
+    for (const header in customHeaders) {
+      if (Object.prototype.hasOwnProperty.call(customHeaders, header)) {
+        xhr.setRequestHeader(header, customHeaders[header]);
+      }
     }
     return xhr;
   }

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -192,6 +192,12 @@ export type TrackerConfiguration = {
    * @defaultValue []
    */
   plugins?: Array<BrowserPlugin>;
+  /**
+   * An object of key value pairs which represent headers to
+   * attach when sending a POST request, only works for POST
+   * @defaultValue `{}`
+   */
+  customHeaders?: Record<string, string>;
 };
 
 /**

--- a/libraries/browser-tracker-core/test/out_queue.test.ts
+++ b/libraries/browser-tracker-core/test/out_queue.test.ts
@@ -50,7 +50,8 @@ describe('OutQueueManager', () => {
       false,
       maxQueueSize,
       5000,
-      false
+      false,
+      {}
     );
   });
 

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -331,6 +331,7 @@ export type TrackerConfiguration = {
         webPage: boolean;
     };
     plugins?: Array<BrowserPlugin>;
+    customHeaders?: Record<string, string>;
 };
 
 // @public

--- a/trackers/javascript-tracker/test/integration/integration.test.ts
+++ b/trackers/javascript-tracker/test/integration/integration.test.ts
@@ -802,5 +802,21 @@ describe('Snowplow Micro integration', () => {
         })
       ).toBe(false);
     });
+
+    const isBeaconEventMethodOrIE9 =
+      method === 'beacon' || F.isMatch({ browserName: 'internet explorer', version: '9' }, browser.capabilities);
+    it(`${method}: has ${isBeaconEventMethodOrIE9 ? 'no ' : ''}custom headers attached`, () => {
+      const results = log.filter(
+        (event: any) =>
+          event.rawEvent.context.headers.includes('Content-Language: de-DE, en-CA') &&
+          event.event.app_id === `sp-${method}`
+      ) as Array<any>;
+
+      if (isBeaconEventMethodOrIE9) {
+        expect(results.length).toBe(0);
+      } else {
+        expect(results.length).toBeGreaterThanOrEqual(1);
+      }
+    });
   });
 });

--- a/trackers/javascript-tracker/test/integration/integration.test.ts
+++ b/trackers/javascript-tracker/test/integration/integration.test.ts
@@ -803,16 +803,14 @@ describe('Snowplow Micro integration', () => {
       ).toBe(false);
     });
 
-    const isBeaconEventMethodOrIE9 =
-      method === 'beacon' || F.isMatch({ browserName: 'internet explorer', version: '9' }, browser.capabilities);
-    it(`${method}: has ${isBeaconEventMethodOrIE9 ? 'no ' : ''}custom headers attached`, () => {
+    it(`${method}: has custom headers attached if possible (not with Beacon or IE9)`, () => {
       const results = log.filter(
         (event: any) =>
           event.rawEvent.context.headers.includes('Content-Language: de-DE, en-CA') &&
           event.event.app_id === `sp-${method}`
       ) as Array<any>;
 
-      if (isBeaconEventMethodOrIE9) {
+      if (method === 'beacon' || F.isMatch({ browserName: 'internet explorer', version: '9' }, browser.capabilities)) {
         expect(results.length).toBe(0);
       } else {
         expect(results.length).toBeGreaterThanOrEqual(1);

--- a/trackers/javascript-tracker/test/pages/integration.html
+++ b/trackers/javascript-tracker/test/pages/integration.html
@@ -72,6 +72,9 @@
         contexts: {
           webPage: true,
         },
+        customHeaders: {
+          'Content-Language': 'de-DE, en-CA',
+        },
       });
 
       window.secondSnowplow('newTracker', 'b64off', collector_endpoint, {

--- a/trackers/javascript-tracker/tsconfig.json
+++ b/trackers/javascript-tracker/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.prod.json",
   "compilerOptions": {
-    "types": ["jest", "node", "@wdio/sync", "@wdio/jasmine-framework"]
+    "types": ["node", "@wdio/sync", "@wdio/jasmine-framework", "jest"]
   },
   "include": ["./test/**/*.test.ts"]
 }


### PR DESCRIPTION
Add support for custom headers in the tracker configuration

You can now do this:

```javascript
window.snowplow('newTracker', 'sp', collector_endpoint, {
  appId: 'sp',
  customHeaders: {
    'Content-Language': 'de-DE, en-CA',
  },
});
```

Headers must either be CORS safe (https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header) or returned in the `Access-Control-Allow-Headers` response header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers).

Note: The collector has a static `Access-Control-Allow-Headers` response header, so this is only useful when a Proxy is set up in front of the collector. Beneficial if someone is using a collector with some Auth for instance (See discourse post linked in Issue).