### PR TITLE
 Allow alternative Access-Control-Allow-Credentials values (close #808)

### DIFF
--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -261,7 +261,8 @@ export function Tracker(
         trackerConfiguration.useStm ?? true,
         trackerConfiguration.maxLocalStorageQueueSize ?? 1000,
         trackerConfiguration.connectionTimeout ?? 5000,
-        configAnonymousServerTracking
+        configAnonymousServerTracking,
+        !!trackerConfiguration.allowCredentials ?? true
       ),
       // Whether pageViewId should be regenerated after each trackPageView. Affect web_page context
       preservePageViewId = false,

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -57,6 +57,7 @@ export interface OutQueue {
  * @param maxLocalStorageQueueSize - Maximum number of queued events we will attempt to store in local storage
  * @param connectionTimeout - Defines how long to wait before aborting the request
  * @param anonymousTracking - Defines whether to set the SP-Anonymous header for anonymous tracking on GET and POST
+ * @param allowCredentials - Sets the value of the `access-control-allow-credentials` in the request headers
  * @returns object OutQueueManager instance
  */
 export function OutQueueManager(
@@ -70,7 +71,8 @@ export function OutQueueManager(
   useStm: boolean,
   maxLocalStorageQueueSize: number,
   connectionTimeout: number,
-  anonymousTracking: boolean
+  anonymousTracking: boolean,
+  allowCredentials: boolean
 ): OutQueue {
   type PostEvent = {
     evt: Record<string, unknown>;
@@ -401,7 +403,7 @@ export function OutQueueManager(
     } else {
       xhr.open('GET', url, !sync);
     }
-    xhr.withCredentials = true;
+    xhr.withCredentials = allowCredentials;
     if (anonymousTracking) {
       xhr.setRequestHeader('SP-Anonymous', '*');
     }

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -93,6 +93,12 @@ export type TrackerConfiguration = {
    */
   cookieLifetime?: number;
   /**
+   * Sets the `Access-Control-Allow-Credentials` header
+   * value to the specified boolean input value
+   * @defaultValue true
+   */
+  allowCredentials?: boolean;
+  /**
    * How long until a session expires
    * @defaultValue 1800 (30 minutes)
    */

--- a/libraries/browser-tracker-core/test/out_queue.test.ts
+++ b/libraries/browser-tracker-core/test/out_queue.test.ts
@@ -50,7 +50,8 @@ describe('OutQueueManager', () => {
       false,
       maxQueueSize,
       5000,
-      false
+      false,
+      true
     );
   });
 


### PR DESCRIPTION
In some implementations of Snowplow, the collection server may specify `access-control-allow-origin` header to the wildcard `'*'`. This is commonly used in staging or development environments where requests are intentionally made cross-domain. In this case, the XHRHttpRequest is rejected when `access-control-allow-origin='*'` and `withCredentials=true` with the following exception;

> Access to XMLHttpRequest at 'https://collection.example.com/i?QUERY_PARAMS' from origin 'http://localhost:3000' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.

The browser terminates the request because it is not safe to include credentials when `access-control-allow-origin` accepts any origin. In theory, other sites could send cross-origin requests with credentials from the client's website, raising a genuine security concern. However, in staging or development environments, we might intentionally make cross-origin requests to a collection server that does not require credentials. Setting the `access-control-allow-credentials` to `false` will prevent cookies, authorization headers, and TLS certificates from being included in the request, and allow the scenario above to complete successfully.