### PR TITLE
Allow enableFormTracking to capture dynamic form changes (close #748)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-form-tracking/issue-748_form_tracking_update_2022-01-05-16-53.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/issue-748_form_tracking_update_2022-01-05-16-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-form-tracking",
+      "comment": "Allow enableFormTracking to capture dynamic form changes (#748)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-748_form_tracking_update_2022-01-05-16-53.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-748_form_tracking_update_2022-01-05-16-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Allow enableFormTracking to capture dynamic form changes (#748)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/test/integration/autoTracking.test.ts
+++ b/trackers/javascript-tracker/test/integration/autoTracking.test.ts
@@ -39,6 +39,8 @@ const isMatchWithCallback = F.isMatchWith((lt, rt) => (F.isFunction(rt) ? rt(lt)
 const SAFARI_EXPECTED_FIRST_NAME = 'Alex';
 const SAFARI_EXPECTED_MESSAGE = 'Changed message';
 
+declare var addField: () => void;
+
 describe('Auto tracking', () => {
   if (F.isMatch({ browserName: 'internet explorer', version: '9' }, browser.capabilities)) {
     fit('Skip IE9', () => {}); // Automated tests for IE autotracking features
@@ -296,6 +298,14 @@ describe('Auto tracking', () => {
 
     browser.pause(1000);
 
+    browser.execute(() => {
+      addField();
+    });
+
+    $('#newfield').click();
+
+    browser.pause(1000);
+
     loadUrlAndWait('/form-tracking.html?filter=exclude');
 
     $('#fname').click();
@@ -329,6 +339,30 @@ describe('Auto tracking', () => {
         log = result;
       })
     );
+  });
+
+  it('should send focus_form for the dynamically added form element', () => {
+    expect(
+      logContains({
+        event: {
+          event: 'unstruct',
+          app_id: 'autotracking',
+          unstruct_event: {
+            data: {
+              schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+              data: {
+                formId: 'myForm',
+                elementId: 'newfield',
+                nodeName: 'INPUT',
+                elementType: 'text',
+                elementClasses: [],
+                value: 'new',
+              },
+            },
+          },
+        },
+      })
+    ).toBe(true);
   });
 
   it('should send focus_form and change_form on text input', () => {

--- a/trackers/javascript-tracker/test/pages/form-tracking.html
+++ b/trackers/javascript-tracker/test/pages/form-tracking.html
@@ -14,6 +14,20 @@
         return query;
       }
     </script>
+    <script type="text/javascript">
+      function addField() {
+        var fields = document.getElementById('fields');
+        fields.appendChild(document.createTextNode('New Field: '));
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.id = 'newfield';
+        input.name = 'newfield';
+        input.value = 'new';
+        fields.appendChild(input);
+        fields.appendChild(document.createElement('br'));
+        snowplow('enableFormTracking');
+      }
+    </script>
   </head>
 
   <body>
@@ -21,7 +35,7 @@
     <div id="init"></div>
 
     <form id="myForm" class="formy-mcformface" action="/form-tracking.html">
-      <fieldset>
+      <fieldset id="fields">
         <legend>Personal Info:</legend>
         <label for="fname">First name:</label><br />
         <input type="text" id="fname" name="fname" value="John" class="test" /><br />


### PR DESCRIPTION
Superseeds #1009

Allows `enableFormTracking` to be called multiple times and will find any newly added form elements that did not exist the first time that `enableFormTracking` was called.