### PR TITLE
Add configurable max GET request size in bytes attribute (close #449)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-449-max_get_bytes_2022-03-08-16-01.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-449-max_get_bytes_2022-03-08-16-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add configurable max GET request size in bytes attribute (#449)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-449-max_get_bytes_2022-03-08-16-01.json
+++ b/common/changes/@snowplow/browser-tracker/issue-449-max_get_bytes_2022-03-08-16-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add configurable max GET request size in bytes attribute (#449)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -268,6 +268,7 @@ export function Tracker(
         configPostPath,
         trackerConfiguration.bufferSize ?? 1,
         trackerConfiguration.maxPostBytes ?? 40000,
+        trackerConfiguration.maxGetBytes ?? false,
         trackerConfiguration.useStm ?? true,
         trackerConfiguration.maxLocalStorageQueueSize ?? 1000,
         trackerConfiguration.connectionTimeout ?? 5000,

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -268,7 +268,7 @@ export function Tracker(
         configPostPath,
         trackerConfiguration.bufferSize ?? 1,
         trackerConfiguration.maxPostBytes ?? 40000,
-        trackerConfiguration.maxGetBytes ?? false,
+        trackerConfiguration.maxGetBytes ?? 0,
         trackerConfiguration.useStm ?? true,
         trackerConfiguration.maxLocalStorageQueueSize ?? 1000,
         trackerConfiguration.connectionTimeout ?? 5000,

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -53,7 +53,7 @@ export interface OutQueue {
  * @param postPath - The path where events are to be posted
  * @param bufferSize - How many events to batch in localStorage before sending them all
  * @param maxPostBytes - Maximum combined size in bytes of the event JSONs in a POST request
- * @param maxGetBytes - Maximum size in bytes of the complete event URL string in a GET request
+ * @param maxGetBytes - Maximum size in bytes of the complete event URL string in a GET request. 0 for no limit.
  * @param useStm - Whether to add timestamp to events
  * @param maxLocalStorageQueueSize - Maximum number of queued events we will attempt to store in local storage
  * @param connectionTimeout - Defines how long to wait before aborting the request
@@ -70,7 +70,7 @@ export function OutQueueManager(
   postPath: string,
   bufferSize: number,
   maxPostBytes: number,
-  maxGetBytes: number | boolean,
+  maxGetBytes: number,
   useStm: boolean,
   maxLocalStorageQueueSize: number,
   connectionTimeout: number,
@@ -237,7 +237,7 @@ export function OutQueueManager(
       }
     } else {
       const querystring = getQuerystring(request);
-      if (maxGetBytes !== false) {
+      if (maxGetBytes > 0) {
         const requestUrl = createGetUrl(querystring);
         const bytes = getUTF8Length(requestUrl);
         if (bytes >= maxGetBytes) {

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -143,10 +143,15 @@ export type TrackerConfiguration = {
    */
   crossDomainLinker?: (elt: HTMLAnchorElement | HTMLAreaElement) => boolean;
   /**
-   * The max size a request can be before the tracker will force send it
+   * The max size a POST request can be before the tracker will force send it
    * @defaultValue 40000
    */
   maxPostBytes?: number;
+  /**
+   * The max size a GET request (its complete URL) can be. Requests over this size will be ignored.
+   * @defaultValue unlimited
+   */
+  maxGetBytes?: number;
   /**
    * Whether the tracker should attempt to figure out what the root
    * domain is to store cookies on

--- a/libraries/browser-tracker-core/test/out_queue.test.ts
+++ b/libraries/browser-tracker-core/test/out_queue.test.ts
@@ -60,7 +60,7 @@ describe('OutQueueManager', () => {
         '/com.snowplowanalytics.snowplow/tp2',
         1,
         40000,
-        false,
+        0, // maxGetBytes – 0 for no limit
         false,
         maxQueueSize,
         5000,
@@ -100,7 +100,7 @@ describe('OutQueueManager', () => {
   });
 
   describe('GET requests', () => {
-    var getOutQueue: (maxGetBytes: number | boolean) => OutQueue;
+    var getOutQueue: (maxGetBytes: number) => OutQueue;
     const getQuerystring = (p: object) =>
       '?' +
       Object.entries(p)
@@ -128,7 +128,7 @@ describe('OutQueueManager', () => {
     });
 
     it('should add large event to out queue without bytes limit', () => {
-      var outQueue = getOutQueue(false);
+      var outQueue = getOutQueue(0);
 
       const expected = { e: 'pv', eid: '20269f92-f07c-44a6-87ef-43e171305076', aid: 'x'.repeat(1000) };
       outQueue.enqueueRequest(expected, '');

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -322,6 +322,7 @@ export type TrackerConfiguration = {
     bufferSize?: number;
     crossDomainLinker?: (elt: HTMLAnchorElement | HTMLAreaElement) => boolean;
     maxPostBytes?: number;
+    maxGetBytes?: number;
     discoverRootDomain?: boolean;
     stateStorageStrategy?: StateStorageStrategy;
     maxLocalStorageQueueSize?: number;


### PR DESCRIPTION
This PR addresses issues #449 and #362.

It adds the `maxGetBytes` configuration parameter that sets the maximum size for GET requests. The size in bytes is checked for the full GET request URL. In case requests are over this size limit, an error is written to `console.log` and the event is ignored (not added to queue).

The default behaviour remains that the request size for GET is unlimited.