### PR TITLE
Add ability to enable only form_change, or form_submit, focus_form or any combination (close #371)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-form-tracking/issue-371-form_tracking_configuration_2022-03-15-08-57.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/issue-371-form_tracking_configuration_2022-03-15-08-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-form-tracking",
+      "comment": "Add ability to enable only form_change, or form_submit, focus_form or any combination (#371)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-371-form_tracking_configuration_2022-03-15-08-57.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-371-form_tracking_configuration_2022-03-15-08-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Add ability to enable only form_change, or form_submit, focus_form or any combination (#371)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/test/integration/autoTracking.test.ts
+++ b/trackers/javascript-tracker/test/integration/autoTracking.test.ts
@@ -791,7 +791,7 @@ describe('Auto tracking', () => {
     ).toBe(false);
   });
 
-  it('should only track focus_form and not change_form events events when focus_form events are filtered', () => {
+  it('should only track focus_form and not change_form events when focus_form events are filtered', () => {
     expect(
       logContains({
         event: {

--- a/trackers/javascript-tracker/test/integration/autoTracking.test.ts
+++ b/trackers/javascript-tracker/test/integration/autoTracking.test.ts
@@ -243,40 +243,44 @@ describe('Auto tracking', () => {
   });
 
   it('should send form events', async () => {
+    async function formInteraction() {
+      await $('#fname').click();
+
+      // Safari 12.1 doesn't fire onchange events when clearing
+      // However some browsers don't support setValue
+      if (F.isMatch({ browserName: 'Safari', browserVersion: '12.1.1' }, browser.capabilities)) {
+        await $('#fname').setValue(SAFARI_EXPECTED_FIRST_NAME);
+      } else {
+        await $('#fname').clearValue();
+      }
+
+      await $('#lname').click();
+
+      await browser.pause(250);
+
+      await $('#bike').click();
+
+      await browser.pause(250);
+
+      await $('#cars').click();
+      await $('#cars').selectByAttribute('value', 'saab');
+      await $('#cars').click();
+
+      await browser.pause(250);
+
+      await $('#message').click();
+
+      // Safari 12.1 doesn't fire onchange events when clearing
+      // However some browsers don't support setValue
+      if (F.isMatch({ browserName: 'Safari', browserVersion: '12.1.1' }, browser.capabilities)) {
+        await $('#message').setValue(SAFARI_EXPECTED_MESSAGE);
+      } else {
+        await $('#message').clearValue();
+      }
+    }
+
     await loadUrlAndWait('/form-tracking.html');
-    await $('#fname').click();
-
-    // Safari 12.1 doesn't fire onchange events when clearing
-    // However some browsers don't support setValue
-    if (F.isMatch({ browserName: 'Safari', browserVersion: '12.1.1' }, browser.capabilities)) {
-      await $('#fname').setValue(SAFARI_EXPECTED_FIRST_NAME);
-    } else {
-      await $('#fname').clearValue();
-    }
-
-    await $('#lname').click();
-
-    await browser.pause(250);
-
-    await $('#bike').click();
-
-    await browser.pause(250);
-
-    await $('#cars').click();
-    await $('#cars').selectByAttribute('value', 'saab');
-    await $('#cars').click();
-
-    await browser.pause(250);
-
-    await $('#message').click();
-
-    // Safari 12.1 doesn't fire onchange events when clearing
-    // However some browsers don't support setValue
-    if (F.isMatch({ browserName: 'Safari', browserVersion: '12.1.1' }, browser.capabilities)) {
-      await $('#message').setValue(SAFARI_EXPECTED_MESSAGE);
-    } else {
-      await $('#message').clearValue();
-    }
+    await formInteraction();
 
     await browser.pause(250);
 
@@ -319,7 +323,12 @@ describe('Auto tracking', () => {
     await loadUrlAndWait('/form-tracking.html?filter=excludedForm');
 
     await $('#excluded-fname').click();
-    $('#excluded-submit').click();
+    await $('#excluded-submit').click();
+
+    await browser.pause(1000);
+
+    await loadUrlAndWait('/form-tracking.html?filter=onlyFocus');
+    await formInteraction();
 
     // time for activity to register and request to arrive
     await browser.pause(2500);
@@ -775,6 +784,38 @@ describe('Auto tracking', () => {
                 formId: 'excludedForm',
                 formClasses: ['excluded-form'],
               },
+            },
+          },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('should only track focus_form and not change_form events events when focus_form events are filtered', () => {
+    expect(
+      logContains({
+        event: {
+          event: 'unstruct',
+          app_id: 'autotracking',
+          page_url: 'http://snowplow-js-tracker.local:8080/form-tracking.html?filter=onlyFocus',
+          unstruct_event: {
+            data: {
+              schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+            },
+          },
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      logContains({
+        event: {
+          event: 'unstruct',
+          app_id: 'autotracking',
+          page_url: 'http://snowplow-js-tracker.local:8080/form-tracking.html?filter=onlyFocus',
+          unstruct_event: {
+            data: {
+              schema: 'iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0',
             },
           },
         },

--- a/trackers/javascript-tracker/test/pages/form-tracking.html
+++ b/trackers/javascript-tracker/test/pages/form-tracking.html
@@ -115,6 +115,9 @@
         case 'excludedForm':
           snowplow('enableFormTracking', { options: { forms: { denylist: ['excluded-form'] } } });
           break;
+        case 'onlyFocus':
+          snowplow('enableFormTracking', { options: { events: ['focus_form'] } });
+          break;
         default:
           snowplow('enableFormTracking', {
             context: [


### PR DESCRIPTION
Issue #371 

This PR adds ability to configure which of the three types of form events to track. It adds an option to the `enableFormTracking` call to list the events to be tracked.

## API

```js
enableFormTracking({
    options: {
        events: ['submit_form', 'focus_form', 'change_form']
    },
});
```

The `events` option is optional and, if not present, all three events are tracked.

## Docs

[Here is a PR](https://github.com/snowplow-incubator/data-value-resources/pull/66) in data-value-resources repo for the documentation changes.

## Implementation

The list of subscribed events is checked in `addFormListeners` before adding event listeners to form fields (for focus and change) and the form (for submit).

I added an end-to-end test that checks that change events are not tracked if not subscribed to.

Also tried it out [in a demo ReactJS app](https://github.com/matus-tomlein/snowplow-javascript-tracker-playground/blob/main/react-app/src/routes/form.jsx#L9-L14), but that's not part of this PR.