### PR TITLE
Enable form tracking on forms embedded within iframes where possible (close #1066)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-form-tracking/issue-1066-iframe_form_tracking_2022-03-23-19-58.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/issue-1066-iframe_form_tracking_2022-03-23-19-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-form-tracking",
+      "comment": "Enable form tracking on forms embedded within iframes where possible (#1066)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1066-iframe_form_tracking_2022-03-23-19-58.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1066-iframe_form_tracking_2022-03-23-19-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Enable form tracking on forms embedded within iframes where possible (#1066)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/plugins/browser-plugin-form-tracking/src/helpers.ts
+++ b/plugins/browser-plugin-form-tracking/src/helpers.ts
@@ -70,7 +70,7 @@ const defaultFormTrackingEvents = [
 ];
 
 export interface FormTrackingOptions {
-  forms?: FilterCriterion<HTMLElement> | HTMLCollectionOf<HTMLElement> | NodeListOf<HTMLFormElement>;
+  forms?: FilterCriterion<HTMLElement> | HTMLCollectionOf<HTMLFormElement> | NodeListOf<HTMLFormElement>;
   fields?: FilterCriterion<TrackedHTMLElement> & { transform: transformFn };
   events?: FormTrackingEvents;
 }
@@ -156,6 +156,15 @@ export function addFormListeners(tracker: BrowserTracker, configuration: FormTra
   });
 }
 
+/**
+ * Check if forms array is a collection of HTML form elements or a filter or undefined
+ */
+function isCollectionOfHTMLFormElements(
+  forms?: FilterCriterion<HTMLFormElement> | HTMLCollectionOf<HTMLFormElement> | NodeListOf<HTMLFormElement>
+): forms is HTMLCollectionOf<HTMLFormElement> | NodeListOf<HTMLFormElement> {
+  return forms != null && Array.prototype.slice.call(forms).length > 0;
+}
+
 /*
  * Configures form tracking: which forms and fields will be tracked, and the context to attach
  */
@@ -163,17 +172,12 @@ function getConfigurationForOptions(options?: FormTrackingOptions) {
   if (options) {
     let formFilter = (_: HTMLElement) => true;
     let forms: HTMLCollectionOf<HTMLFormElement> | NodeListOf<HTMLFormElement> | null = null;
-    if (
-      !options.forms ||
-      (options.forms as FilterCriterion<HTMLElement>).allowlist ||
-      (options.forms as FilterCriterion<HTMLElement>).denylist ||
-      (options.forms as FilterCriterion<HTMLElement>).filter
-    ) {
-      // options.forms is null or a filter
-      formFilter = getFilterByClass(options.forms as FilterCriterion<HTMLElement> | undefined);
-    } else if ((options.forms as any).length !== undefined) {
+    if (isCollectionOfHTMLFormElements(options.forms)) {
       // options.forms is a collection of HTML form elements
-      forms = options.forms as HTMLCollectionOf<HTMLFormElement> | NodeListOf<HTMLFormElement>;
+      forms = options.forms;
+    } else {
+      // options.forms is null or a filter
+      formFilter = getFilterByClass(options.forms);
     }
     return {
       forms: forms,

--- a/plugins/browser-plugin-form-tracking/src/helpers.ts
+++ b/plugins/browser-plugin-form-tracking/src/helpers.ts
@@ -70,7 +70,7 @@ const defaultFormTrackingEvents = [
 ];
 
 export interface FormTrackingOptions {
-  forms?: FilterCriterion<HTMLElement> | HTMLCollectionOf<HTMLElement>;
+  forms?: FilterCriterion<HTMLElement> | HTMLCollectionOf<HTMLElement> | NodeListOf<HTMLFormElement>;
   fields?: FilterCriterion<TrackedHTMLElement> & { transform: transformFn };
   events?: FormTrackingEvents;
 }
@@ -113,7 +113,7 @@ export function addFormListeners(tracker: BrowserTracker, configuration: FormTra
     trackingMarker = tracker.id + 'form',
     config = getConfigurationForOptions(options);
 
-  var forms = config.forms ?? document.getElementsByTagName('form');
+  let forms = config.forms ?? document.getElementsByTagName('form');
   Array.prototype.slice.call(forms).forEach(function (form: HTMLFormElement) {
     if (config.formFilter(form)) {
       Array.prototype.slice.call(innerElementTags).forEach(function (tagname: keyof TrackedHTMLElementTagNameMap) {
@@ -161,8 +161,8 @@ export function addFormListeners(tracker: BrowserTracker, configuration: FormTra
  */
 function getConfigurationForOptions(options?: FormTrackingOptions) {
   if (options) {
-    var formFilter = (_: HTMLElement) => true;
-    var forms: HTMLCollectionOf<HTMLFormElement> | null = null;
+    let formFilter = (_: HTMLElement) => true;
+    let forms: HTMLCollectionOf<HTMLFormElement> | NodeListOf<HTMLFormElement> | null = null;
     if (
       !options.forms ||
       (options.forms as FilterCriterion<HTMLElement>).allowlist ||
@@ -173,7 +173,7 @@ function getConfigurationForOptions(options?: FormTrackingOptions) {
       formFilter = getFilterByClass(options.forms as FilterCriterion<HTMLElement> | undefined);
     } else if ((options.forms as any).length !== undefined) {
       // options.forms is a collection of HTML form elements
-      forms = options.forms as HTMLCollectionOf<HTMLFormElement>;
+      forms = options.forms as HTMLCollectionOf<HTMLFormElement> | NodeListOf<HTMLFormElement>;
     }
     return {
       forms: forms,

--- a/plugins/browser-plugin-form-tracking/src/helpers.ts
+++ b/plugins/browser-plugin-form-tracking/src/helpers.ts
@@ -165,9 +165,9 @@ function getConfigurationForOptions(options?: FormTrackingOptions) {
     var forms: HTMLCollectionOf<HTMLFormElement> | null = null;
     if (
       !options.forms ||
-      (options.forms as any).allowlist ||
-      (options.forms as any).denylist ||
-      (options.forms as any).filter
+      (options.forms as FilterCriterion<HTMLElement>).allowlist ||
+      (options.forms as FilterCriterion<HTMLElement>).denylist ||
+      (options.forms as FilterCriterion<HTMLElement>).filter
     ) {
       // options.forms is null or a filter
       formFilter = getFilterByClass(options.forms as FilterCriterion<HTMLElement> | undefined);

--- a/trackers/javascript-tracker/test/integration/autoTracking.test.ts
+++ b/trackers/javascript-tracker/test/integration/autoTracking.test.ts
@@ -330,6 +330,13 @@ describe('Auto tracking', () => {
     await loadUrlAndWait('/form-tracking.html?filter=onlyFocus');
     await formInteraction();
 
+    await browser.pause(1000);
+
+    await loadUrlAndWait('/form-tracking.html?filter=iframeForm');
+    let frame = await $('#form_iframe');
+    await browser.switchToFrame(frame);
+    await $('#fname').click();
+
     // time for activity to register and request to arrive
     await browser.pause(2500);
 
@@ -821,5 +828,22 @@ describe('Auto tracking', () => {
         },
       })
     ).toBe(false);
+  });
+
+  it('should track focus_form event from form in an iframe', () => {
+    expect(
+      logContains({
+        event: {
+          event: 'unstruct',
+          app_id: 'autotracking',
+          page_url: 'http://snowplow-js-tracker.local:8080/form-tracking.html?filter=iframeForm',
+          unstruct_event: {
+            data: {
+              schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+            },
+          },
+        },
+      })
+    ).toBe(true);
   });
 });

--- a/trackers/javascript-tracker/test/pages/form-tracking.html
+++ b/trackers/javascript-tracker/test/pages/form-tracking.html
@@ -62,9 +62,18 @@
       <input type="submit" value="Submit" id="excluded-submit" />
     </form>
 
+    <iframe id="form_iframe" title="form_iframe"></iframe>
+
     <script>
       var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
       document.body.className += ' loaded';
+
+      var formHtml = '<form><input type="text" name="fname" id="fname"></form>';
+      var iframe = document.getElementById('form_iframe');
+      var iframeDocument = iframe.contentWindow.document.open();
+      iframeDocument.open();
+      iframeDocument.write(formHtml);
+      iframeDocument.close();
     </script>
 
     <script>
@@ -118,6 +127,9 @@
         case 'onlyFocus':
           snowplow('enableFormTracking', { options: { events: ['focus_form'] } });
           break;
+        case 'iframeForm':
+          var forms = iframe.contentWindow.document.getElementsByTagName('form');
+          snowplow('enableFormTracking', { options: { forms: forms } });
         default:
           snowplow('enableFormTracking', {
             context: [


### PR DESCRIPTION
Issue #1066 

This PR adds the ability to set a collection of form elements to be tracked in the `options.forms` argument in `enableFormTracking`. This enables a user to find form elements inside an iframe (if not blocked by the browser) and pass them to the tracker when enabling form tracking on the parent page. This was not possible before as form elements were searched for only on the parent page not considering any embedded iframes.

The `options.forms` attribute in `enableFormTracking` can now serve multiple use cases as it also accepts the `FilterCriterion` filter for finding form elements on the page as well as a collection of specific form elements to track.

## Documentation: Tracking forms embedded inside iframes

The options for tracking forms inside of iframes are limited – browsers block access to contents of iframes that are from different domains than the parent page. We are not able to provide a solution to track events using trackers initialized on the parent page in such cases. However, since version 3.4, it is possible to track events from forms embedded in iframes loaded from the same domain as the parent page or iframes created using JavaScript on the parent page (e.g., HubSpot forms).

In case you are able to access form elements inside an iframe, you can pass them in the `options.forms` argument when calling `enableFormTracking` on the parent page. This will enable form tracking for the specific form elements. The feature may also be used for forms not embedded in iframes, but it's most useful in this particular case.

The following example shows how to identify the form elements inside an iframe and pass them to the `enableFormTracking` function:

```js
let iframe = document.getElementById('form_iframe'); // find the element for the iframe
let forms = iframe.contentWindow.document.getElementsByTagName('form'); // find form elements inside the iframe
enableFormTracking({
    options: {
        forms: forms // pass the embedded forms when enabling form tracking
    },
});
```

## Other resources

The documentation is also in a PR on data-value-resources [here](https://github.com/snowplow-incubator/data-value-resources/pull/66/commits/e09e887d5289614d933bea705db1097f367370a6).

[Here](https://github.com/matus-tomlein/snowplow-javascript-tracker-playground/blob/main/react-app/src/routes/iframeForm.jsx#L18-L23) is an sample example in an app that adds a form to an iframe using JavaScript and tracks it.