### PR TITLE
Update ContextGenerator function return type to also accept SelfDescribingJson list and undefined (close #1070)

### DIFF
--- a/libraries/tracker-core/src/contexts.ts
+++ b/libraries/tracker-core/src/contexts.ts
@@ -54,7 +54,7 @@ export interface ContextEvent {
  * to allow an additional context to be dynamically attached to the event
  * @param args - - Object which contains the event information to help decide what should be included in the returned Context
  */
-export type ContextGenerator = (args?: ContextEvent) => SelfDescribingJson;
+export type ContextGenerator = (args?: ContextEvent) => SelfDescribingJson | SelfDescribingJson[] | undefined;
 
 /**
  * A context filter is a user-supplied callback that is evaluated for each event


### PR DESCRIPTION
Issue #1070

This PR fixes the return type from `ContextGenerator` functions to also include lists of `SelfDescribingJson` and undefined.