### PR TITLE
Add client session context entity (close #1077)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-debugger/issue-1077-client_session_context_2022-06-02-09-08.json
+++ b/common/changes/@snowplow/browser-plugin-debugger/issue-1077-client_session_context_2022-06-02-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-debugger",
+      "comment": "Add client session context entity (#1077)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-debugger"
+}

--- a/common/changes/@snowplow/browser-tracker-core/issue-1077-client_session_context_2022-06-02-09-08.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1077-client_session_context_2022-06-02-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add client session context entity (#1077)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-1077-client_session_context_2022-06-02-09-08.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1077-client_session_context_2022-06-02-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add client session context entity (#1077)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1077-client_session_context_2022-06-02-09-08.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1077-client_session_context_2022-06-02-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Add client session context entity (#1077)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/changes/@snowplow/node-tracker/issue-1077-client_session_context_2022-06-02-09-08.json
+++ b/common/changes/@snowplow/node-tracker/issue-1077-client_session_context_2022-06-02-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Add client session context entity (#1077)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/common/changes/@snowplow/tracker-core/issue-1077-client_session_context_2022-06-02-09-08.json
+++ b/common/changes/@snowplow/tracker-core/issue-1077-client_session_context_2022-06-02-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Add client session context entity (#1077)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/browser-tracker-core/src/tracker/id_cookie.ts
+++ b/libraries/browser-tracker-core/src/tracker/id_cookie.ts
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { PayloadBuilder } from '@snowplow/tracker-core';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Indices of cookie values
+ */
+const cookieDisabledIndex = 0,
+  domainUserIdIndex = 1,
+  createTsIndex = 2,
+  visitCountIndex = 3,
+  nowTsIndex = 4,
+  lastVisitTsIndex = 5,
+  sessionIdIndex = 6,
+  previousSessionIdIndex = 7,
+  firstEventIdIndex = 8,
+  firstEventTsInMsIndex = 9,
+  eventIndexIndex = 10;
+
+export type ParsedIdCookie = [
+  string, // cookieDisabled
+  string, // domainUserId
+  number, // cookieCreateTs
+  number, // visitCount
+  number, // nowTs
+  string | number, // lastVisitTs
+  string, // sessionId
+  string, // previousSessionId
+  string, // firstEventId
+  string | number, // firstEventTs
+  number // eventIndex
+];
+
+/**
+ * Schema for client client session context entity
+ */
+export interface ClientSession extends Record<string, unknown> {
+  /**
+   * An identifier for the user of the session (same as domain_userid)
+   */
+  userId: string;
+
+  /**
+   * An identifier for the session (same as domain_sessionid)
+   */
+  sessionId: string;
+
+  /**
+   * The index of the current session for this user (same as domain_sessionidx)
+   */
+  sessionIndex: number;
+
+  /**
+   * Index of the current event in the session
+   */
+  eventIndex: number;
+
+  /**
+   * The previous session identifier for this user
+   */
+  previousSessionId: string | null;
+
+  /**
+   * The mechanism that the session information has been stored on the device
+   */
+  storageMechanism: string;
+
+  /**
+   * Identifier of the first event for this session
+   */
+  firstEventId: string | null;
+
+  /**
+   * Date-time timestamp of when the first event in the session was tracked
+   */
+  firstEventTimestamp: string | null;
+}
+
+export function emptyIdCookie() {
+  const idCookie: ParsedIdCookie = ['1', '', 0, 0, 0, '', '', '', '', '', 0];
+  return idCookie;
+}
+
+/**
+ * Parses the cookie values from its string representation.
+ *
+ * @param id Cookie value as string
+ * @param domainUserId Domain user ID to be used in case of empty cookie string
+ * @returns Parsed ID cookie tuple
+ */
+export function parseIdCookie(
+  id: string,
+  domainUserId: string,
+  memorizedSessionId: string,
+  memorizedVisitCount: number
+) {
+  let now = new Date(),
+    nowTs = Math.round(now.getTime() / 1000),
+    tmpContainer;
+
+  if (id) {
+    tmpContainer = id.split('.');
+    // cookies enabled
+    tmpContainer.unshift('0');
+  } else {
+    tmpContainer = [
+      // cookies disabled
+      '1',
+      // Domain user ID
+      domainUserId,
+      // Creation timestamp - seconds since Unix epoch
+      nowTs,
+      // visitCount - 0 = no previous visit
+      memorizedVisitCount,
+      // Current visit timestamp
+      nowTs,
+      // Last visit timestamp - blank meaning no previous visit
+      '',
+      // Session ID
+      memorizedSessionId,
+    ];
+  }
+
+  if (!tmpContainer[sessionIdIndex] || tmpContainer[sessionIdIndex] === 'undefined') {
+    // session id
+    tmpContainer[sessionIdIndex] = uuid();
+  }
+  if (!tmpContainer[previousSessionIdIndex] || tmpContainer[previousSessionIdIndex] === 'undefined') {
+    // previous session id
+    tmpContainer[previousSessionIdIndex] = '';
+  }
+  if (!tmpContainer[firstEventIdIndex] || tmpContainer[firstEventIdIndex] === 'undefined') {
+    // firstEventId - blank meaning no previous event
+    tmpContainer[firstEventIdIndex] = '';
+  }
+  if (!tmpContainer[firstEventTsInMsIndex] || tmpContainer[firstEventTsInMsIndex] === 'undefined') {
+    // firstEventTs - blank meaning no previous event
+    tmpContainer[firstEventTsInMsIndex] = '';
+  }
+  if (!tmpContainer[eventIndexIndex] || tmpContainer[eventIndexIndex] === 'undefined') {
+    // eventIndex – 0 = no previous event
+    tmpContainer[eventIndexIndex] = 0;
+  }
+
+  const parsed: ParsedIdCookie = [
+    tmpContainer[0] as string,
+    tmpContainer[1] as string,
+    parseInt(tmpContainer[2] as string),
+    parseInt(tmpContainer[3] as string),
+    parseInt(tmpContainer[4] as string),
+    tmpContainer[5] ? parseInt(tmpContainer[5] as string) : (tmpContainer[5] as string),
+    tmpContainer[6] as string,
+    tmpContainer[7] as string,
+    tmpContainer[8] as string,
+    tmpContainer[9] ? parseInt(tmpContainer[9] as string) : (tmpContainer[9] as string),
+    parseInt(tmpContainer[10] as string),
+  ];
+  return parsed;
+}
+
+/**
+ * Initializes the domain user ID if not already present in the cookie. Sets an empty string if anonymous tracking.
+ *
+ * @param idCookie Parsed cookie
+ * @param configAnonymousTracking Whether anonymous tracking is enabled
+ * @returns Domain user ID
+ */
+export function initializeDomainUserId(idCookie: ParsedIdCookie, configAnonymousTracking: boolean) {
+  let domainUserId;
+  if (idCookie[domainUserIdIndex]) {
+    domainUserId = idCookie[domainUserIdIndex];
+  } else if (!configAnonymousTracking) {
+    domainUserId = uuid();
+    idCookie[domainUserIdIndex] = domainUserId;
+  } else {
+    domainUserId = '';
+    idCookie[domainUserIdIndex] = domainUserId;
+  }
+  return domainUserId;
+}
+
+/**
+ * Starts a new session with a new ID.
+ * Sets the previous session, last visit timestamp, and increments visit count if cookies enabled.
+ * First event references are reset and will be updated in `updateFirstEventInIdCookie`.
+ *
+ * @param idCookie Parsed cookie
+ * @param memorizedVisitCount Visit count to be used if cookies not enabled
+ * @returns New session ID
+ */
+export function startNewIdCookieSession(idCookie: ParsedIdCookie, memorizedVisitCount: number = 1) {
+  // If cookies are enabled, base visit count and session ID on the cookies
+  if (cookiesEnabledInIdCookie(idCookie)) {
+    // Store the previous session ID
+    idCookie[previousSessionIdIndex] = idCookie[sessionIdIndex];
+    // Set lastVisitTs to currentVisitTs
+    idCookie[lastVisitTsIndex] = idCookie[nowTsIndex];
+    // Increment the session ID
+    (idCookie[visitCountIndex] as number)++;
+  } else {
+    idCookie[visitCountIndex] = memorizedVisitCount;
+  }
+
+  // Create a new sessionId
+  const sessionId = uuid();
+  idCookie[sessionIdIndex] = sessionId;
+
+  // Reset event index and first event references
+  idCookie[eventIndexIndex] = 0;
+  idCookie[firstEventIdIndex] = '';
+  idCookie[firstEventTsInMsIndex] = '';
+
+  return sessionId;
+}
+
+/**
+ * Update now timestamp in cookie.
+ *
+ * @param idCookie Parsed cookie
+ */
+export function updateNowTsInIdCookie(idCookie: ParsedIdCookie) {
+  idCookie[nowTsIndex] = Math.round(new Date().getTime() / 1000);
+}
+
+/**
+ * Updates the first event references according to the event payload if first event in session.
+ *
+ * @param idCookie Parsed cookie
+ * @param payloadBuilder Event payload builder
+ */
+export function updateFirstEventInIdCookie(idCookie: ParsedIdCookie, payloadBuilder: PayloadBuilder) {
+  // Update first event references if new session or not present
+  if (idCookie[eventIndexIndex] == 0) {
+    const payload = payloadBuilder.build();
+    idCookie[firstEventIdIndex] = payload['eid'] as string;
+    const ts = (payload['dtm'] || payload['ttm']) as string;
+    idCookie[firstEventTsInMsIndex] = ts ? parseInt(ts) : '';
+  }
+}
+
+/**
+ * Increments event index counter.
+ *
+ * @param idCookie Parsed cookie
+ */
+export function incrementEventIndexInIdCookie(idCookie: ParsedIdCookie) {
+  idCookie[eventIndexIndex] += 1;
+}
+
+/**
+ * Serializes parsed cookie to string representation.
+ *
+ * @param idCookie Parsed cookie
+ * @returns String cookie value
+ */
+export function serializeIdCookie(idCookie: ParsedIdCookie) {
+  idCookie.shift();
+  return idCookie.join('.');
+}
+
+/**
+ * Transforms the parsed cookie into a client session context entity.
+ *
+ * @param idCookie Parsed cookie
+ * @param configStateStorageStrategy Cookie storage strategy
+ * @returns Client session context entity
+ */
+export function clientSessionFromIdCookie(idCookie: ParsedIdCookie, configStateStorageStrategy: string) {
+  const clientSession: ClientSession = {
+    userId: idCookie[domainUserIdIndex],
+    sessionId: idCookie[sessionIdIndex],
+    eventIndex: idCookie[eventIndexIndex],
+    sessionIndex: idCookie[visitCountIndex],
+    previousSessionId: idCookie[previousSessionIdIndex] || null,
+    storageMechanism: configStateStorageStrategy == 'localStorage' ? 'LOCAL_STORAGE' : 'COOKIE_1',
+    firstEventId: idCookie[firstEventIdIndex] || null,
+    firstEventTimestamp: idCookie[firstEventTsInMsIndex]
+      ? new Date(idCookie[firstEventTsInMsIndex]).toISOString()
+      : null,
+  };
+
+  return clientSession;
+}
+
+export function sessionIdFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[sessionIdIndex];
+}
+
+export function domainUserIdFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[domainUserIdIndex];
+}
+
+export function visitCountFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[visitCountIndex];
+}
+
+export function cookiesEnabledInIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[cookieDisabledIndex] === '0';
+}
+
+export function createTsFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[createTsIndex];
+}
+
+export function nowTsFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[nowTsIndex];
+}
+
+export function lastVisitTsFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[lastVisitTsIndex];
+}
+
+export function previousSessionIdFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[previousSessionIdIndex];
+}
+
+export function firstEventIdFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[firstEventIdIndex];
+}
+
+export function firstEventTsInMsFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[firstEventTsInMsIndex];
+}
+
+export function eventIndexFromIdCookie(idCookie: ParsedIdCookie) {
+  return idCookie[eventIndexIndex];
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -74,6 +74,23 @@ import {
   BrowserPluginConfiguration,
   ClearUserDataConfiguration,
 } from './types';
+import {
+  parseIdCookie,
+  initializeDomainUserId,
+  startNewIdCookieSession,
+  updateNowTsInIdCookie,
+  serializeIdCookie,
+  sessionIdFromIdCookie,
+  domainUserIdFromIdCookie,
+  updateFirstEventInIdCookie,
+  visitCountFromIdCookie,
+  cookiesEnabledInIdCookie,
+  ParsedIdCookie,
+  ClientSession,
+  clientSessionFromIdCookie,
+  incrementEventIndexInIdCookie,
+  emptyIdCookie
+} from './id_cookie';
 
 declare global {
   interface Navigator {
@@ -285,7 +302,8 @@ export function Tracker(
         enabled: false,
         installed: false, // Guard against installing the activity tracker more than once per Tracker instance
         configurations: {},
-      };
+      },
+      configSessionContext = trackerConfiguration.contexts?.session ?? false;
 
     if (trackerConfiguration.hasOwnProperty('discoverRootDomain') && trackerConfiguration.discoverRootDomain) {
       configCookieDomain = findRootDomain(configCookieSameSite, configCookieSecure);
@@ -553,17 +571,9 @@ export function Tracker(
      * Sets the Visitor ID cookie: either the first time loadDomainUserIdCookie is called
      * or when there is a new visit or a new page view
      */
-    function setDomainUserIdCookie(
-      domainUserId: string,
-      createTs: number,
-      visitCount: number,
-      nowTs: number,
-      lastVisitTs: number,
-      sessionId: string
-    ) {
+    function setDomainUserIdCookie(idCookie: ParsedIdCookie) {
       const cookieName = getSnowplowCookieName('id');
-      const cookieValue =
-        domainUserId + '.' + createTs + '.' + visitCount + '.' + nowTs + '.' + lastVisitTs + '.' + sessionId;
+      const cookieValue = serializeIdCookie(idCookie);
       setCookie(cookieName, cookieValue, configVisitorCookieTimeout);
     }
 
@@ -582,7 +592,15 @@ export function Tracker(
       if (configStateStorageStrategy == 'localStorage') {
         attemptWriteLocalStorage(name, value, timeout);
       } else if (configStateStorageStrategy == 'cookie' || configStateStorageStrategy == 'cookieAndLocalStorage') {
-        cookie(name, value, timeout, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
+        cookie(
+          name,
+          value,
+          timeout,
+          configCookiePath,
+          configCookieDomain,
+          configCookieSameSite,
+          configCookieSecure
+        );
       }
     }
 
@@ -637,36 +655,21 @@ export function Tracker(
       }
 
       const sesCookieSet = configStateStorageStrategy != 'none' && !!getSnowplowCookieValue('ses');
-      const idCookieComponents = loadDomainUserIdCookie();
+      const idCookie = loadDomainUserIdCookie();
 
-      if (idCookieComponents[1]) {
-        domainUserId = idCookieComponents[1] as string;
-      } else if (!configAnonymousTracking) {
-        domainUserId = uuid();
-        idCookieComponents[1] = domainUserId;
-      } else {
-        domainUserId = '';
-        idCookieComponents[1] = domainUserId;
-      }
-
-      memorizedSessionId = idCookieComponents[6] as string;
+      domainUserId = initializeDomainUserId(idCookie, configAnonymousTracking);
 
       if (!sesCookieSet) {
-        // Increment the session ID
-        (idCookieComponents[3] as number)++;
-        // Create a new sessionId
-        memorizedSessionId = uuid();
-        idCookieComponents[6] = memorizedSessionId;
-        // Set lastVisitTs to currentVisitTs
-        idCookieComponents[5] = idCookieComponents[4];
+        memorizedSessionId = startNewIdCookieSession(idCookie);
+      } else {
+        memorizedSessionId = sessionIdFromIdCookie(idCookie);
       }
 
       if (configStateStorageStrategy != 'none') {
         setSessionCookie();
         // Update currentVisitTs
-        idCookieComponents[4] = Math.round(new Date().getTime() / 1000);
-        idCookieComponents.shift();
-        setDomainUserIdCookie.apply(null, idCookieComponents as any); // TODO: Remove any
+        updateNowTsInIdCookie(idCookie);
+        setDomainUserIdCookie(idCookie);
       }
     }
 
@@ -675,40 +678,10 @@ export function Tracker(
      */
     function loadDomainUserIdCookie() {
       if (configStateStorageStrategy == 'none') {
-        return [];
+        return emptyIdCookie();
       }
-      let now = new Date(),
-        nowTs = Math.round(now.getTime() / 1000),
-        id = getSnowplowCookieValue('id'),
-        tmpContainer;
-
-      if (id) {
-        tmpContainer = id.split('.');
-        // cookies enabled
-        tmpContainer.unshift('0');
-      } else {
-        tmpContainer = [
-          // cookies disabled
-          '1',
-          // Domain user ID
-          domainUserId,
-          // Creation timestamp - seconds since Unix epoch
-          nowTs,
-          // visitCount - 0 = no previous visit
-          0,
-          // Current visit timestamp
-          nowTs,
-          // Last visit timestamp - blank meaning no previous visit
-          '',
-        ];
-      }
-
-      if (!tmpContainer[6] || tmpContainer[6] === 'undefined') {
-        // session id
-        tmpContainer[6] = uuid();
-      }
-
-      return tmpContainer;
+      let id = getSnowplowCookieValue('id') || '';
+      return parseIdCookie(id, domainUserId, memorizedSessionId, memorizedVisitCount);
     }
 
     /**
@@ -777,16 +750,8 @@ export function Tracker(
           const anonymizeSessionOr = (value?: string | number | null) =>
             configAnonymousSessionTracking ? value : anonymizeOr(value);
 
-          let nowTs = Math.round(new Date().getTime() / 1000),
-            ses = getSnowplowCookieValue('ses'),
-            id = loadDomainUserIdCookie(),
-            cookiesDisabled = id[0],
-            _domainUserId = id[1] as string, // We could use the global (domainUserId) but this is better etiquette
-            createTs = id[2] as number,
-            visitCount = id[3] as number,
-            currentVisitTs = id[4] as number,
-            lastVisitTs = id[5] as number,
-            sessionIdFromCookie = id[6] as string;
+          let ses = getSnowplowCookieValue('ses'),
+            idCookie = loadDomainUserIdCookie();
 
           let toOptoutByCookie;
           if (configOptOutCookie) {
@@ -801,30 +766,30 @@ export function Tracker(
           }
 
           // If cookies are enabled, base visit count and session ID on the cookies
-          if (cookiesDisabled === '0') {
-            memorizedSessionId = sessionIdFromCookie as string;
-
+          if (cookiesEnabledInIdCookie(idCookie)) {
             // New session?
             if (!ses && configStateStorageStrategy != 'none') {
-              // New session (aka new visit)
-              (visitCount as number)++;
-              // Update the last visit timestamp
-              lastVisitTs = currentVisitTs;
-              // Regenerate the session ID
-              memorizedSessionId = uuid();
+              memorizedSessionId = startNewIdCookieSession(idCookie);
+            } else {
+              memorizedSessionId = sessionIdFromIdCookie(idCookie);
             }
 
-            memorizedVisitCount = visitCount as number;
+            memorizedVisitCount = visitCountFromIdCookie(idCookie);
           } else if (new Date().getTime() - lastEventTime > configSessionCookieTimeout * 1000) {
-            memorizedSessionId = uuid();
             memorizedVisitCount++;
+            memorizedSessionId = startNewIdCookieSession(idCookie, memorizedVisitCount);
           }
+
+          // Update cookie
+          updateNowTsInIdCookie(idCookie);
+          updateFirstEventInIdCookie(idCookie, payloadBuilder);
+          incrementEventIndexInIdCookie(idCookie);
 
           payloadBuilder.add('vp', detectViewport());
           payloadBuilder.add('ds', detectDocumentSize());
           payloadBuilder.add('vid', anonymizeSessionOr(memorizedVisitCount));
           payloadBuilder.add('sid', anonymizeSessionOr(memorizedSessionId));
-          payloadBuilder.add('duid', anonymizeOr(_domainUserId)); // Set to our local variable
+          payloadBuilder.add('duid', anonymizeOr(domainUserIdFromIdCookie(idCookie))); // Set to our local variable
           payloadBuilder.add('uid', anonymizeOr(businessUserId));
 
           refreshUrl();
@@ -834,9 +799,13 @@ export function Tracker(
           // Add the page URL last as it may take us over the IE limit (and we don't always need it)
           payloadBuilder.add('url', purify(configCustomUrl || locationHrefAlias));
 
+          if (configSessionContext && !configAnonymousSessionTracking && !configAnonymousTracking) {
+            addSessionContextToPayload(payloadBuilder, clientSessionFromIdCookie(idCookie, configStateStorageStrategy));
+          }
+
           // Update cookies
           if (configStateStorageStrategy != 'none') {
-            setDomainUserIdCookie(_domainUserId, createTs, memorizedVisitCount, nowTs, lastVisitTs, memorizedSessionId);
+            setDomainUserIdCookie(idCookie);
             setSessionCookie();
           }
 
@@ -845,47 +814,55 @@ export function Tracker(
       };
     }
 
+    function addSessionContextToPayload(payloadBuilder: PayloadBuilder, clientSession: ClientSession) {
+      let payload = payloadBuilder.build();
+
+      let context = {
+        schema: 'iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0',
+        data: [],
+      };
+      if (payload.cx) {
+        context = JSON.parse(atob(payload.cx as string));
+      }
+      let sessionContext: SelfDescribingJson<ClientSession> = {
+        schema: 'iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2',
+        data: clientSession,
+      };
+      (context.data as any[]).push(sessionContext);
+
+      payloadBuilder.addJson('cx', 'co', context);
+    }
+
     /**
      * Expires current session and starts a new session.
      */
     function newSession() {
       // If cookies are enabled, base visit count and session ID on the cookies
-      let nowTs = Math.round(new Date().getTime() / 1000),
-        id = loadDomainUserIdCookie(),
-        cookiesDisabled = id[0],
-        _domainUserId = id[1] as string, // We could use the global (domainUserId) but this is better etiquette
-        createTs = id[2] as number,
-        visitCount = id[3] as number,
-        currentVisitTs = id[4] as number,
-        lastVisitTs = id[5] as number,
-        sessionIdFromCookie = id[6] as string;
+      let idCookie = loadDomainUserIdCookie();
 
       // When cookies are enabled
-      if (cookiesDisabled === '0') {
-        memorizedSessionId = sessionIdFromCookie;
-
+      if (cookiesEnabledInIdCookie(idCookie)) {
         // When cookie/local storage is enabled - make a new session
         if (configStateStorageStrategy != 'none') {
-          // New session (aka new visit)
-          visitCount++;
-          // Update the last visit timestamp
-          lastVisitTs = currentVisitTs;
-          // Regenerate the session ID
-          memorizedSessionId = uuid();
+          memorizedSessionId = startNewIdCookieSession(idCookie);
+        } else {
+          memorizedSessionId = sessionIdFromIdCookie(idCookie);
         }
 
-        memorizedVisitCount = visitCount;
+        memorizedVisitCount = visitCountFromIdCookie(idCookie);
 
         // Create a new session cookie
         setSessionCookie();
       } else {
-        memorizedSessionId = uuid();
         memorizedVisitCount++;
+        memorizedSessionId = startNewIdCookieSession(idCookie, memorizedVisitCount);
       }
+
+      updateNowTsInIdCookie(idCookie);
 
       // Update cookies
       if (configStateStorageStrategy != 'none') {
-        setDomainUserIdCookie(_domainUserId, createTs, memorizedVisitCount, nowTs, lastVisitTs, memorizedSessionId);
+        setDomainUserIdCookie(idCookie);
         setSessionCookie();
       }
 

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -89,7 +89,7 @@ import {
   ClientSession,
   clientSessionFromIdCookie,
   incrementEventIndexInIdCookie,
-  emptyIdCookie
+  emptyIdCookie,
 } from './id_cookie';
 
 declare global {
@@ -592,15 +592,7 @@ export function Tracker(
       if (configStateStorageStrategy == 'localStorage') {
         attemptWriteLocalStorage(name, value, timeout);
       } else if (configStateStorageStrategy == 'cookie' || configStateStorageStrategy == 'cookieAndLocalStorage') {
-        cookie(
-          name,
-          value,
-          timeout,
-          configCookiePath,
-          configCookieDomain,
-          configCookieSameSite,
-          configCookieSecure
-        );
+        cookie(name, value, timeout, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
       }
     }
 
@@ -815,22 +807,11 @@ export function Tracker(
     }
 
     function addSessionContextToPayload(payloadBuilder: PayloadBuilder, clientSession: ClientSession) {
-      let payload = payloadBuilder.build();
-
-      let context = {
-        schema: 'iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0',
-        data: [],
-      };
-      if (payload.cx) {
-        context = JSON.parse(atob(payload.cx as string));
-      }
       let sessionContext: SelfDescribingJson<ClientSession> = {
         schema: 'iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2',
         data: clientSession,
       };
-      (context.data as any[]).push(sessionContext);
-
-      payloadBuilder.addJson('cx', 'co', context);
+      payloadBuilder.addContextEntity(sessionContext);
     }
 
     /**

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -672,7 +672,7 @@ export function Tracker(
       if (configStateStorageStrategy == 'none') {
         return emptyIdCookie();
       }
-      let id = getSnowplowCookieValue('id') || '';
+      const id = getSnowplowCookieValue('id') || undefined;
       return parseIdCookie(id, domainUserId, memorizedSessionId, memorizedVisitCount);
     }
 
@@ -781,7 +781,7 @@ export function Tracker(
           payloadBuilder.add('ds', detectDocumentSize());
           payloadBuilder.add('vid', anonymizeSessionOr(memorizedVisitCount));
           payloadBuilder.add('sid', anonymizeSessionOr(memorizedSessionId));
-          payloadBuilder.add('duid', anonymizeOr(domainUserIdFromIdCookie(idCookie))); // Set to our local variable
+          payloadBuilder.add('duid', anonymizeOr(domainUserIdFromIdCookie(idCookie))); // Always load from cookie as this is better ettiquette than in-memory values
           payloadBuilder.add('uid', anonymizeOr(businessUserId));
 
           refreshUrl();

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -195,7 +195,7 @@ export type TrackerConfiguration = {
   anonymousTracking?: AnonymousTrackingOptions;
   /**
    * Use to configure built in contexts
-   * @defaultValue `{ webPage: true }`
+   * @defaultValue `{ webPage: true, session: false }`
    */
   contexts?: { webPage: boolean; session: boolean };
   /**

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -197,7 +197,7 @@ export type TrackerConfiguration = {
    * Use to configure built in contexts
    * @defaultValue `{ webPage: true }`
    */
-  contexts?: { webPage: boolean };
+  contexts?: { webPage: boolean; session: boolean };
   /**
    * Inject plugins which will be evaluated for each event
    * @defaultValue []

--- a/libraries/browser-tracker-core/test/id_cookie.test.ts
+++ b/libraries/browser-tracker-core/test/id_cookie.test.ts
@@ -66,9 +66,9 @@ describe('parseIdCookie', () => {
     expect(createTsFromIdCookie(idCookie)).toBeLessThanOrEqual(after);
     expect(nowTsFromIdCookie(idCookie)).toBeGreaterThanOrEqual(before);
     expect(nowTsFromIdCookie(idCookie)).toBeLessThanOrEqual(after);
-    expect(lastVisitTsFromIdCookie(idCookie)).toBe('');
+    expect(lastVisitTsFromIdCookie(idCookie)).toBeUndefined();
     expect(firstEventIdFromIdCookie(idCookie)).toBe('');
-    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe('');
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBeUndefined();
     expect(eventIndexFromIdCookie(idCookie)).toBe(0);
   });
 
@@ -83,7 +83,7 @@ describe('parseIdCookie', () => {
     expect(sessionIdFromIdCookie(idCookie)).toBeTruthy();
     expect(createTsFromIdCookie(idCookie)).toBe(ts);
     expect(firstEventIdFromIdCookie(idCookie)).toBe('');
-    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe('');
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBeUndefined();
     expect(eventIndexFromIdCookie(idCookie)).toBe(0);
   });
 
@@ -137,7 +137,7 @@ describe('startNewIdCookieSession', () => {
     startNewIdCookieSession(idCookie);
 
     expect(firstEventIdFromIdCookie(idCookie)).toBeFalsy();
-    expect(firstEventTsInMsFromIdCookie(idCookie)).toBeFalsy();
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBeUndefined();
     expect(eventIndexFromIdCookie(idCookie)).toBe(0);
   });
 
@@ -159,7 +159,7 @@ describe('startNewIdCookieSession', () => {
     let idCookie = parseIdCookie('', '', '', 0);
     let nowTs = nowTsFromIdCookie(idCookie);
     startNewIdCookieSession(idCookie);
-    expect(lastVisitTsFromIdCookie(idCookie)).toBeFalsy();
+    expect(lastVisitTsFromIdCookie(idCookie)).toBeUndefined();
     expect(nowTsFromIdCookie(idCookie)).toBe(nowTs);
   });
 

--- a/libraries/browser-tracker-core/test/id_cookie.test.ts
+++ b/libraries/browser-tracker-core/test/id_cookie.test.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { payloadBuilder } from '@snowplow/tracker-core';
+import {
+  clientSessionFromIdCookie,
+  cookiesEnabledInIdCookie,
+  createTsFromIdCookie,
+  domainUserIdFromIdCookie,
+  eventIndexFromIdCookie,
+  firstEventIdFromIdCookie,
+  firstEventTsInMsFromIdCookie,
+  incrementEventIndexInIdCookie,
+  initializeDomainUserId,
+  lastVisitTsFromIdCookie,
+  nowTsFromIdCookie,
+  parseIdCookie,
+  previousSessionIdFromIdCookie,
+  serializeIdCookie,
+  sessionIdFromIdCookie,
+  startNewIdCookieSession,
+  updateFirstEventInIdCookie,
+  updateNowTsInIdCookie,
+  visitCountFromIdCookie,
+} from '../src/tracker/id_cookie';
+
+describe('parseIdCookie', () => {
+  it('Initializes a new ID cookie using memorized values given empty string', () => {
+    let before = Math.round(new Date().getTime() / 1000);
+    let idCookie = parseIdCookie('', 'xyz', 'ses', 10);
+    let after = Math.round(new Date().getTime() / 1000);
+
+    expect(cookiesEnabledInIdCookie(idCookie)).not.toBeTruthy();
+    expect(domainUserIdFromIdCookie(idCookie)).toBe('xyz');
+    expect(sessionIdFromIdCookie(idCookie)).toBe('ses');
+    expect(visitCountFromIdCookie(idCookie)).toBe(10);
+    expect(previousSessionIdFromIdCookie(idCookie)).toBeFalsy();
+    expect(createTsFromIdCookie(idCookie)).toBeGreaterThanOrEqual(before);
+    expect(createTsFromIdCookie(idCookie)).toBeLessThanOrEqual(after);
+    expect(nowTsFromIdCookie(idCookie)).toBeGreaterThanOrEqual(before);
+    expect(nowTsFromIdCookie(idCookie)).toBeLessThanOrEqual(after);
+    expect(lastVisitTsFromIdCookie(idCookie)).toBe('');
+    expect(firstEventIdFromIdCookie(idCookie)).toBe('');
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe('');
+    expect(eventIndexFromIdCookie(idCookie)).toBe(0);
+  });
+
+  it('Initializes from a partial version of the cookie', () => {
+    let ts = Math.round(new Date().getTime() / 1000);
+    let idCookie = parseIdCookie(`abc.${ts}.10.${ts + 10}.${ts - 10}`, '', '', 0);
+
+    expect(domainUserIdFromIdCookie(idCookie)).toBe('abc');
+    expect(visitCountFromIdCookie(idCookie)).toBe(10);
+    expect(nowTsFromIdCookie(idCookie)).toBe(ts + 10);
+    expect(lastVisitTsFromIdCookie(idCookie)).toBe(ts - 10);
+    expect(sessionIdFromIdCookie(idCookie)).toBeTruthy();
+    expect(createTsFromIdCookie(idCookie)).toBe(ts);
+    expect(firstEventIdFromIdCookie(idCookie)).toBe('');
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe('');
+    expect(eventIndexFromIdCookie(idCookie)).toBe(0);
+  });
+
+  it('Initializes from a partial version of the cookie including session id', () => {
+    let ts = Math.round(new Date().getTime() / 1000);
+    let idCookie = parseIdCookie(`abc.${ts}.10.${ts + 10}.${ts - 10}.ses`, '', '', 0);
+
+    expect(sessionIdFromIdCookie(idCookie)).toBe('ses');
+  });
+
+  it('Initializes from a complete cookie', () => {
+    let idCookie = parseIdCookie(`def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9`, '', '', 0);
+
+    expect(domainUserIdFromIdCookie(idCookie)).toBe('def');
+    expect(visitCountFromIdCookie(idCookie)).toBe(10);
+    expect(sessionIdFromIdCookie(idCookie)).toBe('ses');
+    expect(previousSessionIdFromIdCookie(idCookie)).toBe('previous');
+    expect(firstEventIdFromIdCookie(idCookie)).toBe('fid');
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe(1653632252);
+    expect(eventIndexFromIdCookie(idCookie)).toBe(9);
+  });
+});
+
+describe('initializeDomainUserId', () => {
+  it('Uses existing ID if present', () => {
+    let idCookie = parseIdCookie(`abc.1653632272.10.1653632272.1653632272`, '', '', 0);
+
+    let duidAnonymous = initializeDomainUserId(idCookie, true);
+    expect(duidAnonymous).toBe('abc');
+
+    let duidNonAnonymous = initializeDomainUserId(idCookie, false);
+    expect(duidNonAnonymous).toBe('abc');
+  });
+
+  it('Generates a new ID', () => {
+    let duid = initializeDomainUserId(parseIdCookie('', '', '', 0), false);
+
+    expect(duid).toBeTruthy();
+  });
+
+  it('Is empty in case of anonymous tracking', () => {
+    let duid = initializeDomainUserId(parseIdCookie('', '', '', 0), true);
+
+    expect(duid).toBeFalsy();
+  });
+});
+
+describe('startNewIdCookieSession', () => {
+  it('Resets the first event references and event index', () => {
+    let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9', '', '', 0);
+    startNewIdCookieSession(idCookie);
+
+    expect(firstEventIdFromIdCookie(idCookie)).toBeFalsy();
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBeFalsy();
+    expect(eventIndexFromIdCookie(idCookie)).toBe(0);
+  });
+
+  it('Increments the visit count', () => {
+    let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262', '', '', 0);
+
+    expect(visitCountFromIdCookie(idCookie)).toBe(10);
+    startNewIdCookieSession(idCookie);
+    expect(visitCountFromIdCookie(idCookie)).toBe(11);
+  });
+
+  it('Uses the passed visit count in case of disabled cookies', () => {
+    let idCookie = parseIdCookie('', '', '', 0);
+    startNewIdCookieSession(idCookie, 100);
+    expect(visitCountFromIdCookie(idCookie)).toBe(100);
+  });
+
+  it("Doesn't set the last visit timestamp if disabled cookies and keeps now timestamp", () => {
+    let idCookie = parseIdCookie('', '', '', 0);
+    let nowTs = nowTsFromIdCookie(idCookie);
+    startNewIdCookieSession(idCookie);
+    expect(lastVisitTsFromIdCookie(idCookie)).toBeFalsy();
+    expect(nowTsFromIdCookie(idCookie)).toBe(nowTs);
+  });
+
+  it('Generates a new session ID', () => {
+    let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262', '', '', 0);
+
+    let before = sessionIdFromIdCookie(idCookie);
+    startNewIdCookieSession(idCookie);
+    let after = sessionIdFromIdCookie(idCookie);
+
+    expect(before).not.toBe(after);
+  });
+
+  it('Moves current visit to last visit timestamp', () => {
+    let idCookie = parseIdCookie(`def.1653632100.10.1653632200.1653632300`, '', '', 0);
+
+    startNewIdCookieSession(idCookie);
+    expect(lastVisitTsFromIdCookie(idCookie)).toBe(1653632200);
+  });
+
+  it('Sets the previous session ID', () => {
+    let idCookie = parseIdCookie('def.1653632100.10.1653632200.1653632300.ses', '', '', 0);
+
+    startNewIdCookieSession(idCookie);
+    expect(previousSessionIdFromIdCookie(idCookie)).toBe('ses');
+  });
+});
+
+describe('updateNowTsInIdCookie', () => {
+  it('Sets the timestamp to current time', () => {
+    let idCookie = parseIdCookie('def.1653632100.10.1653632200.1653632300.ses', '', '', 0);
+
+    let before = Math.round(new Date().getTime() / 1000);
+    updateNowTsInIdCookie(idCookie);
+    let after = Math.round(new Date().getTime() / 1000);
+
+    expect(nowTsFromIdCookie(idCookie)).toBeGreaterThanOrEqual(before);
+    expect(nowTsFromIdCookie(idCookie)).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('updateFirstEventInIdCookie', () => {
+  it('Sets the first event references if first event in session', () => {
+    let pb = payloadBuilder();
+    let timestamp = new Date().getTime();
+    pb.add('eid', 'xyz');
+    pb.add('dtm', timestamp);
+
+    let idCookie = parseIdCookie('', '', '', 0);
+    updateFirstEventInIdCookie(idCookie, pb);
+
+    expect(firstEventIdFromIdCookie(idCookie)).toBe('xyz');
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe(timestamp);
+  });
+
+  it('Sets the first event timestamp from true timestamp if device timestamp not available', () => {
+    let pb = payloadBuilder();
+    let timestamp = new Date().getTime();
+    pb.add('eid', 'xyz');
+    pb.add('ttm', timestamp);
+
+    let idCookie = parseIdCookie('', '', '', 0);
+    updateFirstEventInIdCookie(idCookie, pb);
+
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe(timestamp);
+  });
+
+  it("Doesn't change first event references if not first event in session", () => {
+    let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9', '', '', 0);
+
+    let pb = payloadBuilder();
+    pb.add('eid', 'xyz');
+    pb.add('dtm', new Date().getTime());
+
+    updateFirstEventInIdCookie(idCookie, pb);
+
+    expect(firstEventIdFromIdCookie(idCookie)).toBe('fid');
+    expect(firstEventTsInMsFromIdCookie(idCookie)).toBe(1653632252);
+  });
+});
+
+describe('incrementEventIndexInIdCookie', () => {
+  it('Increments the event index', () => {
+    let idCookie = parseIdCookie('', '', '', 0);
+    expect(eventIndexFromIdCookie(idCookie)).toBe(0);
+    incrementEventIndexInIdCookie(idCookie);
+    expect(eventIndexFromIdCookie(idCookie)).toBe(1);
+    incrementEventIndexInIdCookie(idCookie);
+    expect(eventIndexFromIdCookie(idCookie)).toBe(2);
+  });
+});
+
+describe('serializeIdCookie', () => {
+  it("Doesn't change the original cookie", () => {
+    let cookie = `def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9`;
+    expect(serializeIdCookie(parseIdCookie(cookie, '', '', 0))).toBe(cookie);
+  });
+});
+
+describe('clientSessionFromIdCookie', () => {
+  it('Correctly fills out the properties', () => {
+    let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653638673483.9', '', '', 0);
+    let clientSession = clientSessionFromIdCookie(idCookie, 'cookieAndLocalStorage');
+
+    expect(clientSession.userId).toBe('def');
+    expect(clientSession.sessionId).toBe('ses');
+    expect(clientSession.previousSessionId).toBe('previous');
+    expect(clientSession.eventIndex).toBe(9);
+    expect(clientSession.sessionIndex).toBe(10);
+    expect(clientSession.storageMechanism).toBe('COOKIE_1');
+    expect(clientSession.firstEventId).toBe('fid');
+    expect(clientSession.firstEventTimestamp).toBe('2022-05-27T08:04:33.483Z');
+  });
+});

--- a/libraries/tracker-core/src/payload.ts
+++ b/libraries/tracker-core/src/payload.ts
@@ -207,7 +207,7 @@ export function payloadJsonProcessor(encodeBase64: boolean): JsonProcessor {
 
     let context: SelfDescribingJsonArray | undefined = undefined;
     for (const json of jsonForProcessing) {
-      if (json.keyIfEncoded == 'cx') {
+      if (json.keyIfEncoded === 'cx') {
         context = combineContexts(context, json.json as SelfDescribingJsonArray);
       } else {
         add(json.json, json.keyIfEncoded, json.keyIfNotEncoded);

--- a/libraries/tracker-core/test/payload.ts
+++ b/libraries/tracker-core/test/payload.ts
@@ -162,6 +162,15 @@ test('Maintain context entities after subsequent builds', (t) => {
   t.deepEqual(payload, expectedPayloads[1], 'JSON should be added correctly');
 });
 
+test('Add multiple context entities through addJson', (t) => {
+  const sb = payloadBuilder();
+  sb.withJsonProcessor(payloadJsonProcessor(true));
+  sb.addJson('cx', 'co', { schema: sampleJson.schema, data: [sampleJson.data[0]] });
+  sb.addJson('cx', 'co', { schema: sampleJson.schema, data: [sampleJson.data[1]] });
+  let payload = sb.build();
+  t.deepEqual(payload, expectedPayloads[1], 'JSON should be added correctly');
+});
+
 test('Combines context entities added through addJson and addContextEntity', (t) => {
   const sb = payloadBuilder();
   sb.withJsonProcessor(payloadJsonProcessor(true));

--- a/libraries/tracker-core/test/payload.ts
+++ b/libraries/tracker-core/test/payload.ts
@@ -142,3 +142,31 @@ test('payloadBuilder with no json processor, processes no json', (t) => {
 
   t.deepEqual(sb.build(), {}, 'JSON should be missing');
 });
+
+test('Add a context entity', (t) => {
+  const sb = payloadBuilder();
+  sb.withJsonProcessor(payloadJsonProcessor(false));
+  sb.addContextEntity(sampleJson.data[0]);
+  sb.addContextEntity(sampleJson.data[1]);
+  let payload = sb.build();
+  t.deepEqual(payload, expectedPayloads[0], 'JSON should be added correctly');
+});
+
+test('Maintain context entities after subsequent builds', (t) => {
+  const sb = payloadBuilder();
+  sb.withJsonProcessor(payloadJsonProcessor(true));
+  sb.addContextEntity(sampleJson.data[0]);
+  sb.build();
+  sb.addContextEntity(sampleJson.data[1]);
+  let payload = sb.build();
+  t.deepEqual(payload, expectedPayloads[1], 'JSON should be added correctly');
+});
+
+test('Combines context entities added through addJson and addContextEntity', (t) => {
+  const sb = payloadBuilder();
+  sb.withJsonProcessor(payloadJsonProcessor(true));
+  sb.addJson('cx', 'co', { schema: sampleJson.schema, data: [sampleJson.data[0]] });
+  sb.addContextEntity(sampleJson.data[1]);
+  let payload = sb.build();
+  t.deepEqual(payload, expectedPayloads[1], 'JSON should be added correctly');
+});

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -331,6 +331,7 @@ export type TrackerConfiguration = {
     anonymousTracking?: AnonymousTrackingOptions;
     contexts?: {
         webPage: boolean;
+        session: boolean;
     };
     plugins?: Array<BrowserPlugin>;
     customHeaders?: Record<string, string>;

--- a/trackers/javascript-tracker/src/configuration.ts
+++ b/trackers/javascript-tracker/src/configuration.ts
@@ -33,6 +33,7 @@ import { TrackerConfiguration } from '@snowplow/browser-tracker-core';
 export interface JavaScriptTrackerConfiguration extends TrackerConfiguration {
   contexts: {
     webPage: boolean;
+    session: boolean;
     performanceTiming: boolean;
     gaCookies: boolean;
     geolocation: boolean;

--- a/trackers/javascript-tracker/test/functional/cookies.test.ts
+++ b/trackers/javascript-tracker/test/functional/cookies.test.ts
@@ -67,7 +67,7 @@ describe('Tracker created domain cookies', () => {
       /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/i
     );
     expect(await $('#getDomainUserInfo').getText()).toMatch(
-      /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b.[0-9]+.[0-9].[0-9]+.[0-9]+.\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/i
+      /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b.[0-9]+.[0-9].[0-9]+.[0-9]*.\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b.(\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)?.(\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)?.[0-9]*.[0-9]+/i
     );
     expect(await $('#getUserId').getText()).toBe('Dave');
     expect(await $('#getCookieName').getText()).toMatch(/_sp_1id.[0-9a-z]{4}/i);

--- a/trackers/javascript-tracker/test/pages/session-integration.html
+++ b/trackers/javascript-tracker/test/pages/session-integration.html
@@ -32,6 +32,12 @@
 
       window.snowplow('newTracker', 'cookieSessionTracker', collector_endpoint, {
         sessionCookieTimeout: 1,
+        cookieSameSite: 'Lax',
+        cookieSecure: false,
+        contexts: {
+          session: true,
+          webPage: false,
+        },
       });
 
       setTimeout(function () {

--- a/trackers/node-tracker/docs/node-tracker.api.md
+++ b/trackers/node-tracker/docs/node-tracker.api.md
@@ -283,6 +283,7 @@ export type Payload = Record<string, unknown>;
 // @public
 export interface PayloadBuilder {
     add: (key: string, value: unknown) => void;
+    addContextEntity: (entity: SelfDescribingJson) => void;
     addDict: (dict: Payload) => void;
     addJson: (keyIfEncoded: string, keyIfNotEncoded: string, json: Record<string, unknown>) => void;
     build: () => Payload;


### PR DESCRIPTION
This PR addresses issue #1077 and adds the `client_session` ([schema version 1.0.2](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2)) context entity to the Web trackers. This entity contains session information.

The context entity repeats some of the session information stored in canonical event properties (`domain_userid`, `domain_sessionid`, `domain_sessionidx`), but also adds new information. It adds a reference to the previous session (`previousSessionId`) and first event in the current session (`firstEventId`, `firstEventTimestamp`). It also adds an index of the event in the session useful for ordering events as they were tracked (`eventIndex`).

## Cookie format

The new session information is stored in the ID cookie (`sp_id`). It is appended to the end of the cookie. There are 4 new properties stored in the cookie, which now has the format:

`{domainUserId}.{createdTime}.{visitCount}.{nowTime}.{lastVisitTime}.{sessionId}.{previousSessionId}.{firstEventId}.{firstEventTsInMs}.{eventIndex}`

The new properties are:

- `previousSessionId` – ID of the previous session
- `firstEventId` – ID of the first event in the current session
- `firstEventTsInMs` Device created timestamp of the first event in the current session
- `eventIndex` – Index of the last event in the session

## Configuration

The session context entity is disabled by default. It can be enabled using the `contexts.session` property:

```js
window.snowplow('newTracker', 'sp1', 'https://...', {
    ...,
    contexts: {
        session: true
    }
});
```

Anonymous tracking has to be disabled for the session context entity to be added to events.

## Changes in the browser-tracker-core

I did some refactoring of the code handling the ID cookies. I extracted the functions from `tracker/index.ts` to `tracker/id_cookie.ts` and added unit tests for them. Also I added types for the parsed ID cookie array, which is now a TypeScript tuple. New sessions were started in a few different places so I unified the logic into a single function (`startNewIdCookieSession`).

The session information is updated and added to events in the `beforeTrack()` of `BrowserDataPlugin`. I modified the function to operate on the ID cookie tuple directly.

If the `contexts.session` configuration is enabled, `beforeTrack()` adds the context entity to the `PayloadBuilder` (see below). All the new information is tracked in the cookie (previous session ID, first event, event index) even if the configuration is disabled, but it is not used.

## Changes in PayloadBuilder

I needed a way to add the context entity to the `PayloadBuilder` object in `beforeTrack`. In order to avoid parsing the `cx` property and serializing the context again in the `beforeTrack`, I added a new helper function to the `PayloadBuilder` – `addContextEntity(entity: SelfDescribingJson)`.

This function stores the passed object in a list and adds it to the payload dictionary in the `build()` method along with other JSON objects. It tries to combine the new context entities with existing entities added through `addJson()` or already stored in the payload dictionary. This adds more complexity to it, but is safer as we don't know how the plugins might assign new context entities. It also enables `build()` to be called multiple times.

## Documentation

PR with changes in the documentation is open [in the data-value-resources repo.](https://github.com/snowplow-incubator/data-value-resources/pull/109)