### PR TITLE
Add a customizable set of failure HTTP status codes for which collector requests should not be retried (close #1079)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-1079-retry_status_codes_2022-06-03-08-26.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1079-retry_status_codes_2022-06-03-08-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add a customizable set of failure HTTP status codes for which collector requests should not be retried (#1079)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-1079-retry_status_codes_2022-06-03-08-26.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1079-retry_status_codes_2022-06-03-08-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add a customizable set of failure HTTP status codes for which collector requests should not be retried (#1079)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -276,7 +276,7 @@ export function Tracker(
         trackerConfiguration.customHeaders ?? {},
         trackerConfiguration.withCredentials ?? true,
         trackerConfiguration.retryStatusCodes ?? [],
-        trackerConfiguration.dontRetryStatusCodes ?? []
+        (trackerConfiguration.dontRetryStatusCodes ?? []).concat([400, 401, 403, 410, 422])
       ),
       // Whether pageViewId should be regenerated after each trackPageView. Affect web_page context
       preservePageViewId = false,

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -274,7 +274,9 @@ export function Tracker(
         trackerConfiguration.connectionTimeout ?? 5000,
         configAnonymousServerTracking,
         trackerConfiguration.customHeaders ?? {},
-        trackerConfiguration.withCredentials ?? true
+        trackerConfiguration.withCredentials ?? true,
+        trackerConfiguration.retryStatusCodes ?? [],
+        trackerConfiguration.dontRetryStatusCodes ?? []
       ),
       // Whether pageViewId should be regenerated after each trackPageView. Affect web_page context
       preservePageViewId = false,

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -60,6 +60,8 @@ export interface OutQueue {
  * @param anonymousTracking - Defines whether to set the SP-Anonymous header for anonymous tracking on GET and POST
  * @param customHeaders - Allows custom headers to be defined and passed on XMLHttpRequest requests
  * @param withCredentials - Sets the value of the withCredentials flag on XMLHttpRequest (GET and POST) requests
+ * @param retryStatusCodes – Failure HTTP response status codes from Collector for which sending events should be retried
+ * @param dontRetryStatusCodes – Failure HTTP response status codes from Collector for which sending events should not be retried
  * @returns object OutQueueManager instance
  */
 export function OutQueueManager(
@@ -76,7 +78,9 @@ export function OutQueueManager(
   connectionTimeout: number,
   anonymousTracking: boolean,
   customHeaders: Record<string, string>,
-  withCredentials: boolean
+  withCredentials: boolean,
+  retryStatusCodes: number[],
+  dontRetryStatusCodes: number[]
 ): OutQueue {
   type PostEvent = {
     evt: Record<string, unknown>;
@@ -333,25 +337,34 @@ export function OutQueueManager(
         executingQueue = false;
       }, connectionTimeout);
 
-      // The events (`numberToSend` of them), have been sent, so we remove them from the outQueue
-      // We also call executeQueue() again, to let executeQueue() check if we should keep running through the queue
-      const onPostSuccess = (numberToSend: number): void => {
+      const removeEventsFromQueue = (numberToSend: number): void => {
         for (let deleteCount = 0; deleteCount < numberToSend; deleteCount++) {
           outQueue.shift();
         }
         if (useLocalStorage) {
           attemptWriteLocalStorage(queueName, JSON.stringify(outQueue.slice(0, maxLocalStorageQueueSize)));
         }
+      };
+
+      // The events (`numberToSend` of them), have been sent, so we remove them from the outQueue
+      // We also call executeQueue() again, to let executeQueue() check if we should keep running through the queue
+      const onPostSuccess = (numberToSend: number): void => {
+        removeEventsFromQueue(numberToSend);
         executeQueue();
       };
 
       xhr.onreadystatechange = function () {
-        if (xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 400) {
+        if (xhr.readyState === 4 && xhr.status >= 200) {
           clearTimeout(xhrTimeout);
-          onPostSuccess(numberToSend);
-        } else if (xhr.readyState === 4 && xhr.status >= 400) {
-          clearTimeout(xhrTimeout);
-          executingQueue = false;
+          if (xhr.status < 300) {
+            onPostSuccess(numberToSend);
+          } else {
+            if (!shouldRetryForStatusCode(xhr.status)) {
+              LOG.error(`Collector responded with status code ${xhr.status}, sending events won't be retried.`);
+              removeEventsFromQueue(numberToSend);
+            }
+            executingQueue = false;
+          }
         }
       };
 
@@ -420,6 +433,22 @@ export function OutQueueManager(
     } else {
       executingQueue = false;
     }
+  }
+
+  function shouldRetryForStatusCode(statusCode: number) {
+    // success, don't retry
+    if (statusCode >= 200 && statusCode < 300) {
+      return false;
+    }
+
+    // retry if status code among custom user-supplied retry codes
+    if (retryStatusCodes.includes(statusCode)) {
+      return true;
+    }
+
+    // retry if status code *not* among custom user-supplied don't retry codes and default don't retry codes
+    const dontRetryStatusCodesDefault = [400, 401, 403, 410, 422];
+    return !dontRetryStatusCodes.includes(statusCode) && !dontRetryStatusCodesDefault.includes(statusCode);
   }
 
   /**

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -60,7 +60,7 @@ export interface OutQueue {
  * @param anonymousTracking - Defines whether to set the SP-Anonymous header for anonymous tracking on GET and POST
  * @param customHeaders - Allows custom headers to be defined and passed on XMLHttpRequest requests
  * @param withCredentials - Sets the value of the withCredentials flag on XMLHttpRequest (GET and POST) requests
- * @param retryStatusCodes – Failure HTTP response status codes from Collector for which sending events should be retried
+ * @param retryStatusCodes – Failure HTTP response status codes from Collector for which sending events should be retried (they can override the `dontRetryStatusCodes`)
  * @param dontRetryStatusCodes – Failure HTTP response status codes from Collector for which sending events should not be retried
  * @returns object OutQueueManager instance
  */
@@ -360,7 +360,7 @@ export function OutQueueManager(
             onPostSuccess(numberToSend);
           } else {
             if (!shouldRetryForStatusCode(xhr.status)) {
-              LOG.error(`Collector responded with status code ${xhr.status}, sending events won't be retried.`);
+              LOG.error(`Status ${xhr.status}, will not retry.`);
               removeEventsFromQueue(numberToSend);
             }
             executingQueue = false;
@@ -446,9 +446,8 @@ export function OutQueueManager(
       return true;
     }
 
-    // retry if status code *not* among custom user-supplied don't retry codes and default don't retry codes
-    const dontRetryStatusCodesDefault = [400, 401, 403, 410, 422];
-    return !dontRetryStatusCodes.includes(statusCode) && !dontRetryStatusCodesDefault.includes(statusCode);
+    // retry if status code *not* among the don't retry codes
+    return !dontRetryStatusCodes.includes(statusCode);
   }
 
   /**

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -209,6 +209,20 @@ export type TrackerConfiguration = {
    * @defaultValue `{}`
    */
   customHeaders?: Record<string, string>;
+  /**
+   * List of HTTP response status codes for which events sent to Collector should be retried in future requests.
+   * Only non-success status codes are considered (greater or equal to 300).
+   * The retry codes are only considered for GET and POST requests.
+   * By default, the tracker retries on all non-success status codes except for 400, 401, 403, 410, and 422.
+   */
+  retryStatusCodes?: number[];
+  /**
+   * List of HTTP response status codes for which events sent to Collector should not be retried in future request.
+   * Only non-success status codes are considered (greater or equal to 300).
+   * The don't retry codes are only considered for GET and POST requests.
+   * By default, the tracker retries on all non-success status codes except for 400, 401, 403, 410, and 422.
+   */
+  dontRetryStatusCodes?: number[];
 };
 
 /**

--- a/libraries/browser-tracker-core/test/out_queue.test.ts
+++ b/libraries/browser-tracker-core/test/out_queue.test.ts
@@ -82,8 +82,8 @@ describe('OutQueueManager', () => {
         false,
         {},
         true,
-        [401],
-        [505]
+        [401], // retry status codes - override don't retry ones
+        [401, 505] // don't retry status codes
       );
     });
 
@@ -133,18 +133,6 @@ describe('OutQueueManager', () => {
       respondMockRequest(500);
       retrievedQueue = getQueue();
       expect(retrievedQueue).toHaveLength(1);
-    });
-
-    it('should remove events from queue on no-retry status code', () => {
-      const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
-      outQueue.enqueueRequest(request, 'http://example.com');
-
-      let retrievedQueue = getQueue();
-      expect(retrievedQueue).toHaveLength(1);
-
-      respondMockRequest(403);
-      retrievedQueue = getQueue();
-      expect(retrievedQueue).toHaveLength(0);
     });
 
     it('should retry on custom retry status code', () => {

--- a/libraries/browser-tracker-core/test/out_queue.test.ts
+++ b/libraries/browser-tracker-core/test/out_queue.test.ts
@@ -50,8 +50,21 @@ describe('OutQueueManager', () => {
     jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => xhrMock as XMLHttpRequest);
   });
 
+  const respondMockRequest = (status: number) => {
+    (xhrMock as any).status = status;
+    (xhrMock as any).response = '';
+    (xhrMock as any).readyState = 4;
+    (xhrMock as any).onreadystatechange();
+  };
+
   describe('POST requests', () => {
     var outQueue: OutQueue;
+
+    const getQueue = () => {
+      return JSON.parse(
+        window.localStorage.getItem('snowplowOutQueue_sp_post2') ?? fail('Unable to find local storage queue')
+      );
+    };
 
     beforeEach(() => {
       outQueue = OutQueueManager(
@@ -68,7 +81,9 @@ describe('OutQueueManager', () => {
         5000,
         false,
         {},
-        true
+        true,
+        [401],
+        [505]
       );
     });
 
@@ -76,9 +91,7 @@ describe('OutQueueManager', () => {
       const expected = { e: 'pv', eid: '20269f92-f07c-44a6-87ef-43e171305076' };
       outQueue.enqueueRequest(expected, 'http://example.com');
 
-      const retrievedQueue = JSON.parse(
-        window.localStorage.getItem('snowplowOutQueue_sp_post2') ?? fail('Unable to find local storage queue')
-      );
+      const retrievedQueue = getQueue();
       expect(retrievedQueue).toHaveLength(1);
       expect(retrievedQueue[0]).toMatchObject({ bytes: 55, evt: expected });
     });
@@ -92,12 +105,70 @@ describe('OutQueueManager', () => {
       outQueue.enqueueRequest(expected2, 'http://example.com');
       outQueue.enqueueRequest(unexpected, 'http://example.com');
 
-      const retrievedQueue = JSON.parse(
-        window.localStorage.getItem('snowplowOutQueue_sp_post2') ?? fail('Unable to find local storage queue')
-      );
+      const retrievedQueue = getQueue();
       expect(retrievedQueue).toHaveLength(maxQueueSize);
       expect(retrievedQueue[0]).toMatchObject({ bytes: 55, evt: expected1 });
       expect(retrievedQueue[1]).toMatchObject({ bytes: 55, evt: expected2 });
+    });
+
+    it('should remove events from event queue on success', () => {
+      const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
+      outQueue.enqueueRequest(request, 'http://example.com');
+
+      let retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(1);
+
+      respondMockRequest(200);
+      retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(0);
+    });
+
+    it('should keep events in queue on failure', () => {
+      const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
+      outQueue.enqueueRequest(request, 'http://example.com');
+
+      let retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(1);
+
+      respondMockRequest(500);
+      retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(1);
+    });
+
+    it('should remove events from queue on no-retry status code', () => {
+      const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
+      outQueue.enqueueRequest(request, 'http://example.com');
+
+      let retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(1);
+
+      respondMockRequest(403);
+      retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(0);
+    });
+
+    it('should retry on custom retry status code', () => {
+      const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
+      outQueue.enqueueRequest(request, 'http://example.com');
+
+      let retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(1);
+
+      respondMockRequest(401);
+      retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(1);
+    });
+
+    it("should not retry on custom don't retry status code", () => {
+      const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
+      outQueue.enqueueRequest(request, 'http://example.com');
+
+      let retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(1);
+
+      respondMockRequest(505);
+      retrievedQueue = getQueue();
+      expect(retrievedQueue).toHaveLength(0);
     });
   });
 
@@ -125,7 +196,9 @@ describe('OutQueueManager', () => {
           5000,
           false,
           {},
-          true
+          true,
+          [],
+          []
         );
     });
 

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -334,6 +334,8 @@ export type TrackerConfiguration = {
     };
     plugins?: Array<BrowserPlugin>;
     customHeaders?: Record<string, string>;
+    retryStatusCodes?: number[];
+    dontRetryStatusCodes?: number[];
 };
 
 // @public


### PR DESCRIPTION
This PR addresses issue #1079.

It adds a set of 5 HTTP status codes (400, 401, 403, 410, and 422) for which sending events should not be retried and the events should be dropped. This is in line with the strategy for handling HTTP status codes that we [outlined here](https://github.com/snowplow-incubator/data-value-resources/blob/main/30%20Tracker%20Architecture/emitter_architecture/handling_http_status_codes.md).

The behaviour for 3xx status codes has also changed – previously they were considered as successful and not retried. This doesn't fit with how we decided to handle them, so I changed them to be retried.

It also makes the retry behaviour configurable. It adds two configuration options: `retryStatusCodes` and `dontRetryStatusCodes` which are lists of non-successful status codes (>= 300) that override the default behaviour.

## Documentation: Setting custom retry HTTP status codes

The tracker provides a retry functionality that sends the same events repeatedly in case GET or POST requests to the Collector fail. This may happen due to connection issues or a non-successful HTTP status code in Collector response.

Prior to version 3.5 of the tracker, requests receiving all 4xx and 5xx HTTP status codes in Collector response were retried. Since version 3.5, the behaviour changed and became customizable:

By default, the tracker retries on all 3xx, 4xx, and 5xx status codes except for 400, 401, 403, 410, and 422. The set of status codes for which events should be retried or not is customizable. You can make use of the `retryStatusCodes` and `dontRetryStatusCodes` lists to specify them. Retry behaviour can only be configured for non-successful status codes (i.e., >= 300).

```js
retryStatusCodes: [403], // override default behavior and retry on 403
dontRetryStatusCodes: [418] // force retry on 418
```

Please note that not retrying sending events to the Collector means that the events will be dropped when they fail to be sent. Take caution when choosing the `dontRetryStatusCodes`.

PR for documentation is in the [data-value-resources repo here](https://github.com/snowplow-incubator/data-value-resources/pull/110).