### PR TITLE
Update got version to 11.8.5 (fixes #1095)

### DIFF
--- a/common/changes/@snowplow/node-tracker/issue-1095-fix-node-got-vulnerable-version_2022-08-29-14-31.json
+++ b/common/changes/@snowplow/node-tracker/issue-1095-fix-node-got-vulnerable-version_2022-08-29-14-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Update got to 11.8.5 for a vulnerability fix",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1263,7 +1263,7 @@ importers:
       ava: ~4.1.0
       eslint: ~8.11.0
       eslint-plugin-ava: ~13.2.0
-      got: ^11.7.0
+      got: ^11.8.5
       nock: ~13.2.4
       rollup: ~2.70.1
       rollup-plugin-license: ~2.6.1
@@ -1274,7 +1274,7 @@ importers:
       typescript: ~4.6.2
     dependencies:
       '@snowplow/tracker-core': link:../../libraries/tracker-core
-      got: 11.7.0
+      got: 11.8.5
       tslib: 2.3.1
     devDependencies:
       '@rollup/plugin-json': 4.1.0_rollup@2.70.1
@@ -2156,15 +2156,9 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /@sindresorhus/is/3.1.2:
-    resolution: {integrity: sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==}
-    engines: {node: '>=10'}
-    dev: false
-
   /@sindresorhus/is/4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
-    dev: true
 
   /@sinonjs/commons/1.8.3:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
@@ -2936,7 +2930,7 @@ packages:
       typescript: ^4.6.2
     dependencies:
       '@types/node': 17.0.22
-      got: 11.8.3
+      got: 11.8.5
       typescript: 4.6.2
     dev: true
 
@@ -3670,19 +3664,6 @@ packages:
       responselike: 1.0.2
     dev: true
 
-  /cacheable-request/7.0.1:
-    resolution: {integrity: sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==}
-    engines: {node: '>=8'}
-    dependencies:
-      clone-response: 1.0.2
-      get-stream: 5.2.0
-      http-cache-semantics: 4.1.0
-      keyv: 4.0.3
-      lowercase-keys: 2.0.0
-      normalize-url: 4.5.0
-      responselike: 2.0.0
-    dev: false
-
   /cacheable-request/7.0.2:
     resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
     engines: {node: '>=8'}
@@ -3694,7 +3675,6 @@ packages:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.0
-    dev: true
 
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -5553,25 +5533,8 @@ packages:
       google-closure-compiler-windows: 20210808.0.0
     dev: true
 
-  /got/11.7.0:
-    resolution: {integrity: sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==}
-    engines: {node: '>=10.19.0'}
-    dependencies:
-      '@sindresorhus/is': 3.1.2
-      '@szmarczak/http-timer': 4.0.5
-      '@types/cacheable-request': 6.0.1
-      '@types/responselike': 1.0.0
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.1
-      decompress-response: 6.0.0
-      http2-wrapper: 1.0.0-beta.5.2
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.0.0
-      responselike: 2.0.0
-    dev: false
-
-  /got/11.8.3:
-    resolution: {integrity: sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==}
+  /got/11.8.5:
+    resolution: {integrity: sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==}
     engines: {node: '>=10.19.0'}
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -5585,7 +5548,6 @@ packages:
       lowercase-keys: 2.0.0
       p-cancelable: 2.0.0
       responselike: 2.0.0
-    dev: true
 
   /got/8.3.2:
     resolution: {integrity: sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==}
@@ -7706,15 +7668,9 @@ packages:
       sort-keys: 2.0.0
     dev: true
 
-  /normalize-url/4.5.0:
-    resolution: {integrity: sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==}
-    engines: {node: '>=8'}
-    dev: false
-
   /normalize-url/6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
-    dev: true
 
   /npm-bundled/1.1.2:
     resolution: {integrity: sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==}
@@ -8873,7 +8829,7 @@ packages:
       change-case: 4.1.2
       download: 8.0.0
       form-data: 4.0.0
-      got: 11.8.3
+      got: 11.8.5
       hash.js: 1.1.7
       tunnel: 0.0.6
       yargs: 17.3.1
@@ -10039,7 +9995,7 @@ packages:
       '@wdio/protocols': 7.19.0
       '@wdio/types': 7.19.1_typescript@4.6.2
       '@wdio/utils': 7.19.3_typescript@4.6.2
-      got: 11.8.3
+      got: 11.8.5
       ky: 0.30.0
       lodash.merge: 4.6.2
     transitivePeerDependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "25296592812eecc3191f48ac56183dca6339f7dc",
+  "pnpmShrinkwrapHash": "2558e954907dfe5745ba70aabb0d499ae988e860",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/trackers/node-tracker/package.json
+++ b/trackers/node-tracker/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@snowplow/tracker-core": "workspace:*",
-    "got": "^11.7.0",
+    "got": "^11.8.5",
     "tslib": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
Update got to 11.8.5 to fix a medium security vulnerability. From the release log, nothing seems to impact the behaviour on our node tracker.

Fixes #1095