### PR TITLE
Add tests to verify Node.js tracker returns eid (event id) attribute (closes #1098)

### DIFF
--- a/common/changes/@snowplow/node-tracker/feature-1098-verify-eid-returned-node-track_2022-08-31-10-09.json
+++ b/common/changes/@snowplow/node-tracker/feature-1098-verify-eid-returned-node-track_2022-08-31-10-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Add tests verifying that the track method returns event id (eid) in the payload (#1098)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/common/changes/@snowplow/tracker-core/feature-1098-verify-eid-returned-node-track_2022-08-31-10-09.json
+++ b/common/changes/@snowplow/tracker-core/feature-1098-verify-eid-returned-node-track_2022-08-31-10-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Add tests verifying that the track method returns event id (eid) in the payload (#1098)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/tracker-core/test/core.ts
+++ b/libraries/tracker-core/test/core.ts
@@ -53,6 +53,8 @@ import {
 } from '../src/core';
 import { Payload } from '../src/payload';
 
+const UUID_REGEX = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+
 const selfDescribingEventSchema = 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0';
 let beforeCount = 0,
   afterCount = 0;
@@ -67,6 +69,22 @@ function compare(result: Payload, expected: Payload, t: ExecutionContext) {
   delete result['dtm'];
   t.deepEqual(result, expected);
 }
+
+test('tracker.track API should return the eid attribute', (t) => {
+  const pageUrl = 'http://www.example.com';
+  const pageTitle = 'title page';
+  const referrer = 'https://www.google.com';
+  const expected = {
+    e: 'pv',
+    url: pageUrl,
+    page: pageTitle,
+    refr: referrer,
+  };
+  const eventPayload = tracker.track(buildPageView({ pageUrl, pageTitle, referrer }));
+  t.truthy(eventPayload.eid);
+  t.regex(eventPayload.eid as string, UUID_REGEX);
+  compare(eventPayload, expected, t);
+});
 
 test('should track a page view', (t) => {
   const pageUrl = 'http://www.example.com';

--- a/trackers/node-tracker/test/tracker.ts
+++ b/trackers/node-tracker/test/tracker.ts
@@ -46,6 +46,8 @@ import test, { ExecutionContext } from 'ava';
 import nock from 'nock';
 import querystring from 'querystring';
 
+const UUID_REGEX = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+
 const testMethods = [HttpMethod.GET, HttpMethod.POST];
 
 const endpoint = 'd3rkrsqld9gmqf.cloudfront.net';
@@ -104,6 +106,18 @@ test.after(() => {
 });
 
 for (const method of testMethods) {
+  test(method + ' method: track API should return eid in the payload', async (t) => {
+    const e = gotEmitter(endpoint, HttpProtocol.HTTP);
+
+    const track = tracker(e, 'cf', 'cfe35', false);
+    const eventPayload = track.track(
+      buildPageView({ pageUrl: 'http://www.example.com', pageTitle: 'example page', referrer: 'http://google.com' }),
+      context
+    );
+    t.truthy(eventPayload.eid);
+    t.regex(eventPayload.eid as string, UUID_REGEX);
+  });
+
   test(method + ' method: trackPageView should send a page view event', async (t) => {
     const expected = {
       tv: 'node-' + version,


### PR DESCRIPTION
### Description
As per other trackers, e.g. [objc](https://github.com/snowplow/snowplow-objc-tracker/pull/711), we implemented returning the event id from the `track` method. 
In the node-tracker, this was already possible as the `tracker.track` method which is used in the package, returns the event payload making `eid` accessible like so:
`const { eid } = tracker.track(...);`

This PR just adds a simple test verifying this behaviour.

#### _Note_
Additionally since the node-tracker uses the `tracker.track()` method from the core directly, a test was added there for completion and future abstraction possibility.

(closes #1098)