### PR TITLE
Make HTTPS the default collector protocol in gotEmitter (closes #1100)

### DIFF
--- a/common/changes/@snowplow/node-tracker/feature-1100-make-https-default-on-gotemitter_2022-09-01-07-35.json
+++ b/common/changes/@snowplow/node-tracker/feature-1100-make-https-default-on-gotemitter_2022-09-01-07-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Make HTTPS the default collector protocol in gotEmitter (close #1100)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/trackers/node-tracker/README.md
+++ b/trackers/node-tracker/README.md
@@ -35,7 +35,7 @@ import { tracker, gotEmitter } from '@snowplow/node-tracker';
 
 const e = gotEmitter(
   'collector.mydomain.net', // Collector endpoint
-  snowplow.HttpProtocol.HTTPS, // Optionally specify a method - http is the default
+  snowplow.HttpProtocol.HTTPS, // Optionally specify a method - https is the default
   8080, // Optionally specify a port
   snowplow.HttpMethod.POST, // Method - defaults to GET
   5 // Only send events once n are buffered. Defaults to 1 for GET requests and 10 for POST requests.

--- a/trackers/node-tracker/docs/node-tracker.api.md
+++ b/trackers/node-tracker/docs/node-tracker.api.md
@@ -235,7 +235,7 @@ export interface FormSubmissionEvent {
 }
 
 // @public
-export function gotEmitter(endpoint: string, protocol: HttpProtocol, port?: number, method?: HttpMethod, bufferSize?: number, retry?: number | Partial<RequiredRetryOptions>, cookieJar?: PromiseCookieJar | ToughCookieJar, callback?: (error?: RequestError, response?: Response<string>) => void, agents?: Agents): Emitter;
+export function gotEmitter(endpoint: string, protocol?: HttpProtocol, port?: number, method?: HttpMethod, bufferSize?: number, retry?: number | Partial<RequiredRetryOptions>, cookieJar?: PromiseCookieJar | ToughCookieJar, callback?: (error?: RequestError, response?: Response<string>) => void, agents?: Agents): Emitter;
 
 // @public (undocumented)
 export enum HttpMethod {

--- a/trackers/node-tracker/src/got_emitter.ts
+++ b/trackers/node-tracker/src/got_emitter.ts
@@ -49,7 +49,7 @@ import { Emitter, HttpProtocol, HttpMethod, preparePayload } from './emitter';
  */
 export function gotEmitter(
   endpoint: string,
-  protocol: HttpProtocol,
+  protocol: HttpProtocol = HttpProtocol.HTTPS,
   port?: number,
   method?: HttpMethod,
   bufferSize?: number,

--- a/trackers/node-tracker/test/got_emitter.ts
+++ b/trackers/node-tracker/test/got_emitter.ts
@@ -60,7 +60,7 @@ test('gotEmitter should send an HTTP GET request', async (t) => {
   await new Promise((resolve, reject) => {
     const e = gotEmitter(
       endpoint,
-      HttpProtocol.HTTP,
+      HttpProtocol.HTTPS,
       80,
       HttpMethod.GET,
       undefined,
@@ -80,7 +80,7 @@ test('gotEmitter should send an HTTP POST request', async (t) => {
   await new Promise((resolve, reject) => {
     const e = gotEmitter(
       endpoint,
-      HttpProtocol.HTTP,
+      HttpProtocol.HTTPS,
       undefined,
       HttpMethod.POST,
       1,
@@ -185,7 +185,7 @@ test('gotEmitter should add STM querystring parameter when sending POST requests
   await new Promise((resolve, reject) => {
     const e = gotEmitter(
       endpoint,
-      HttpProtocol.HTTP,
+      HttpProtocol.HTTPS,
       undefined,
       HttpMethod.POST,
       1,

--- a/trackers/node-tracker/test/tracker.ts
+++ b/trackers/node-tracker/test/tracker.ts
@@ -119,7 +119,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -155,7 +155,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -193,7 +193,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -264,7 +264,7 @@ for (const method of testMethods) {
       await new Promise((resolve, reject) => {
         const e = gotEmitter(
           endpoint,
-          HttpProtocol.HTTP,
+          HttpProtocol.HTTPS,
           undefined,
           method,
           0,
@@ -340,7 +340,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -379,7 +379,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -418,7 +418,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -461,7 +461,7 @@ for (const method of testMethods) {
       await new Promise((resolve, reject) => {
         const e = gotEmitter(
           endpoint,
-          HttpProtocol.HTTP,
+          HttpProtocol.HTTPS,
           undefined,
           method,
           0,
@@ -504,7 +504,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -539,7 +539,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,
@@ -569,7 +569,7 @@ for (const method of testMethods) {
     await new Promise((resolve, reject) => {
       const e = gotEmitter(
         endpoint,
-        HttpProtocol.HTTP,
+        HttpProtocol.HTTPS,
         undefined,
         method,
         0,


### PR DESCRIPTION
### Description
Make HTTPs protocol the default one for Node.js tracker `gotEmitter` to align it with other trackers.

closes #1100