### PR TITLE
Add bundlemon and first size limits on distributables (closes #1083)

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -1,0 +1,35 @@
+{
+  "files": [
+    {
+      "path": "./trackers/browser-tracker/dist/index.module.js",
+      "maxSize": "5kb",
+      "maxPercentIncrease": 10
+    },
+    {
+      "path": "./trackers/browser-tracker/dist/index.umd.min.js",
+      "maxSize": "15kb",
+      "maxPercentIncrease": 10
+    },
+    {
+      "path": "./trackers/javascript-tracker/dist/sp.js",
+      "maxSize": "25kb",
+      "maxPercentIncrease": 10
+    },
+    {
+      "path": "./trackers/javascript-tracker/dist/sp.lite.js",
+      "maxSize": "15kb",
+      "maxPercentIncrease": 10
+    },
+    {
+      "path": "./libraries/browser-tracker-core/dist/index.module.js",
+      "maxSize": "25kb",
+      "maxPercentIncrease": 10
+    },
+    {
+      "path": "./libraries/tracker-core/dist/index.module.js",
+      "maxSize": "15kb",
+      "maxPercentIncrease": 10
+    }
+  ],
+  "reportOutput": ["github"]
+}

--- a/.github/workflows/change_check.yml
+++ b/.github/workflows/change_check.yml
@@ -49,3 +49,9 @@ jobs:
       - name: Check for API changes to @snowplow/node-tracker
         working-directory: ./trackers/node-tracker
         run: api-extractor run
+
+      - name: Check bundle size using bundlemon
+        run: npx bundlemon@1.4.0
+        env:
+          BUNDLEMON_PROJECT_ID: 630fceda4ed824a9d3733ec0
+          CI_COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}


### PR DESCRIPTION
### Description
Add bundlemon to keep size limit in check and get reports on each PR about size differences on our distributables.

closes #1083 