### PR TITLE
Remove user and session identifiers from cookies when anonymous tracking becomes enabled (close #1103)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-1103-clear_cookies_anonymous_tracking_2022-09-02-14-33.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1103-clear_cookies_anonymous_tracking_2022-09-02-14-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Remove user and session identifiers from cookies when anonymous tracking becomes enabled (#1103)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1103-clear_cookies_anonymous_tracking_2022-09-02-14-33.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1103-clear_cookies_anonymous_tracking_2022-09-02-14-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Remove user and session identifiers from cookies when anonymous tracking becomes enabled (#1103)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/id_cookie.ts
+++ b/libraries/browser-tracker-core/src/tracker/id_cookie.ts
@@ -202,7 +202,7 @@ export function parseIdCookie(
  */
 export function initializeDomainUserId(idCookie: ParsedIdCookie, configAnonymousTracking: boolean) {
   let domainUserId;
-  if (idCookie[domainUserIdIndex]) {
+  if (idCookie[domainUserIdIndex] && !configAnonymousTracking) {
     domainUserId = idCookie[domainUserIdIndex];
   } else if (!configAnonymousTracking) {
     domainUserId = uuid();

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -642,7 +642,7 @@ export function Tracker(
     /*
      * Load the domain user ID and the session ID
      * Set the cookies (if cookies are enabled)
-     * If anonymous tracking is enabled, it clears the anonymised identifiers
+     * If anonymous tracking is enabled, it clears the stored identifiers that should be anonymous
      */
     function initializeIdsAndCookies() {
       if (configAnonymousTracking && !configAnonymousSessionTracking) {

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -642,9 +642,14 @@ export function Tracker(
     /*
      * Load the domain user ID and the session ID
      * Set the cookies (if cookies are enabled)
+     * If anonymous tracking is enabled, it clears the anonymised identifiers
      */
     function initializeIdsAndCookies() {
       if (configAnonymousTracking && !configAnonymousSessionTracking) {
+        clearUserDataAndCookies({
+          preserveSession: false,
+          preserveUser: false,
+        });
         return;
       }
 
@@ -1200,6 +1205,9 @@ export function Tracker(
         trackerConfiguration.anonymousTracking = (configuration && configuration?.options) ?? true;
 
         toggleAnonymousTracking(configuration);
+
+        // Re-initialize the ID cookie which clears the domain_userid (if session tracking) or clears the whole cookie
+        initializeIdsAndCookies();
 
         // Reset the page view, if not tracking the session, so can't stitch user into new events on the page view id
         if (!configAnonymousSessionTracking) {

--- a/libraries/browser-tracker-core/test/id_cookie.test.ts
+++ b/libraries/browser-tracker-core/test/id_cookie.test.ts
@@ -111,11 +111,15 @@ describe('initializeDomainUserId', () => {
   it('Uses existing ID if present', () => {
     let idCookie = parseIdCookie(`abc.1653632272.10.1653632272.1653632272`, '', '', 0);
 
-    let duidAnonymous = initializeDomainUserId(idCookie, true);
-    expect(duidAnonymous).toBe('abc');
-
     let duidNonAnonymous = initializeDomainUserId(idCookie, false);
     expect(duidNonAnonymous).toBe('abc');
+  });
+
+  it('Clears existing domain user ID if anonymous tracking', () => {
+    let idCookie = parseIdCookie(`abc.1653632272.10.1653632272.1653632272`, '', '', 0);
+
+    let duidAnonymous = initializeDomainUserId(idCookie, true);
+    expect(duidAnonymous).toBe('');
   });
 
   it('Generates a new ID', () => {

--- a/trackers/javascript-tracker/test/integration/cookieless.test.ts
+++ b/trackers/javascript-tracker/test/integration/cookieless.test.ts
@@ -39,7 +39,7 @@ const retrieveSchemaData = (schema: unknown) => F.compose(F.get('data'), F.find(
 describe('Anonymous tracking features', () => {
   let log: Array<unknown> = [];
   let docker: DockerWrapper;
-  let cookies: { name: string; value: string }[] = [];
+  let cookiesAnonymousTracking: { name: string; value: string }[] = [];
   let cookiesWithSessionTracking: { name: string; value: string }[] = [];
 
   const listContains = (items: Array<unknown>, ev: unknown) => F.some(F.isMatch(ev as object), items);
@@ -50,33 +50,17 @@ describe('Anonymous tracking features', () => {
     await browser.setCookies({ name: 'container', value: docker.url });
     await browser.url('/cookieless.html');
     await browser.pause(5000); // Time for requests to get written
-    cookies = await browser.getCookies();
-
-    await browser.url('/cookieless.html?ieTest=true');
-    await browser.pause(2500); // Time for requests to get written
-
-    log = await browser.call(async () => await fetchResults(docker.url));
+    cookiesAnonymousTracking = await browser.getCookies();
 
     await browser.url('/cookieless.html?ieTest=true&withSessionTracking=true');
     await browser.pause(2500); // Time for requests to get written
     cookiesWithSessionTracking = await browser.getCookies();
+
+    log = await browser.call(async () => await fetchResults(docker.url));
   });
 
   afterAll(async () => {
     await browser.call(async () => await stop(docker.container));
-  });
-
-  describe('sp_id cookies with user and session IDs', () => {
-    it('should not have the cookie with full anonymous tracking', () => {
-      expect(cookies.filter((c) => c.name.includes('_sp_id')).length).toBe(0);
-    });
-
-    it('should have the cookie without user ID if session tracking', () => {
-      let cookie = cookiesWithSessionTracking.filter((c) => c.name.includes('_sp_id'))[0];
-      expect(cookie).toBeTruthy();
-      // the cookie should start with . which means without domain_userid
-      expect(cookie.value.startsWith('.')).toBeTrue();
-    });
   });
 
   it('should have no user information in page view when server anonymisation ', () => {
@@ -207,5 +191,16 @@ describe('Anonymous tracking features', () => {
     } else {
       expect(F.size(pageViews)).toBe(2);
     }
+  });
+
+  it('should not have the sp_id cookie with full anonymous tracking', () => {
+    expect(cookiesAnonymousTracking.filter((c) => c.name.includes('_sp_id')).length).toBe(0);
+  });
+
+  it('should have the sp_id cookie without user ID if session tracking', () => {
+    let cookie = cookiesWithSessionTracking.filter((c) => c.name.includes('_sp_id'))[0];
+    expect(cookie).toBeTruthy();
+    // the cookie should start with . which means without domain_userid
+    expect(cookie.value.startsWith('.')).toBeTrue();
   });
 });

--- a/trackers/javascript-tracker/test/pages/cookieless.html
+++ b/trackers/javascript-tracker/test/pages/cookieless.html
@@ -44,6 +44,7 @@
       document.write(collector_endpoint);
 
       var ieTest = parseQuery().ieTest;
+      var withSessionTracking = parseQuery().withSessionTracking;
 
       window.snowplow('newTracker', 'sp', collector_endpoint, {
         appId: ieTest ? 'ie' : 'anon',
@@ -52,6 +53,8 @@
           webPage: true,
         },
         anonymousTracking: { withServerAnonymisation: true },
+        cookieSameSite: 'Lax',
+        cookieSecure: false,
       });
 
       window.snowplow('setUserId', 'Malcolm');
@@ -66,6 +69,15 @@
           window.snowplow('enableAnonymousTracking');
           window.snowplow('trackPageView', { title: 'Client Anon' });
         }, 2000);
+      }
+
+      if (withSessionTracking) {
+        setTimeout(function () {
+          window.snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
+          window.snowplow('trackPageView', { title: 'No Anon' });
+          window.snowplow('enableAnonymousTracking', { options: { withSessionTracking: true } });
+          window.snowplow('trackPageView', { title: 'Client Anon' });
+        }, 500);
       }
     </script>
   </body>

--- a/trackers/javascript-tracker/test/pages/cookieless.html
+++ b/trackers/javascript-tracker/test/pages/cookieless.html
@@ -43,11 +43,13 @@
 
       document.write(collector_endpoint);
 
-      var ieTest = parseQuery().ieTest;
-      var withSessionTracking = parseQuery().withSessionTracking;
+      var query = parseQuery();
+      var ieTest = query.ieTest;
+      var withSessionTracking = query.withSessionTracking;
+      var appId = withSessionTracking ? 'ses' : ieTest ? 'ie' : 'anon';
 
       window.snowplow('newTracker', 'sp', collector_endpoint, {
-        appId: ieTest ? 'ie' : 'anon',
+        appId: appId,
         eventMethod: 'post',
         contexts: {
           webPage: true,
@@ -61,7 +63,12 @@
       window.snowplow('trackPageView', { title: 'Server Anon' });
       window.snowplow('trackPageView', { title: 'Server Anon' }); // Should have different network_userid
 
-      if (!ieTest) {
+      if (withSessionTracking) {
+        setTimeout(function () {
+          window.snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
+          window.snowplow('enableAnonymousTracking', { options: { withSessionTracking: true } });
+        }, 500);
+      } else if (!ieTest) {
         setTimeout(function () {
           window.snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
           window.snowplow('setUserId', 'Malcolm');
@@ -69,13 +76,6 @@
           window.snowplow('enableAnonymousTracking');
           window.snowplow('trackPageView', { title: 'Client Anon' });
         }, 2000);
-      }
-
-      if (withSessionTracking) {
-        setTimeout(function () {
-          window.snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
-          window.snowplow('enableAnonymousTracking', { options: { withSessionTracking: true } });
-        }, 500);
       }
     </script>
   </body>

--- a/trackers/javascript-tracker/test/pages/cookieless.html
+++ b/trackers/javascript-tracker/test/pages/cookieless.html
@@ -74,9 +74,7 @@
       if (withSessionTracking) {
         setTimeout(function () {
           window.snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
-          window.snowplow('trackPageView', { title: 'No Anon' });
           window.snowplow('enableAnonymousTracking', { options: { withSessionTracking: true } });
-          window.snowplow('trackPageView', { title: 'Client Anon' });
         }, 500);
       }
     </script>


### PR DESCRIPTION
This addresses issue #1103 with the goal to clear the `sp_id` cookie when anonymous tracking is enabled.

The problem does not occur in case anonymous tracking wasn't disabled before. For example, if `newTracker()` is called with anonymous tracking already enabled, no identifiers are stored in the cookies. However, if `newTracker()` is called without anonymous tracking enabled, and later the user calls `enableAnonymousTracking()`, the user and session identifiers remain in cookies.

The new suggested behaviour can have two forms:

1. If form tracking is enabled without session tracking, the whole `sp_id` cookie should be removed. This is equivalent to calling `clearUserData()` in the current API – the cookie will be removed and in-memory identifiers reset.
2. If form tracking is enabled with session tracking, we shouldn't clear the whole cookie, just remove the `domain_userid` from it while maintaining the same session ID and rest of the `sp_id` cookie.