### PR TITLE
Fix youtube error mapping codes to fit the Iglu schema (closes #1111)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1111-fix-youtube-error-code-mapping_2022-10-09-22-22.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1111-fix-youtube-error-code-mapping_2022-10-09-22-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-youtube-tracking",
+      "comment": "Fix youtube error mapping codes to fit the Iglu schema (closes #1111)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-youtube-tracking"
+}

--- a/plugins/browser-plugin-youtube-tracking/src/constants.ts
+++ b/plugins/browser-plugin-youtube-tracking/src/constants.ts
@@ -41,9 +41,9 @@ export enum YTState {
 }
 
 export const YTError: Record<number, string> = {
-  2: 'INVALID_URL',
-  5: 'HTML5_ERROR',
-  100: 'VIDEO_NOT_FOUND',
-  101: 'MISSING_EMBED_PERMISSION',
-  150: 'MISSING_EMBED_PERMISSION',
+  2: 'INVALID_PARAMETER',
+  5: 'HTML5_PLAYER_ERROR',
+  100: 'NOT_FOUND',
+  101: 'EMBED_DISALLOWED',
+  150: 'EMBED_DISALLOWED',
 };


### PR DESCRIPTION
### Description

Fix Youtube error mapping codes to match the [YT error schema](https://github.com/snowplow/iglu-central/blob/cb00a49406207243ae22d282441359735f8850e6/schemas/com.youtube/youtube/jsonschema/1-0-0#L56).

### Note
Probably this implementation never worked, so we should keep in mind that clients updating to the new version, might see new events coming up in the good pipeline.

closes #1111