### PR TITLE
Use shared logger for Youtube plugin loading and add helpful message for missing plugin initialization ( closes #1113 )

### DIFF
--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1113-fix-youtube-logger-initialization_2022-10-09-22-40.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1113-fix-youtube-logger-initialization_2022-10-09-22-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-youtube-tracking",
+      "comment": "Use shared logger for Youtube plugin loading and add helpful message for plugin initialization missing (closes #1113)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-youtube-tracking"
+}


### PR DESCRIPTION
### Description
Use the shared `LOG` function from `@snowplow/tracker-core` to prevent undefined state before plugin initialization.

### Notes
- Added a _somewhat_ helpful message when no tracker has the plugin installed.
- Why did we not use the LOG object initially and we needed to use the `logger` callback ? 🤔  We might need to fix this in a couple more places if there was no valid reason.

closes #1113