### PR TITLE
Support JWPlayer in browser-plugin-media-tracking (closes #1116)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/feature-1116-support-jwplayer-on-media-tracking_2022-10-12-17-40.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/feature-1116-support-jwplayer-on-media-tracking_2022-10-12-17-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Support JWPlayer in browser-plugin-media-tracking (closes #1116)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/plugins/browser-plugin-media-tracking/src/buildMediaEvent.ts
+++ b/plugins/browser-plugin-media-tracking/src/buildMediaEvent.ts
@@ -9,7 +9,7 @@ export function buildMediaEvent(
   conf: TrackingOptions,
   detail?: EventDetail
 ): MediaEventData {
-  const context = [getHTMLMediaElementEntities(el), getMediaPlayerEntities(el, detail)];
+  const context = [getHTMLMediaElementEntities(el, conf), getMediaPlayerEntities(el, detail)];
   if (el instanceof HTMLVideoElement) context.push(getHTMLVideoElementEntities(el as HTMLVideoElement));
   const data: MediaPlayerEvent = { type: e in eventNames ? eventNames[e] : e };
   if (conf.label) data.label = conf.label;
@@ -40,9 +40,11 @@ function getMediaPlayerEntities(el: HTMLAudioElement | HTMLVideoElement, detail?
   };
 }
 
-function getHTMLMediaElementEntities(el: HTMLAudioElement | HTMLVideoElement): MediaEntities {
+function getHTMLMediaElementEntities(el: HTMLAudioElement | HTMLVideoElement, conf: TrackingOptions): MediaEntities {
+  // In cases where the media does not have explicit id, we use the container id passed from the configuration.
+  const htmlId = el.id || conf.id;
   const data: MediaElement = {
-    htmlId: el.id,
+    htmlId,
     mediaType: el.tagName as MediaElement['mediaType'],
     autoPlay: el.autoplay,
     buffered: timeRangesToObjectArray(el.buffered),

--- a/plugins/browser-plugin-media-tracking/src/findMediaElement.ts
+++ b/plugins/browser-plugin-media-tracking/src/findMediaElement.ts
@@ -25,6 +25,10 @@ function findMediaElementChild(el: Element): SearchResult {
     if (elem.length === 1) {
       if (isAudioElement(elem[0])) return { el: elem[0] };
       if (isVideoElement(elem[0])) return { el: elem[0] };
+    } else if (elem.length === 2 && tag === 'VIDEO' && isVideoElement(elem[0])) {
+      // Special JWPlayer case where two video elements are used for cover-video effect.
+      // In that case, we select the first video element.
+      return { el: elem[0] };
     } else if (elem.length > 1) {
       return { err: SEARCH_ERROR.MULTIPLE_ELEMENTS };
     }

--- a/plugins/browser-plugin-media-tracking/test/media.test.ts
+++ b/plugins/browser-plugin-media-tracking/test/media.test.ts
@@ -165,8 +165,15 @@ describe('element searcher', () => {
     expect(output).toStrictEqual({ err: 'More than one media element in the provided node' });
   });
 
+  it('returns the first video element if exactly two exist in the same parent. Covers the cover-video case.', () => {
+    document.body.innerHTML = '<div id="parentElem"><video id="test-id"></video><video></video></div>';
+    const output = findMediaElem('parentElem');
+    expect(output.el?.tagName).toBe('VIDEO');
+    expect(output.el?.id).toBe('test-id');
+  });
+
   it('returns an error if multiple child video elements exist in a parent', () => {
-    document.body.innerHTML = '<div id="parentElem"><video></video><video></video></div>';
+    document.body.innerHTML = '<div id="parentElem"><video></video><video></video><video></video></div>';
     const output = findMediaElem('parentElem');
     expect(output).toStrictEqual({ err: 'More than one media element in the provided node' });
   });


### PR DESCRIPTION
This PR adds a minimal set of changes to be able to support JWPlayer media. Additionally the JWPlayer media with poster functionality.

### Notes
- The check that has been added for the length of the detected media could be in some way enhanced with some `classname` search, but I do not think that it is required in this case.
- JWplayer adds the poster video on an additional 'second' video element, that is why we select the first which is the functional one.
- Do you think we should create an exhaustive jwplayer check ?

- There is an edge case for existing clients will see new events if they update to the latest version that we will publish.
This edge case is described in the following scenario:
1. A client has added media tracking.
2. The client had targeted a container element with exactly two video elements.
3. The tracking would not work and a console error would be shown continouusly until we publish this release.
4. He updates to the latest version of the tracker.
If all the above happen, he will start seeing some video events from the 'first' video element.
 
closes #1116 