### PR TITLE
Use currentSrc as src when source element in used in media-tracking (closes #1118)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/feature-1118-support-src-from-source-element_2022-10-17-14-05.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/feature-1118-support-src-from-source-element_2022-10-17-14-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Use currentSrc as src when source element in used in media-tracking (closes #1118)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/plugins/browser-plugin-media-tracking/src/buildMediaEvent.ts
+++ b/plugins/browser-plugin-media-tracking/src/buildMediaEvent.ts
@@ -56,7 +56,7 @@ function getHTMLMediaElementEntities(el: HTMLAudioElement | HTMLVideoElement): M
     readyState: READY_STATE[el.readyState] as MediaElement['readyState'],
     seekable: timeRangesToObjectArray(el.seekable),
     seeking: el.seeking,
-    src: dataUrlHandler(el.src),
+    src: dataUrlHandler(el.src || el.currentSrc),
     textTracks: textTrackListToJson(el.textTracks),
     fileExtension: el.currentSrc.split('.').pop() as string,
     fullscreen: isElementFullScreen(el.id),


### PR DESCRIPTION
Use `currentSrc` as `src` when src is not available. This is the case where there is a `source` element under our audio or video we wish to track.

### Notes
- Unfortunately testing will require a bit more time since `jsdom` does not have the functionality to work properly with `currentSrc`

(closes #1118)