### PR TITLE
Remove fixed values for playbackQuality in YT integration tests plus some type fixes

### DIFF
--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1122-fix-youtube-e2e-playbackQuality-values_2022-10-24-08-31.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1122-fix-youtube-e2e-playbackQuality-values_2022-10-24-08-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-youtube-tracking",
+      "comment": "Remove fixed values for playbackQuality in YT integrations plus type fixes (closes #1122)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-youtube-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1122-fix-youtube-e2e-playbackQuality-values_2022-10-24-08-31.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1122-fix-youtube-e2e-playbackQuality-values_2022-10-24-08-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/plugins/browser-plugin-youtube-tracking/src/buildYouTubeEvent.ts
+++ b/plugins/browser-plugin-youtube-tracking/src/buildYouTubeEvent.ts
@@ -34,6 +34,7 @@ function getYouTubeEntities(player: YT.Player, urlParameters: UrlParameters, eve
   let data: YouTube = {
     autoPlay: urlParameters.autoplay === '1',
     avaliablePlaybackRates: player.getAvailablePlaybackRates(),
+    avaliableQualityLevels: player.getAvailableQualityLevels(),
     buffering: playerStates[YT.PlayerState.BUFFERING],
     controls: urlParameters.controls !== '0',
     cued: playerStates[YT.PlayerState.CUED],
@@ -55,9 +56,6 @@ function getYouTubeEntities(player: YT.Player, urlParameters: UrlParameters, eve
   if (playlist) {
     data.playlist = playlist.map((item: string) => parseInt(item));
   }
-
-  const qualityLevels = player.getAvailableQualityLevels();
-  if (qualityLevels) data.avaliableQualityLevels = qualityLevels;
 
   return {
     schema: 'iglu:com.youtube/youtube/jsonschema/1-0-0',

--- a/plugins/browser-plugin-youtube-tracking/src/contexts.ts
+++ b/plugins/browser-plugin-youtube-tracking/src/contexts.ts
@@ -89,11 +89,19 @@ export interface MediaPlayer {
   [key: string]: unknown;
 }
 
+/**
+ * Some of the types can be found at https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/youtube/index.d.ts
+ */
 export interface YouTube {
+  /**
+   * An array of quality levels in which the current video is available
+   */
+  avaliableQualityLevels: string[];
+
   /**
    * An array of playback rates in which the current video is available
    **/
-  avaliablePlaybackRates: Array<number>;
+  avaliablePlaybackRates: number[];
 
   /**
    * If the video is cued
@@ -136,9 +144,15 @@ export interface YouTube {
   origin?: string | null;
 
   /**
+   * The quality level of the current video
+   * Documented types come from the `SuggestedVideoQuality` enum. But from our experiences this is not dependable.
+   */
+  playbackQuality?: string;
+
+  /**
    * An array of the video IDs in the playlist as they are currently ordered.
    **/
-  playlist?: Array<number> | null;
+  playlist?: number[] | null;
 
   /**
    * The index of the playlist video that is currently playing

--- a/trackers/javascript-tracker/test/integration/youtube.test.ts
+++ b/trackers/javascript-tracker/test/integration/youtube.test.ts
@@ -41,7 +41,7 @@ const makeExpectedEvent = (
       {
         schema: 'iglu:com.youtube/youtube/jsonschema/1-0-0',
         data: {
-          playbackQuality: jasmine.stringMatching(/small|medium|large|hd720|hd1080|highres|auto|unknown/),
+          playbackQuality: jasmine.any(String),
           cued: false,
           playerId: playerId,
           autoPlay: false,


### PR DESCRIPTION
- Remove fixed test values for youtube integration tests.
- Add missing types in the Youtube interface

### Notes
- The `Youtube` interface is not exposed on the plugin typings (_or arguments_) so this can be regarded a safe change.

(closes #1122)