### PR TITLE
Round youtube volume sent on volumechange (closes #1126)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1126-fix-yt-volume-rounding_2022-10-28-13-47.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1126-fix-yt-volume-rounding_2022-10-28-13-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-youtube-tracking",
+      "comment": "Round youtube volume sent on volumechange (closes #1126)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-youtube-tracking"
+}

--- a/plugins/browser-plugin-youtube-tracking/src/buildYouTubeEvent.ts
+++ b/plugins/browser-plugin-youtube-tracking/src/buildYouTubeEvent.ts
@@ -89,7 +89,7 @@ function getMediaPlayerEntities(
     muted: player.isMuted(),
     paused: playerStates[YT.PlayerState.PAUSED],
     playbackRate: player.getPlaybackRate(),
-    volume: player.getVolume(),
+    volume: Math.round(player.getVolume()),
   };
 
   if (e === SnowplowEvent.PERCENTPROGRESS) {


### PR DESCRIPTION
As it seems `player.getVolume()` from the YTPlayer API returns a decimal in many occasions breaking the [schema](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/media_player/jsonschema/1-0-0#L62).

Closes #1126 