### PR TITLE
Update Node.js compatibility to v14 (closes #1129)

### DIFF
--- a/common/changes/@snowplow/node-tracker/feature-1129-update-supported-node-v14_2022-11-29-08-48.json
+++ b/common/changes/@snowplow/node-tracker/feature-1129-update-supported-node-v14_2022-11-29-08-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Update Node.js to v14 (closes #1129)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/trackers/node-tracker/tsconfig.json
+++ b/trackers/node-tracker/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "lib": ["es2018"],
-    "target": "es2018" /* Good for Node 10 - https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping */,
+    "lib": ["ES2020"],
+    "target": "ES2020" /* Good for Node 14 - https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping */,
     "module": "commonjs" /* Ignored by rollup but used by ts-node for tests */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "resolveJsonModule": true,


### PR DESCRIPTION
From v4 onwards minimum Node.js version is 14.

closes #1129 