### PR TITLE
Make sure brands array in client hints plugin is serialized as an array in context entity (close #1082)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-client-hints/issue-1082-client_hints_brands_2023-01-23-16-15.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/issue-1082-client_hints_brands_2023-01-23-16-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-client-hints",
+      "comment": "Make sure brands array in client hints plugin is serialized as an array in context entity",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-client-hints"
+}

--- a/plugins/browser-plugin-client-hints/src/index.ts
+++ b/plugins/browser-plugin-client-hints/src/index.ts
@@ -57,6 +57,16 @@ declare global {
 let uaClientHints: HttpClientHints;
 
 /**
+ * This function makes sure that the expected array is returned as an array instead of an object.
+ * It handles a problem that in some cases the `navigator.userAgentData.brands` was returned as an object instead of array.
+ */
+function forceArray<T>(array: T[]): T[] {
+  return Object.keys(array).map((e) => {
+    return (array as any)[e];
+  });
+}
+
+/**
  * Attaches Client Hint information where available
  * @param includeHighEntropy - Should high entropy values be included
  */
@@ -67,7 +77,7 @@ export function ClientHintsPlugin(includeHighEntropy?: boolean): BrowserPlugin {
     if (navigatorAlias.userAgentData) {
       uaClientHints = {
         isMobile: navigatorAlias.userAgentData.mobile,
-        brands: navigatorAlias.userAgentData.brands,
+        brands: forceArray(navigatorAlias.userAgentData.brands),
       };
       if (includeHighEntropy && navigatorAlias.userAgentData.getHighEntropyValues) {
         navigatorAlias.userAgentData

--- a/plugins/browser-plugin-client-hints/src/index.ts
+++ b/plugins/browser-plugin-client-hints/src/index.ts
@@ -60,9 +60,11 @@ let uaClientHints: HttpClientHints;
  * This function makes sure that the expected array is returned as an array instead of an object.
  * It handles a problem that in some cases the `navigator.userAgentData.brands` was returned as an object instead of array.
  */
-function forceArray<T>(array: T[]): T[] {
+function forceArray<T>(array: T[] | Record<string, T>): T[] {
+  if (Array.isArray(array)) return array;
+
   return Object.keys(array).map((e) => {
-    return (array as any)[e];
+    return array[e];
   });
 }
 


### PR DESCRIPTION
Issue #1082

The PR addresses the problem where the `brands` array in the `http_client_hints` context entity produced by the client hints plugin was malformed. In some cases reported in the issue, it was in the form of an object instead of an array. I suspect that this is due to some browser bugs or other influences but I wasn't able to replicate the issue myself.

The fix just converts the `brands` object or array into an array by iterating over its values. Since I wasn't able to replicate the problem, I can't verify it helps but it should be able to convert an object to an array.