### PR TITLE
Change default tracker initialization parameters for JS/Browser v4

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/feature-v4-change-default-initialization-params-browser_2023-01-26-08-53.json
+++ b/common/changes/@snowplow/browser-tracker-core/feature-v4-change-default-initialization-params-browser_2023-01-26-08-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Change default tracker initialization params (discoverRootDomain, cookieSameSite)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/javascript-tracker/feature-v4-change-default-initialization-params-browser_2023-01-26-08-53.json
+++ b/common/changes/@snowplow/javascript-tracker/feature-v4-change-default-initialization-params-browser_2023-01-26-08-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -229,11 +229,12 @@ export function Tracker(
       // First-party cookie domain
       // User agent defaults to origin hostname
       configCookieDomain = trackerConfiguration.cookieDomain ?? undefined,
+      discoverRootDomain = trackerConfiguration.discoverRootDomain || true,
       // First-party cookie path
       // Default is user agent defined.
       configCookiePath = '/',
       // First-party cookie samesite attribute
-      configCookieSameSite = trackerConfiguration.cookieSameSite ?? 'None',
+      configCookieSameSite = trackerConfiguration.cookieSameSite ?? 'Lax',
       // First-party cookie secure attribute
       configCookieSecure = trackerConfiguration.cookieSecure ?? true,
       // Do Not Track browser feature
@@ -308,7 +309,7 @@ export function Tracker(
       configSessionContext = trackerConfiguration.contexts?.session ?? false,
       toOptoutByCookie: string | boolean;
 
-    if (trackerConfiguration.hasOwnProperty('discoverRootDomain') && trackerConfiguration.discoverRootDomain) {
+    if (discoverRootDomain && !configCookieDomain) {
       configCookieDomain = findRootDomain(configCookieSameSite, configCookieSecure);
     }
 

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -91,7 +91,7 @@ export type TrackerConfiguration = {
   /**
    * The SameSite value for the cookie
    * {@link https://snowplowanalytics.com/blog/2020/09/07/pipeline-configuration-for-complete-and-accurate-data/}
-   * @defaultValue None
+   * @defaultValue Lax
    */
   cookieSameSite?: CookieSameSite;
   /**
@@ -170,7 +170,7 @@ export type TrackerConfiguration = {
    *
    * This sets cookies to try to determine the root domain, and some cookies may
    * fail to save. This is expected behavior.
-   * @defaultValue false
+   * @defaultValue true
    */
   discoverRootDomain?: boolean;
   /**

--- a/libraries/browser-tracker-core/test/helpers/index.ts
+++ b/libraries/browser-tracker-core/test/helpers/index.ts
@@ -58,7 +58,7 @@ export function createTestIdCookie(params: Partial<CreateTestIdCookie>) {
   const { domainHash } = cookieParams;
   // @ts-expect-error
   delete cookieParams.domainHash;
-  return `_sp_id.${domainHash}=${Object.values(cookieParams).join('.')}; Expires=; Path=/; SameSite=None; Secure;`;
+  return `_sp_id.${domainHash}=${Object.values(cookieParams).join('.')}; Expires=; Path=/; SameSite=Lax; Secure;`;
 }
 
 interface CreateTestSessionIdCookie {
@@ -70,5 +70,5 @@ interface CreateTestSessionIdCookie {
  */
 export function createTestSessionIdCookie(params?: CreateTestSessionIdCookie) {
   const domainHash = DEFAULT_DOMAIN_HASH || params?.domainHash;
-  return `_sp_ses.${domainHash}=*; Expires=; Path=/; SameSite=None; Secure;`;
+  return `_sp_ses.${domainHash}=*; Expires=; Path=/; SameSite=Lax; Secure;`;
 }

--- a/trackers/javascript-tracker/test/pages/cookies.html
+++ b/trackers/javascript-tracker/test/pages/cookies.html
@@ -34,7 +34,6 @@
 
       snowplow('newTracker', 'sp1', 'snowplow-js-tracker.local:9090', {
         cookieName: '_sp_1',
-        cookieSameSite: 'Lax',
         cookieSecure: false,
       });
 
@@ -49,7 +48,6 @@
 
       snowplow('newTracker', 'sp3', 'snowplow-js-tracker.local:9090', {
         cookieName: '_sp_3',
-        cookieSameSite: 'Lax',
         cookieSecure: false,
         sessionCookieTimeout: 1,
         cookieLifetime: 1,
@@ -57,28 +55,24 @@
 
       snowplow('newTracker', 'sp4', 'snowplow-js-tracker.local:9090', {
         cookieName: '_sp_4',
-        cookieSameSite: 'Lax',
         cookieSecure: false,
         anonymousTracking: true,
       });
 
       snowplow('newTracker', 'sp5', 'snowplow-js-tracker.local:9090', {
         cookieName: '_sp_5',
-        cookieSameSite: 'Lax',
         cookieSecure: false,
         stateStorageStrategy: 'localStorage',
       });
 
       snowplow('newTracker', 'sp6', 'snowplow-js-tracker.local:9090', {
         cookieName: '_sp_6',
-        cookieSameSite: 'Lax',
         cookieSecure: false,
         stateStorageStrategy: 'cookie',
       });
 
       snowplow('newTracker', 'sp7', 'snowplow-js-tracker.local:9090', {
         cookieName: '_sp_7',
-        cookieSameSite: 'Lax',
         cookieSecure: false,
         cookieDomain: '.google.com',
       });


### PR DESCRIPTION
This PR includes the proposed changes for the JS/Browser tracker initialization parameters:

Currently it includes:
- `discoverRootDomain`: The default becomes `true`
- `configCookieSameSite`: The default becomes `Lax`

A bit more info:

### `discoverRootDomain`
On the previous version this value defaulted to `false`. 

This had an important effect when used as a default. If the tracker was installed in a subdomain (_foo.example.com_), or any number of subdomains _(bar.example.com etc),_ and a TLD _(example.com)_, then all instances had different domain userIds.

That would make the analysis a bit more challenging when trying to count unique users, without the existance of user ID _(`uid`),_ and cross TLD-subdomain behaviours/attribution.

The behaviour now mimics what other tools like Google Analytics have as a default.

### `configCookieSameSite`
This was set as the recommended value of `Lax` but defaults to `None` which seems to have caused some issues for unsupported browsers and tracking use cases. 
Since our v4 compatibility does not allow us to follow the changes made in latest browser versions, this would be a good default to follow for this version:
More info:
- https://snowplow.io/blog/understanding-the-samesite-cookie-update/
- https://www.chromium.org/updates/same-site/incompatible-clients/
