### PR TITLE
v4: Revise Node.js initialization

### DIFF
--- a/common/changes/@snowplow/node-tracker/feature-revise-nodejs-initialization_2023-01-30-17-24.json
+++ b/common/changes/@snowplow/node-tracker/feature-revise-nodejs-initialization_2023-01-30-17-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Revise Node.js initialization API & upgrade got to @12",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/common/changes/@snowplow/tracker-core/feature-revise-nodejs-initialization_2023-01-31-10-50.json
+++ b/common/changes/@snowplow/tracker-core/feature-revise-nodejs-initialization_2023-01-31-10-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Upgrade ava to @5",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -355,6 +355,10 @@
       "allowedCategories": [ "libraries", "plugins", "trackers" ]
     },
     {
+      "name": "tsx",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
       "name": "typescript",
       "allowedCategories": [ "libraries", "plugins", "trackers" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
       '@types/uuid': ^8.3.2
       '@typescript-eslint/eslint-plugin': ~5.15.0
       '@typescript-eslint/parser': ~5.15.0
-      ava: ~4.1.0
+      ava: ~5.1.1
       eslint: ~8.11.0
       jest-standard-reporter: ~2.0.0
       rollup: ~2.70.1
@@ -94,7 +94,7 @@ importers:
       '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.15.0_f2c49ce7d0e93ebcfdb4b7d25b131b28
       '@typescript-eslint/parser': 5.15.0_eslint@8.11.0+typescript@4.6.2
-      ava: 4.1.0
+      ava: 5.1.1
       eslint: 8.11.0
       jest-standard-reporter: 2.0.0
       rollup: 2.70.1
@@ -1264,7 +1264,7 @@ importers:
       '@types/sinon': ~10.0.11
       '@typescript-eslint/eslint-plugin': ~5.15.0
       '@typescript-eslint/parser': ~5.15.0
-      ava: ~4.1.0
+      ava: ~5.1.1
       eslint: ~8.11.0
       eslint-plugin-ava: ~13.2.0
       got: ^11.8.5
@@ -1286,7 +1286,7 @@ importers:
       '@types/sinon': 10.0.11
       '@typescript-eslint/eslint-plugin': 5.15.0_f2c49ce7d0e93ebcfdb4b7d25b131b28
       '@typescript-eslint/parser': 5.15.0_eslint@8.11.0+typescript@4.6.2
-      ava: 4.1.0
+      ava: 5.1.1
       eslint: 8.11.0
       eslint-plugin-ava: 13.2.0_eslint@8.11.0
       nock: 13.2.4
@@ -2208,7 +2208,7 @@ packages:
     resolution: {integrity: sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==}
     engines: {node: '>=10'}
     dependencies:
-      defer-to-connect: 2.0.0
+      defer-to-connect: 2.0.1
 
   /@testim/chrome-version/1.1.2:
     resolution: {integrity: sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==}
@@ -2278,7 +2278,7 @@ packages:
   /@types/cacheable-request/6.0.1:
     resolution: {integrity: sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==}
     dependencies:
-      '@types/http-cache-semantics': 4.0.0
+      '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.1
       '@types/node': 14.6.4
       '@types/responselike': 1.0.0
@@ -2352,8 +2352,8 @@ packages:
       '@types/node': 14.6.4
     dev: true
 
-  /@types/http-cache-semantics/4.0.0:
-    resolution: {integrity: sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==}
+  /@types/http-cache-semantics/4.0.1:
+    resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
 
   /@types/inquirer/8.2.0:
     resolution: {integrity: sha512-BNoMetRf3gmkpAlV5we+kxyZTle7YibdOntIZbU5pyIfMdcwy784KfeZDAcuyMznkh5OLa17RVXZOGA5LTlkgQ==}
@@ -3028,6 +3028,12 @@ packages:
     hasBin: true
     dev: true
 
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
   /agent-base/6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -3130,8 +3136,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /ansi-styles/6.1.0:
-    resolution: {integrity: sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==}
+  /ansi-styles/6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
     dev: true
 
@@ -3266,9 +3272,9 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
-  /ava/4.1.0:
-    resolution: {integrity: sha512-QD6MBWHzagAwb9vxduXzVWx6Q77DUHLxvIebSY6+enL+Ri6KzSZYj0IBOFifA26wfpJPZnWKLUh3vwx1LyVh/g==}
-    engines: {node: '>=12.22 <13 || >=14.17 <15 || >=16.4 <17 || >=17'}
+  /ava/5.1.1:
+    resolution: {integrity: sha512-od1CWgWVIKZSdEc1dhQWhbsd6KBs0EYjek7eqZNGPvy+NyC9Q1bXixcadlgOXwDG9aM0zLMQZwRXfe9gMb1LQQ==}
+    engines: {node: '>=14.19 <15 || >=16.15 <17 || >=18'}
     hasBin: true
     peerDependencies:
       '@ava/typescript': '*'
@@ -3276,17 +3282,17 @@ packages:
       '@ava/typescript':
         optional: true
     dependencies:
-      acorn: 8.7.0
+      acorn: 8.8.2
       acorn-walk: 8.2.0
-      ansi-styles: 6.1.0
+      ansi-styles: 6.2.1
       arrgv: 1.0.2
       arrify: 3.0.0
       callsites: 4.0.0
       cbor: 8.1.0
-      chalk: 5.0.0
+      chalk: 5.2.0
       chokidar: 3.5.3
       chunkd: 2.0.1
-      ci-info: 3.3.0
+      ci-info: 3.7.1
       ci-parallel-vars: 1.0.1
       clean-yaml-object: 0.1.0
       cli-truncate: 3.1.0
@@ -3294,12 +3300,12 @@ packages:
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
-      debug: 4.3.3
-      del: 6.0.0
-      emittery: 0.10.1
-      figures: 4.0.0
-      globby: 13.1.1
-      ignore-by-default: 2.0.0
+      debug: 4.3.4
+      del: 7.0.0
+      emittery: 1.0.1
+      figures: 5.0.0
+      globby: 13.1.3
+      ignore-by-default: 2.1.0
       indent-string: 5.0.0
       is-error: 2.2.2
       is-plain-object: 5.0.0
@@ -3308,19 +3314,19 @@ packages:
       mem: 9.0.2
       ms: 2.1.3
       p-event: 5.0.1
-      p-map: 5.3.0
+      p-map: 5.5.0
       picomatch: 2.3.1
       pkg-conf: 4.0.0
       plur: 5.1.0
-      pretty-ms: 7.0.1
+      pretty-ms: 8.0.0
       resolve-cwd: 3.0.0
       slash: 3.0.0
-      stack-utils: 2.0.5
+      stack-utils: 2.0.6
       strip-ansi: 7.0.1
       supertap: 3.0.1
-      temp-dir: 2.0.0
-      write-file-atomic: 4.0.1
-      yargs: 17.3.1
+      temp-dir: 3.0.0
+      write-file-atomic: 5.0.0
+      yargs: 17.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3685,7 +3691,7 @@ packages:
       clone-response: 1.0.2
       get-stream: 5.2.0
       http-cache-semantics: 4.1.0
-      keyv: 4.0.3
+      keyv: 4.5.2
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.0
@@ -3788,8 +3794,8 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /chalk/5.0.0:
-    resolution: {integrity: sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==}
+  /chalk/5.2.0:
+    resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
@@ -3888,6 +3894,11 @@ packages:
     resolution: {integrity: sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==}
     dev: true
 
+  /ci-info/3.7.1:
+    resolution: {integrity: sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==}
+    engines: {node: '>=8'}
+    dev: true
+
   /ci-parallel-vars/1.0.1:
     resolution: {integrity: sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==}
     dev: true
@@ -3909,7 +3920,7 @@ packages:
     dev: true
 
   /clean-yaml-object/0.1.0:
-    resolution: {integrity: sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=}
+    resolution: {integrity: sha512-3yONmlN9CSAkzNwnRCiJQ7Q2xK5mWuEfL3PuTZcAUzhObbXsfsnMptJzXwz93nc5zn9V9TwCVMmV7w4xsm43dw==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -3945,6 +3956,15 @@ packages:
 
   /cliui/7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /cliui/8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -4239,7 +4259,7 @@ packages:
     dev: true
 
   /currently-unhandled/0.4.1:
-    resolution: {integrity: sha1-mI3zP+qxke95mmE2nddsF635V+o=}
+    resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
     engines: {node: '>=0.10.0'}
     dependencies:
       array-find-index: 1.0.2
@@ -4288,6 +4308,18 @@ packages:
 
   /debug/4.3.3:
     resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: true
+
+  /debug/4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -4392,8 +4424,8 @@ packages:
       clone: 1.0.4
     dev: true
 
-  /defer-to-connect/2.0.0:
-    resolution: {integrity: sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==}
+  /defer-to-connect/2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
 
   /define-properties/1.1.3:
@@ -4415,6 +4447,20 @@ packages:
       p-map: 4.0.0
       rimraf: 3.0.2
       slash: 3.0.0
+    dev: true
+
+  /del/7.0.0:
+    resolution: {integrity: sha512-tQbV/4u5WVB8HMJr08pgw0b6nG4RGt/tj+7Numvq+zqcvUFeMaIWWOUFltiU+6go8BSO2/ogsB4EasDaj0y68Q==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      globby: 13.1.3
+      graceful-fs: 4.2.10
+      is-glob: 4.0.3
+      is-path-cwd: 3.0.0
+      is-path-inside: 4.0.0
+      p-map: 5.5.0
+      rimraf: 3.0.2
+      slash: 4.0.0
     dev: true
 
   /delayed-stream/1.0.0:
@@ -4611,14 +4657,14 @@ packages:
     resolution: {integrity: sha512-JNEmcYl3mk1tGQmy0EvL5eik/CKSBuzAyGP0QFdG6LIgxQe3II0BL1m2zKc2MZMf3uGqHWE1TFddJML0RpjSHQ==}
     dev: true
 
-  /emittery/0.10.1:
-    resolution: {integrity: sha512-OBSS9uVXbpgqEGq2V5VnpfCu9vSnfiR9eYVJmxFYToNIcWRHkM4BAFbJe/PWjf/pQdEL7OPxd2jOW/bJiyX7gg==}
-    engines: {node: '>=12'}
-    dev: true
-
   /emittery/0.8.1:
     resolution: {integrity: sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==}
     engines: {node: '>=10'}
+    dev: true
+
+  /emittery/1.0.1:
+    resolution: {integrity: sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /emoji-regex/8.0.0:
@@ -4708,7 +4754,7 @@ packages:
     dev: true
 
   /escape-string-regexp/1.0.5:
-    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
     dev: true
 
@@ -5101,12 +5147,12 @@ packages:
       escape-string-regexp: 1.0.5
     dev: true
 
-  /figures/4.0.0:
-    resolution: {integrity: sha512-VnYcWq6H6F0qDN0QnorznBr0abEovifzUokmnezpKZBUbDmbLAt7LMryOp1TKFVxLxyNYkxEkCEADZR58U9oSw==}
-    engines: {node: '>=12'}
+  /figures/5.0.0:
+    resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
+    engines: {node: '>=14'}
     dependencies:
       escape-string-regexp: 5.0.0
-      is-unicode-supported: 1.1.0
+      is-unicode-supported: 1.3.0
     dev: true
 
   /file-entry-cache/6.0.1:
@@ -5483,8 +5529,8 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /globby/13.1.1:
-    resolution: {integrity: sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==}
+  /globby/13.1.3:
+    resolution: {integrity: sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
@@ -5584,6 +5630,10 @@ packages:
       timed-out: 4.0.1
       url-parse-lax: 3.0.0
       url-to-options: 1.0.1
+    dev: true
+
+  /graceful-fs/4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
     dev: true
 
   /graceful-fs/4.2.4:
@@ -5757,7 +5807,7 @@ packages:
     engines: {node: '>=10.19.0'}
     dependencies:
       quick-lru: 5.1.1
-      resolve-alpn: 1.0.0
+      resolve-alpn: 1.2.1
 
   /https-proxy-agent/5.0.0:
     resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
@@ -5799,8 +5849,8 @@ packages:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: true
 
-  /ignore-by-default/2.0.0:
-    resolution: {integrity: sha512-+mQSgMRiFD3L3AOxLYOCxjIq4OnAmo5CIuC+lj5ehCJcPtV++QacEV7FdpzvYxH6DaOySWzQU6RR0lPLy37ckA==}
+  /ignore-by-default/2.1.0:
+    resolution: {integrity: sha512-yiWd4GVmJp0Q6ghmM2B/V3oZGRmjrKLXvHR3TE1nfoXsmoggllfZUQe74EN0fJdPFZu2NIvNdrMMLm3OsV7Ohw==}
     engines: {node: '>=10 <11 || >=12 <13 || >=14'}
     dev: true
 
@@ -6043,9 +6093,19 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /is-path-cwd/3.0.0:
+    resolution: {integrity: sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /is-path-inside/3.0.2:
     resolution: {integrity: sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /is-path-inside/4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
     dev: true
 
   /is-plain-obj/1.1.0:
@@ -6111,8 +6171,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /is-unicode-supported/1.1.0:
-    resolution: {integrity: sha512-lDcxivp8TJpLG75/DpatAqNzOpDPSpED8XNtrpBHTdQ2InQ1PbW78jhwSxyxhhu+xbVSast2X38bwj8atwoUQA==}
+  /is-unicode-supported/1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
     dev: true
 
@@ -6873,7 +6933,7 @@ packages:
     dev: true
 
   /js-string-escape/1.0.1:
-    resolution: {integrity: sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=}
+    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
     dev: true
 
@@ -6992,7 +7052,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
     dev: true
 
   /jsonparse/1.3.1:
@@ -7024,8 +7084,8 @@ packages:
       json-buffer: 3.0.0
     dev: true
 
-  /keyv/4.0.3:
-    resolution: {integrity: sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==}
+  /keyv/4.5.2:
+    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
     dependencies:
       json-buffer: 3.0.1
 
@@ -7902,7 +7962,7 @@ packages:
     engines: {node: '>=8'}
 
   /p-defer/1.0.0:
-    resolution: {integrity: sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=}
+    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
     engines: {node: '>=4'}
     dev: true
 
@@ -7984,8 +8044,8 @@ packages:
       aggregate-error: 3.1.0
     dev: true
 
-  /p-map/5.3.0:
-    resolution: {integrity: sha512-SRbIQFoLYNezHkqZslqeg963HYUtqOrfMCxjNrFOpJ19WTYuq26rQoOXeX8QQiMLUlLqdYV/7PuDsdYJ7hLE1w==}
+  /p-map/5.5.0:
+    resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
     engines: {node: '>=12'}
     dependencies:
       aggregate-error: 4.0.0
@@ -8083,6 +8143,11 @@ packages:
   /parse-ms/2.1.0:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
+    dev: true
+
+  /parse-ms/3.0.0:
+    resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
+    engines: {node: '>=12'}
     dev: true
 
   /parse5/6.0.1:
@@ -8319,6 +8384,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       parse-ms: 2.1.0
+    dev: true
+
+  /pretty-ms/8.0.0:
+    resolution: {integrity: sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      parse-ms: 3.0.0
     dev: true
 
   /printj/1.1.2:
@@ -8597,12 +8669,12 @@ packages:
     dev: true
 
   /require-directory/2.1.1:
-    resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /resolve-alpn/1.0.0:
-    resolution: {integrity: sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==}
+  /resolve-alpn/1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
   /resolve-cwd/3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -9023,7 +9095,7 @@ packages:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
     dependencies:
-      ansi-styles: 6.1.0
+      ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
     dev: true
 
@@ -9169,7 +9241,7 @@ packages:
     dev: true
 
   /sprintf-js/1.0.3:
-    resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
 
   /ssh2/1.5.0:
@@ -9216,6 +9288,13 @@ packages:
 
   /stack-utils/2.0.5:
     resolution: {integrity: sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 2.0.0
+    dev: true
+
+  /stack-utils/2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
     dependencies:
       escape-string-regexp: 2.0.0
@@ -9504,9 +9583,9 @@ packages:
       - supports-color
     dev: true
 
-  /temp-dir/2.0.0:
-    resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
-    engines: {node: '>=8'}
+  /temp-dir/3.0.0:
+    resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /terminal-link/2.1.1:
@@ -9550,7 +9629,7 @@ packages:
     dev: true
 
   /time-zone/1.0.0:
-    resolution: {integrity: sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=}
+    resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
     dev: true
 
@@ -10155,9 +10234,9 @@ packages:
       typedarray-to-buffer: 3.1.5
     dev: true
 
-  /write-file-atomic/4.0.1:
-    resolution: {integrity: sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
+  /write-file-atomic/5.0.0:
+    resolution: {integrity: sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
@@ -10225,6 +10304,11 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /yargs-parser/21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /yargs/16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
@@ -10249,6 +10333,19 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.5
       yargs-parser: 21.0.0
+    dev: true
+
+  /yargs/17.6.2:
+    resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.5
+      yargs-parser: 21.1.1
     dev: true
 
   /yarn-install/1.0.0:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "b567a75507adfc01f2e560e13f843685c8ada935",
+  "pnpmShrinkwrapHash": "7544ccbaa7ab486e61cd4c28903876c14cd070a3",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/tracker-core/package.json
+++ b/libraries/tracker-core/package.json
@@ -56,7 +56,7 @@
     "@types/uuid": "^8.3.2",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
-    "ava": "~4.1.0",
+    "ava": "~5.1.1",
     "eslint": "~8.11.0",
     "jest-standard-reporter": "~2.0.0",
     "rollup": "~2.70.1",

--- a/trackers/node-tracker/README.md
+++ b/trackers/node-tracker/README.md
@@ -31,17 +31,11 @@ npm install @snowplow/node-tracker
 Initialize your tracker with your desired configuration:
 
 ```js
-import { tracker, gotEmitter } from '@snowplow/node-tracker';
-
-const e = gotEmitter(
-  'collector.mydomain.net', // Collector endpoint
-  snowplow.HttpProtocol.HTTPS, // Optionally specify a method - https is the default
-  8080, // Optionally specify a port
-  snowplow.HttpMethod.POST, // Method - defaults to GET
-  5 // Only send events once n are buffered. Defaults to 1 for GET requests and 10 for POST requests.
+import { newTracker } from '@snowplow/node-tracker';
+const t = newTracker(
+  { namespace: 'myTracker', appId: 'myApp', encodeBase64: false }, 
+  { endpoint:  'collector.mydomain.net', port: 8080, bufferSize: 5 }
 );
-
-const t = tracker(e, 'myTracker', 'myApp', false);
 ```
 
 Then use the `track` function from this package, along with the `buildX` functions to send events to your configured emitters:
@@ -73,7 +67,7 @@ const eventJson = {
   },
 };
 
-track.track(buildSelfDescribingEvent({ event: eventJson }), context);
+t.track(buildSelfDescribingEvent({ event: eventJson }), context);
 ```
 
 To enable success and failure callback debugging, run your application with `NODE_DEBUG=snowplow`.

--- a/trackers/node-tracker/docs/markdown/node-tracker.md
+++ b/trackers/node-tracker/docs/markdown/node-tracker.md
@@ -35,7 +35,7 @@
 |  [buildSocialInteraction(event)](./node-tracker.buildsocialinteraction.md) | Build a Social Interaction Event Social tracking will be used to track the way users interact with Facebook, Twitter and Google + widgets e.g. to capture “like this” or “tweet this” events. |
 |  [buildStructEvent(event)](./node-tracker.buildstructevent.md) | Build a Structured Event A classic style of event tracking, allows for easier movement between analytics systems. A loosely typed event, creating a Self Describing event is preferred, but useful for interoperability. |
 |  [gotEmitter(endpoint, protocol, port, method, bufferSize, retry, cookieJar, callback, agents)](./node-tracker.gotemitter.md) | Create an emitter object, which uses the <code>got</code> library, that will send events to a collector |
-|  [tracker(emitters, namespace, appId, encodeBase64)](./node-tracker.tracker.md) | Snowplow Node.js Tracker |
+|  [newTracker(emitters, namespace, appId, encodeBase64)](./node-tracker.tracker.md) | Snowplow Node.js Tracker |
 
 ## Interfaces
 

--- a/trackers/node-tracker/docs/node-tracker.api.md
+++ b/trackers/node-tracker/docs/node-tracker.api.md
@@ -235,25 +235,6 @@ export interface FormSubmissionEvent {
 }
 
 // @public
-export function gotEmitter(endpoint: string, protocol?: HttpProtocol, port?: number, method?: HttpMethod, bufferSize?: number, retry?: number | Partial<RequiredRetryOptions>, cookieJar?: PromiseCookieJar | ToughCookieJar, callback?: (error?: RequestError, response?: Response<string>) => void, agents?: Agents): Emitter;
-
-// @public (undocumented)
-export enum HttpMethod {
-    // (undocumented)
-    GET = "get",
-    // (undocumented)
-    POST = "post"
-}
-
-// @public (undocumented)
-export enum HttpProtocol {
-    // (undocumented)
-    HTTP = "http",
-    // (undocumented)
-    HTTPS = "https"
-}
-
-// @public
 export interface LinkClickEvent {
     elementClasses?: Array<string>;
     elementContent?: string;
@@ -261,6 +242,12 @@ export interface LinkClickEvent {
     elementTarget?: string;
     targetUrl: string;
 }
+
+// Warning: (ae-forgotten-export) The symbol "TrackerConfiguration" needs to be exported by the entry point index.module.d.ts
+// Warning: (ae-forgotten-export) The symbol "EmitterConfiguration" needs to be exported by the entry point index.module.d.ts
+//
+// @public (undocumented)
+export function newTracker(trackerConfiguration: TrackerConfiguration, emitterConfiguration: EmitterConfiguration | EmitterConfiguration[]): Tracker;
 
 // @public
 export interface PagePingEvent extends PageViewEvent {
@@ -361,9 +348,6 @@ export interface Tracker extends TrackerCore {
     setDomainUserId: (userId: string) => void;
     setNetworkUserId: (userId: string) => void;
 }
-
-// @public
-export function tracker(emitters: Emitter | Array<Emitter>, namespace: string, appId: string, encodeBase64: boolean): Tracker;
 
 // @public (undocumented)
 export const version: string;

--- a/trackers/node-tracker/package.json
+++ b/trackers/node-tracker/package.json
@@ -51,7 +51,7 @@
     "@types/sinon": "~10.0.11",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
-    "ava": "~4.1.0",
+    "ava": "~5.1.1",
     "eslint": "~8.11.0",
     "eslint-plugin-ava": "~13.2.0",
     "nock": "~13.2.4",

--- a/trackers/node-tracker/src/emitter.ts
+++ b/trackers/node-tracker/src/emitter.ts
@@ -35,16 +35,6 @@ export interface Emitter {
   input: (payload: Payload) => void;
 }
 
-export enum HttpProtocol {
-  HTTP = 'http',
-  HTTPS = 'https',
-}
-
-export enum HttpMethod {
-  GET = 'get',
-  POST = 'post',
-}
-
 /**
  * Convert all fields in a payload dictionary to strings
  *

--- a/trackers/node-tracker/src/got_emitter.ts
+++ b/trackers/node-tracker/src/got_emitter.ts
@@ -29,37 +29,48 @@
  */
 
 import util from 'util';
-import got, { Response, RequestError, Agents, RequiredRetryOptions, ToughCookieJar, PromiseCookieJar } from 'got';
+import got, { Response, RequestError, RequiredRetryOptions, PromiseCookieJar, ToughCookieJar, Agents } from 'got';
 import { Payload, version } from '@snowplow/tracker-core';
 
-import { Emitter, HttpProtocol, HttpMethod, preparePayload } from './emitter';
+import { Emitter, preparePayload } from './emitter';
+
+export interface GotEmitterConfiguration {
+  /* The collector URL to which events will be sent */
+  endpoint: string;
+  /* http or https. Defaults to https */
+  protocol?: 'http' | 'https';
+  /* Collector port number */
+  port?: number;
+  /* get or post. Defaults to post */
+  method?: 'get' | 'post';
+  /* Number of events which can be queued before flush is called */
+  bufferSize?: number;
+  /*  Configure the retry policy for got */
+  retry?: number | Partial<RequiredRetryOptions>;
+  /* Add a cookieJar to got */
+  cookieJar?: PromiseCookieJar | ToughCookieJar;
+  /* Callback called after a `got` request following retries */
+  callback?: (error?: RequestError, response?: Response<string>) => void;
+  /* Set new http.Agent and https.Agent objects on `got` requests */
+  agent?: Agents;
+}
 
 /**
  * Create an emitter object, which uses the `got` library, that will send events to a collector
- *
- * @param endpoint - The collector to which events will be sent
- * @param protocol - http or https
- * @param port - The port for requests to use
- * @param method - get or post
- * @param bufferSize - Number of events which can be queued before flush is called
- * @param retry - Configure the retry policy for `got` - https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#retry
- * @param cookieJar - Add a cookieJar to `got` - https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#cookiejar
- * @param callback - Callback called after a `got` request following retries - called with ErrorRequest (https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#errors) and Response (https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#response)
- * @param agents - Set new http.Agent and https.Agent objects on `got` requests - https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#agent
  */
-export function gotEmitter(
-  endpoint: string,
-  protocol: HttpProtocol = HttpProtocol.HTTPS,
-  port?: number,
-  method?: HttpMethod,
-  bufferSize?: number,
-  retry?: number | Partial<RequiredRetryOptions>,
-  cookieJar?: PromiseCookieJar | ToughCookieJar,
-  callback?: (error?: RequestError, response?: Response<string>) => void,
-  agents?: Agents
-): Emitter {
-  const maxBufferLength = bufferSize ?? (method === HttpMethod.GET ? 0 : 10);
-  const path = method === HttpMethod.GET ? '/i' : '/com.snowplowanalytics.snowplow/tp2';
+export function gotEmitter({
+  endpoint,
+  protocol = 'https',
+  port,
+  method = 'post',
+  bufferSize,
+  retry,
+  cookieJar,
+  callback,
+  agent,
+}: GotEmitterConfiguration): Emitter {
+  const maxBufferLength = bufferSize ?? (method === 'get' ? 0 : 10);
+  const path = method === 'get' ? '/i' : '/com.snowplowanalytics.snowplow/tp2';
   const targetUrl = protocol + '://' + endpoint + (port ? ':' + port : '') + path;
   const debuglog = util.debuglog('snowplow');
 
@@ -103,7 +114,7 @@ export function gotEmitter(
       return;
     }
 
-    if (method === HttpMethod.POST) {
+    if (method === 'post') {
       const postJson = {
         schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4',
         data: bufferCopy.map(preparePayload),
@@ -115,9 +126,9 @@ export function gotEmitter(
             'content-type': 'application/json; charset=utf-8',
             'user-agent': `snowplow-nodejs-tracker/${version}`,
           },
-          agent: agents,
-          retry: retry,
-          cookieJar: cookieJar,
+          agent,
+          retry,
+          cookieJar,
         })
         .then(handleSuccess, handleFailure);
     } else {
@@ -128,9 +139,9 @@ export function gotEmitter(
             headers: {
               'user-agent': `snowplow-nodejs-tracker/${version}`,
             },
-            agent: agents,
-            retry: retry,
-            cookieJar: cookieJar,
+            agent,
+            retry,
+            cookieJar,
           })
           .then(handleSuccess, handleFailure);
       }

--- a/trackers/node-tracker/src/index.ts
+++ b/trackers/node-tracker/src/index.ts
@@ -28,9 +28,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export { Emitter, HttpMethod, HttpProtocol } from './emitter';
-export { gotEmitter } from './got_emitter';
-export { tracker, Tracker } from './tracker';
+export { Emitter } from './emitter';
+export { newTracker, Tracker } from './tracker';
 
 export {
   version,

--- a/trackers/node-tracker/src/tracker.ts
+++ b/trackers/node-tracker/src/tracker.ts
@@ -31,6 +31,7 @@
 import { trackerCore, PayloadBuilder, TrackerCore, version } from '@snowplow/tracker-core';
 
 import { Emitter } from './emitter';
+import { gotEmitter, GotEmitterConfiguration } from './got_emitter';
 
 export interface Tracker extends TrackerCore {
   /**
@@ -48,31 +49,40 @@ export interface Tracker extends TrackerCore {
   setNetworkUserId: (userId: string) => void;
 }
 
-/**
- * Snowplow Node.js Tracker
- *
- * @param string - or array emitters The emitter or emitters to which events will be sent
- * @param string - namespace The namespace of the tracker
- * @param string - appId The application ID
- * @param boolean - encodeBase64 Whether unstructured events and custom contexts should be base 64 encoded
- */
-export function tracker(
-  emitters: Emitter | Array<Emitter>,
-  namespace: string,
-  appId: string,
-  encodeBase64: boolean
-): Tracker {
-  let domainUserId: string;
-  let networkUserId: string;
-  let allEmitters: Array<Emitter>;
+interface TrackerConfiguration {
+  /* The namespace of the tracker */
+  namespace: string;
+  /* The application ID */
+  appId: string;
+  /* Whether unstructured events and custom contexts should be base64 encoded. */
+  encodeBase64: boolean;
+}
 
-  if (Array.isArray(emitters)) {
-    allEmitters = emitters;
+type CustomEmitter = {
+  /* Function returning custom Emitter or Emitter[] to be used. If set, other options are irrelevant */
+  customEmitter: () => Emitter | Array<Emitter>;
+};
+
+type EmitterConfiguration = CustomEmitter | GotEmitterConfiguration;
+
+export function newTracker(
+  trackerConfiguration: TrackerConfiguration,
+  emitterConfiguration: EmitterConfiguration | EmitterConfiguration[]
+): Tracker {
+  const { namespace, appId, encodeBase64 = true } = trackerConfiguration;
+
+  let allEmitters: Emitter[] = [];
+  if (Array.isArray(emitterConfiguration)) {
+    allEmitters = emitterConfiguration.map((config) => gotEmitter(config as GotEmitterConfiguration));
+  } else if (emitterConfiguration && emitterConfiguration.hasOwnProperty('customEmitter')) {
+    const customEmitters = (emitterConfiguration as CustomEmitter).customEmitter();
+    allEmitters = Array.isArray(customEmitters) ? customEmitters : [customEmitters];
   } else {
-    allEmitters = [emitters];
+    allEmitters = [gotEmitter(emitterConfiguration as GotEmitterConfiguration)];
   }
 
-  encodeBase64 = encodeBase64 !== false;
+  let domainUserId: string;
+  let networkUserId: string;
 
   const addUserInformation = (payload: PayloadBuilder): void => {
     payload.add('duid', domainUserId);

--- a/trackers/node-tracker/test/got_emitter.ts
+++ b/trackers/node-tracker/test/got_emitter.ts
@@ -31,7 +31,7 @@
 import test from 'ava';
 import sinon from 'sinon';
 import nock from 'nock';
-import { HttpMethod, HttpProtocol, gotEmitter } from '../src/index';
+import { gotEmitter } from '../src/got_emitter';
 
 const endpoint = 'd3rkrsqld9gmqf.cloudfront.net';
 
@@ -46,7 +46,7 @@ nock(new RegExp('https*://' + endpoint))
   .persist()
   .filteringRequestBody(() => '*')
   .post('/com.snowplowanalytics.snowplow/tp2', '*')
-  .reply(200, (_uri, body: Record<string, unknown>) => (body['data'] as Array<unknown>)[0]);
+  .reply(200, (_uri: string, body: Record<string, unknown>) => (body['data'] as Array<unknown>)[0]);
 
 test.before(() => {
   nock.disableNetConnect();
@@ -58,96 +58,72 @@ test.after(() => {
 
 test('gotEmitter should send an HTTP GET request', async (t) => {
   await new Promise((resolve, reject) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      80,
-      HttpMethod.GET,
-      undefined,
-      undefined,
-      undefined,
-      function (error, response) {
+      port: 80,
+      method: 'get',
+      callback: function (error, response) {
         t.regex(response?.body as string, /\/i\?.*a=b.*/);
         if (error) reject(error);
         else resolve(response);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
 });
 
 test('gotEmitter should send an HTTP POST request', async (t) => {
   await new Promise((resolve, reject) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      undefined,
-      HttpMethod.POST,
-      1,
-      undefined,
-      undefined,
-      function (error, response) {
+      bufferSize: 1,
+      callback: function (error, response) {
         t.like(JSON.parse(response?.body as string), { a: 'b' });
         if (error) reject(error);
         else resolve(response);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
 });
 
 test('gotEmitter should send an HTTPS GET request', async (t) => {
   await new Promise((resolve, reject) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      443,
-      HttpMethod.GET,
-      undefined,
-      undefined,
-      undefined,
-      function (error, response) {
+      port: 443,
+      method: 'get',
+      callback: function (error, response) {
         t.regex(response?.body as string, /\/i\?.*a=b.*/);
         if (error) reject(error);
         else resolve(response);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
 });
 
 test('gotEmitter should send an HTTPS POST request', async (t) => {
   await new Promise((resolve, reject) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      undefined,
-      HttpMethod.POST,
-      1,
-      undefined,
-      undefined,
-      function (error, response) {
+      bufferSize: 1,
+      callback: function (error, response) {
         t.like(JSON.parse(response?.body as string), { a: 'b' });
         if (error) reject(error);
         else resolve(response);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
 });
 
 test('gotEmitter should not send requests if the buffer is not full', async (t) => {
   await new Promise((resolve) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      undefined,
-      HttpMethod.POST,
-      undefined,
-      undefined,
-      undefined,
-      () => t.fail('Event unexpectedly emitted')
-    );
+      callback: () => t.fail('Event unexpectedly emitted'),
+    });
     e.input({});
     e.input({});
     e.input({});
@@ -160,16 +136,10 @@ test('gotEmitter should not send requests if the buffer is not full', async (t) 
 
 test('gotEmitter should not send requests if the buffer is empty', async (t) => {
   await new Promise((resolve) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      undefined,
-      HttpMethod.POST,
-      undefined,
-      undefined,
-      undefined,
-      () => t.fail('Event unexpectedly emitted')
-    );
+      callback: () => t.fail('Event unexpectedly emitted'),
+    });
     e.flush();
     setTimeout(() => {
       t.pass();
@@ -183,20 +153,15 @@ test('gotEmitter should add STM querystring parameter when sending POST requests
   const clock = sinon.useFakeTimers(testTime);
 
   await new Promise((resolve, reject) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      undefined,
-      HttpMethod.POST,
-      1,
-      undefined,
-      undefined,
-      function (error, response) {
+      bufferSize: 1,
+      callback: function (error, response) {
         t.like(JSON.parse(response?.body as string), { stm: testTime.toString() });
         if (error) reject(error);
         else resolve(response);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
 
@@ -208,20 +173,16 @@ test('gotEmitter should add STM querystring parameter when sending GET requests'
   const clock = sinon.useFakeTimers(testTime);
 
   await new Promise((resolve, reject) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      443,
-      HttpMethod.GET,
-      undefined,
-      undefined,
-      undefined,
-      function (error, response) {
+      port: 443,
+      method: 'get',
+      callback: function (error, response) {
         t.regex(response?.body as string, new RegExp(`/i?.*stm=${testTime}.*`));
         if (error) reject(error);
         else resolve(response);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
   clock.restore();
@@ -230,16 +191,11 @@ test('gotEmitter should add STM querystring parameter when sending GET requests'
 test('gotEmitter should handle undefined callbacks on success situation', async (t) => {
   await new Promise((resolve) => {
     t.notThrows(() => {
-      const e = gotEmitter(
+      const e = gotEmitter({
         endpoint,
-        HttpProtocol.HTTPS,
-        443,
-        HttpMethod.GET,
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      );
+        port: 443,
+        method: 'get',
+      });
       e.input({ a: 'b' });
     });
     resolve(true);
@@ -249,7 +205,7 @@ test('gotEmitter should handle undefined callbacks on success situation', async 
 test('gotEmitter should handle undefined callbacks on failure situation', async (t) => {
   await new Promise((resolve) => {
     t.notThrows(() => {
-      const e = gotEmitter('invalid-url', HttpProtocol.HTTPS, 443, HttpMethod.POST, 1, undefined, undefined, undefined);
+      const e = gotEmitter({ endpoint: 'invalid-url', port: 443, bufferSize: 1 });
       e.input({ a: 'b' });
     });
     resolve(true);
@@ -259,18 +215,14 @@ test('gotEmitter should handle undefined callbacks on failure situation', async 
 test('gotEmitter should catch error in success situation', async (t) => {
   await new Promise((resolve) => {
     t.notThrows(() => {
-      const e = gotEmitter(
+      const e = gotEmitter({
         endpoint,
-        HttpProtocol.HTTPS,
-        443,
-        HttpMethod.GET,
-        undefined,
-        undefined,
-        undefined,
-        function () {
+        port: 443,
+        method: 'get',
+        callback: function () {
           throw new Error('test error');
-        }
-      );
+        },
+      });
       e.input({ a: 'b' });
     });
     resolve(true);
@@ -280,18 +232,14 @@ test('gotEmitter should catch error in success situation', async (t) => {
 test('gotEmitter should catch error in error situation', async (t) => {
   await new Promise((resolve) => {
     t.notThrows(() => {
-      const e = gotEmitter(
-        'invalid-url',
-        HttpProtocol.HTTPS,
-        443,
-        HttpMethod.POST,
-        1,
-        undefined,
-        undefined,
-        function () {
+      const e = gotEmitter({
+        endpoint: 'invalid-url',
+        port: 443,
+        bufferSize: 1,
+        callback: function () {
           throw new Error('test error');
-        }
-      );
+        },
+      });
       e.input({ a: 'b' });
     });
     resolve(true);
@@ -300,41 +248,33 @@ test('gotEmitter should catch error in error situation', async (t) => {
 
 test('gotEmitter should pass response in success situation', async (t) => {
   await new Promise((resolve, reject) => {
-    const e = gotEmitter(
+    const e = gotEmitter({
       endpoint,
-      HttpProtocol.HTTPS,
-      443,
-      HttpMethod.GET,
-      undefined,
-      undefined,
-      undefined,
-      function (error, response) {
+      port: 443,
+      method: 'get',
+      callback: function (error, response) {
         t.falsy(error);
         t.truthy(response);
         if (error) reject(error);
         else resolve(response);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
 });
 
 test('gotEmitter should pass error in error situation', async (t) => {
   await new Promise((resolve) => {
-    const e = gotEmitter(
-      'invalid-url',
-      HttpProtocol.HTTPS,
-      443,
-      HttpMethod.POST,
-      1,
-      undefined,
-      undefined,
-      function (error, response) {
+    const e = gotEmitter({
+      endpoint: 'invalid-url',
+      port: 443,
+      bufferSize: 1,
+      callback: function (error, response) {
         t.truthy(error);
         t.falsy(response);
         resolve(error);
-      }
-    );
+      },
+    });
     e.input({ a: 'b' });
   });
 });


### PR DESCRIPTION
Node.js tracker API revision:

## API revision
This is a v4 revision of the Node.js API. 

**From**
```ts
function tracker( 
  emitters: Emitter | Array<Emitter>, 
  namespace: string, 
  appId: string, 
  encodeBase64: boolean )
: Tracker
```
**To**
```ts
function tracker(
  trackerConfiguration: NodejsTrackerConfiguration,
  emitterConfiguration: NodejsEmitterConfiguration
): Tracker 
```

It mainly removes the need to initialize the `gotEmitter` separately and now allows all the available options under the `NodejsEmitterConfiguration` options.
If clients want to initialize a different or more than one emitter, they can use the `customEmitter` option.

```ts
// v3
import { tracker, gotEmitter } from '@snowplow/node-tracker';

const e = gotEmitter(
  'collector.mydomain.net', // Collector endpoint
  snowplow.HttpProtocol.HTTPS,
  snowplow.HttpMethod.POST
);

const t = tracker(e, 'myTracker', 'myApp', false);

// v4
import { tracker } from '@snowplow/node-tracker';
const t = tracker(
  { namespace: 'myTracker', appId: 'myApp', encodeBase64: false }, 
  { endpoint:  'collector.mydomain.net' }
);

// v4 multiple (got)emitters
import { tracker } from '@snowplow/node-tracker';
const t = tracker(
  { namespace: 'myTracker', appId: 'myApp', encodeBase64: false }, 
  [ { endpoint:  'collector.mydomain.net' } ,  { endpoint:  'collector.mydomain.net' } ]
);

// v4 custom emitter
import { tracker } from '@snowplow/node-tracker';
const t = tracker(
  { namespace: 'myTracker', appId: 'myApp', encodeBase64: false }, 
  { customEmitter: () => (/* Return custom emitter/s */) }
);
```

## Exposed fields
- `gotEmitter` is no longer exported.
- Extraneous interfaces e.g. HTTPMethod are no longer exported.

## Notes
- Default configuration changes
  - Protocol defaults to `https`
  - Method defaults to `post`
- Some TS magic to only allow `customEmitter` when available and not other options, to avoid confusion.
- Upgrade ava to @5