### PR TITLE
Revise default plugins included on the JavaScript tracker

### DIFF
--- a/common/changes/@snowplow/browser-plugin-browser-features/feature-revise-default-plugins_2023-02-06-13-02.json
+++ b/common/changes/@snowplow/browser-plugin-browser-features/feature-revise-default-plugins_2023-02-06-13-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-browser-features",
+      "comment": "Add deprecation warning",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-browser-features"
+}

--- a/common/changes/@snowplow/browser-plugin-consent/feature-revise-default-plugins_2023-02-06-08-43.json
+++ b/common/changes/@snowplow/browser-plugin-consent/feature-revise-default-plugins_2023-02-06-08-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-consent",
+      "comment": "Add deprecation warning",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-consent"
+}

--- a/common/changes/@snowplow/browser-plugin-ecommerce/feature-revise-default-plugins_2023-02-06-08-43.json
+++ b/common/changes/@snowplow/browser-plugin-ecommerce/feature-revise-default-plugins_2023-02-06-08-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-ecommerce",
+      "comment": "Add deprecation warning",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ecommerce"
+}

--- a/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/feature-revise-default-plugins_2023-02-06-13-02.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/feature-revise-default-plugins_2023-02-06-13-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-enhanced-ecommerce",
+      "comment": "Add deprecation warning",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely/feature-revise-default-plugins_2023-02-06-13-02.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely/feature-revise-default-plugins_2023-02-06-13-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-optimizely",
+      "comment": "Add deprecation warning",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely"
+}

--- a/common/changes/@snowplow/javascript-tracker/feature-revise-default-plugins_2023-02-06-08-43.json
+++ b/common/changes/@snowplow/javascript-tracker/feature-revise-default-plugins_2023-02-06-08-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Revise default plugins",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/plugins/browser-plugin-browser-features/README.md
+++ b/plugins/browser-plugin-browser-features/README.md
@@ -3,6 +3,10 @@
 [![npm version][npm-image]][npm-url]
 [![License][license-image]](LICENSE)
 
+<h3>⚠️ This package is deprecated ⚠️</h3>
+
+---
+
 Browser Plugin to be used with `@snowplow/browser-tracker`.
 
 Adds Browser Features to your Snowplow tracking. Identifies available MIME Types.

--- a/plugins/browser-plugin-consent/README.md
+++ b/plugins/browser-plugin-consent/README.md
@@ -3,6 +3,10 @@
 [![npm version][npm-image]][npm-url]
 [![License][license-image]](LICENSE)
 
+<h3>⚠️ This package is deprecated, please use <a href="https://www.npmjs.com/package/@snowplow/browser-plugin-enhanced-consent">@snowplow/browser-plugin-enhanced-consent</a> instead. ⚠️</h3>
+
+---
+
 Browser Plugin to be used with `@snowplow/browser-tracker`.
 
 Adds consent information to your Snowplow tracking.

--- a/plugins/browser-plugin-ecommerce/README.md
+++ b/plugins/browser-plugin-ecommerce/README.md
@@ -3,6 +3,10 @@
 [![npm version][npm-image]][npm-url]
 [![License][license-image]](LICENSE)
 
+<h3>⚠️ This package is deprecated, please use <a href="https://www.npmjs.com/package/@snowplow/browser-plugin-snowplow-ecommerce">@snowplow/browser-plugin-snowplow-ecommerce</a> instead. ⚠️</h3>
+
+---
+
 Browser Plugin to be used with `@snowplow/browser-tracker`.
 
 Adds ecommerce events to your Snowplow tracking.

--- a/plugins/browser-plugin-enhanced-ecommerce/README.md
+++ b/plugins/browser-plugin-enhanced-ecommerce/README.md
@@ -3,6 +3,10 @@
 [![npm version][npm-image]][npm-url]
 [![License][license-image]](LICENSE)
 
+<h3>⚠️ This package is deprecated, please use <a href="https://www.npmjs.com/package/@snowplow/browser-plugin-snowplow-ecommerce">@snowplow/browser-plugin-snowplow-ecommerce</a> instead. ⚠️</h3>
+
+---
+
 Browser Plugin to be used with `@snowplow/browser-tracker`.
 
 Adds enhanced ecommerce events to your Snowplow tracking.

--- a/plugins/browser-plugin-optimizely/README.md
+++ b/plugins/browser-plugin-optimizely/README.md
@@ -3,6 +3,10 @@
 [![npm version][npm-image]][npm-url]
 [![License][license-image]](LICENSE)
 
+<h3>⚠️ This package is deprecated ⚠️</h3>
+
+---
+
 Browser Plugin to be used with `@snowplow/browser-tracker`.
 
 Adds Optimizely Classic contexts to your Snowplow tracking.

--- a/trackers/javascript-tracker/tracker.config.ts
+++ b/trackers/javascript-tracker/tracker.config.ts
@@ -28,23 +28,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export const performanceTiming = true;
+/* By default included plugins in sp.js */
+export const adTracking = true;
+export const clientHints = true;
+export const enhancedConsent = true;
+export const errorTracking = true;
+export const formTracking = true;
 export const gaCookies = true;
 export const geolocation = true;
-export const optimizelyX = true;
-export const clientHints = true;
-export const consent = true;
 export const linkClickTracking = true;
-export const formTracking = true;
-export const errorTracking = true;
-export const timezone = true;
-export const ecommerce = true;
-export const enhancedEcommerce = true;
-export const adTracking = true;
+export const performanceTiming = true;
 export const siteTracking = true;
-export const snowplowEcommerceTracking = false;
-export const optimizely = false;
-export const browserFeatures = false;
+export const snowplowEcommerceTracking = true;
+export const timezone = true;
+
+/* By default excluded plugins in sp.js */
 export const mediaTracking = false;
+export const optimizelyX = false;
 export const youtubeTracking = false;
-export const enhancedConsent = false;
+
+/* Deprecated */
+export const browserFeatures = false;
+export const consent = false;
+export const ecommerce = false;
+export const enhancedEcommerce = false;
+export const optimizely = false;


### PR DESCRIPTION
Revise the 'by default' included plugins on `sp.js`. _(Reduction is about 1.5kb)_


- Remove by default:
  - ecommerce
  - enhanced ecommerce
  - consent
  - optimizelyX
- Add by default
  - enhanced consent
  - snowplow ecommerce
- Add deprecation warning on ecommerce/consent packages since they will be replaced by `snowplow ecommerce` and `enhanced consent`.


_This will be paired with changes in the docs as well_