### PR TITLE
Add files attribute for npm publishing in JavaScript tracker 

### DIFF
--- a/common/changes/@snowplow/javascript-tracker/fix-1146-js-tracker-add-files-attribute-for-npm_2023-02-07-09-57.json
+++ b/common/changes/@snowplow/javascript-tracker/fix-1146-js-tracker-add-files-attribute-for-npm_2023-02-07-09-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Add files attribute for npm publishing",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -25,6 +25,9 @@
     "Paul Boocock"
   ],
   "browser": "dist/sp.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
     "docker:micro": "docker pull snowplow/snowplow-micro:1.2.1",


### PR DESCRIPTION
Allow only `dist` folder to be published on npm.
More info on #1146 

close #1146 