### PR TITLE
Add refund tracking capability to the snowplow-ecommerce plugin

### DIFF
--- a/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/feature-1153-add-snowplow-ecommerce-refund-tracking_2023-02-14-08-21.json
+++ b/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/feature-1153-add-snowplow-ecommerce-refund-tracking_2023-02-14-08-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-snowplow-ecommerce",
+      "comment": "Add refund tracking capability to the snowplow-ecommerce plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
+}

--- a/plugins/browser-plugin-snowplow-ecommerce/src/api.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/api.ts
@@ -7,6 +7,7 @@ import {
   PAGE_SCHEMA,
   PRODUCT_SCHEMA,
   PROMO_SCHEMA,
+  REFUND_SCHEMA,
   TRANSACTION_SCHEMA,
   USER_SCHEMA,
 } from './schemata';
@@ -19,6 +20,7 @@ import {
   Page as PageContext,
   Product,
   Promotion,
+  Refund,
   Transaction,
   User as UserContext,
 } from './types';
@@ -216,6 +218,25 @@ export function trackTransaction(
 
   dispatchToTrackersInCollection(trackers, _trackers, (t) => {
     t.core.track(buildEcommerceActionEvent({ type: 'transaction' }), context, timestamp);
+  });
+}
+
+/**
+ * Track a refund event
+ *
+ * @param refund - The refund information
+ * @param trackers - The tracker identifiers which the event will be sent to
+ */
+export function trackRefund(
+  refund: Refund & CommonEcommerceEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { context = [], timestamp, products = [], ...refundAttributes } = refund;
+  products.forEach((product) => context.push({ schema: PRODUCT_SCHEMA, data: product }));
+  context.push({ schema: REFUND_SCHEMA, data: { ...refundAttributes } });
+
+  dispatchToTrackersInCollection(trackers, _trackers, (t) => {
+    t.core.track(buildEcommerceActionEvent({ type: 'refund' }), context, timestamp);
   });
 }
 

--- a/plugins/browser-plugin-snowplow-ecommerce/src/schemata.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/schemata.ts
@@ -7,3 +7,4 @@ export const PAGE_SCHEMA = 'iglu:com.snowplowanalytics.snowplow.ecommerce/page/j
 export const USER_SCHEMA = 'iglu:com.snowplowanalytics.snowplow.ecommerce/user/jsonschema/1-0-0';
 export const TRANSACTION_SCHEMA = 'iglu:com.snowplowanalytics.snowplow.ecommerce/transaction/jsonschema/1-0-0';
 export const PROMO_SCHEMA = 'iglu:com.snowplowanalytics.snowplow.ecommerce/promotion/jsonschema/1-0-0';
+export const REFUND_SCHEMA = 'iglu:com.snowplowanalytics.snowplow.ecommerce/refund/jsonschema/1-0-0';

--- a/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
@@ -16,7 +16,8 @@ export interface Action {
     | 'promo_click'
     | 'promo_view'
     | 'checkout_step'
-    | 'transaction';
+    | 'transaction'
+    | 'refund';
 
   /**
    * You can add a name for the list presented to the user.
@@ -234,6 +235,33 @@ export interface Transaction {
   credit_order?: boolean;
   /**
    * Array of products on the transaction from cart
+   */
+  products?: Product[];
+}
+
+/**
+ * Type/Schema for a refund entity in Ecommerce
+ */
+export interface Refund {
+  /**
+   * The ID of the transaction.
+   */
+  transaction_id: string;
+  /**
+   * The currency in which the product is being priced (ISO 4217).
+   */
+  currency: string;
+  /**
+   * The monetary amount refunded.
+   */
+  refund_amount: number;
+  /**
+   * Reason for refunding the whole or part of the transaction.
+   */
+  refund_reason?: string | null;
+  /**
+   * Array of products on the refund. This is used when specific products are refunded.
+   * If not present, the whole transaction and products will be marked as refunded.
    */
   products?: Product[];
 }


### PR DESCRIPTION
Add refund capability to the `snowplow-ecommerce` plugin.

_Blocked until the refund schema is deployed_

close #1153 

