### PR TITLE
Add touchend and touchstart events on page ping calculation (close #479)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/feature-478-add-touch-listeners-on-page-pings_2023-02-24-09-22.json
+++ b/common/changes/@snowplow/browser-tracker-core/feature-478-add-touch-listeners-on-page-pings_2023-02-24-09-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add touchmove and touchstart events on page ping calculation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -939,7 +939,17 @@ export function Tracker(
 
         // Add event handlers; cross-browser compatibility here varies significantly
         // @see http://quirksmode.org/dom/events
-        const documentHandlers = ['click', 'mouseup', 'mousedown', 'mousemove', 'keypress', 'keydown', 'keyup'];
+        const documentHandlers = [
+          'click',
+          'mouseup',
+          'mousedown',
+          'mousemove',
+          'keypress',
+          'keydown',
+          'keyup',
+          'touchend',
+          'touchstart',
+        ];
         const windowHandlers = ['resize', 'focus', 'blur'];
         const listener =
           (_: Document | Window, handler = activityHandler) =>


### PR DESCRIPTION
Adding the `touchend` and `touchstart` events as triggers for page pings.

The difference can be seen in the videos below:

## Old behaviour
https://user-images.githubusercontent.com/15251081/221143374-3264f825-94b1-462a-875e-97ba643756c9.mp4


## New behaviour with touch
https://user-images.githubusercontent.com/15251081/221143353-8afec3e8-6063-4ce4-93db-36cbeec7ff08.mp4
