### PR TITLE
Fix generating domain user ID when clearing user data with anonymous tracking (close #1164)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-1164-clearing_domain_userid_2023-03-07-17-26.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1164-clearing_domain_userid_2023-03-07-17-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Fix generating domain user ID when clearing user data with anonymous tracking (#1164)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -606,7 +606,7 @@ export function Tracker(
         memorizedVisitCount = 1;
       }
       if (!configuration?.preserveUser) {
-        domainUserId = uuid();
+        domainUserId = configAnonymousTracking ? '' : uuid();
         businessUserId = null;
       }
     }

--- a/libraries/browser-tracker-core/test/tracker/session_data.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/session_data.test.ts
@@ -86,6 +86,15 @@ describe('Tracker API: ', () => {
     expect(tracker?.getDomainSessionIndex()).toEqual(1);
   });
 
+  it('Sets blank domain user id after clearUserData() if anonymous tracking', () => {
+    const tracker = createTracker({
+      anonymousTracking: { withSessionTracking: true },
+    });
+
+    tracker?.clearUserData();
+    expect(tracker?.getDomainUserId()).toEqual('');
+  });
+
   it('Sets correct domain session index anonymous track', () => {
     const tracker = createTracker({ anonymousTracking: true });
     expect(tracker?.getDomainSessionIndex()).toEqual(1);


### PR DESCRIPTION
Issue #1164 

This PR fixes the issue caused by the following scenario:

1. enable anonymous tracking with session tracking
2. clear user data (call `clearUserData({ preserveUser: false })`)
3. track an event

Previously, the tracker would save the `sp_id` cookie with a domain user ID generated in step 2. Although the duid wouldn't be added to the event as a property, the cookie would be present in the request header sent to the collector. Also, having a user ID in the cookie is not desirable when anonymous tracking is enabled.

To fix this, the `clearUserData()` function now sets the memorized domain user ID value to an empty string.