### PR TITLE
Add implicit total_quantity calculation on snowplow ecommerce transac…

### DIFF
--- a/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/feat-implicit-total-quantity-calculation_2023-03-24-17-45.json
+++ b/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/feat-implicit-total-quantity-calculation_2023-03-24-17-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-snowplow-ecommerce",
+      "comment": "Add implicit total_quantity calculation on snowplow ecommerce transaction tracking",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
+}

--- a/plugins/browser-plugin-snowplow-ecommerce/test/events.test.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/test/events.test.ts
@@ -232,8 +232,8 @@ describe('SnowplowEcommercePlugin events', () => {
   });
 
   it('trackTransaction adds the expected "transaction" event to the queue', () => {
-    const productX = { id: '1234', price: 12, currency: 'EUR' };
-    const productY = { id: '12345', price: 25, currency: 'EUR' };
+    const productX = { id: '1234', price: 12, currency: 'EUR', quantity: 4 };
+    const productY = { id: '12345', price: 25, currency: 'EUR', quantity: 1 };
     const transaction = { revenue: 45, currency: 'EUR', transaction_id: '12345', payment_method: 'card' };
     trackTransaction({
       ...transaction,
@@ -256,6 +256,11 @@ describe('SnowplowEcommercePlugin events', () => {
         schema: TRANSACTION_SCHEMA,
       },
     ]);
+
+    /* Expect implicit total_quantity calculation */
+    const emmitedTransaction = context[2].data;
+    expect(emmitedTransaction).toHaveProperty('total_quantity');
+    expect(emmitedTransaction.total_quantity).toEqual(productX.quantity + productY.quantity);
 
     expect(unstructuredEvent).toMatchObject({
       schema: ECOMMERCE_ACTION_SCHEMA,


### PR DESCRIPTION
Add explicit `total_quantity` calculation for the `trackTransaction` API. 

Currently the `total_quantity` on the transaction context is optional. If not passed the event could fail in the pipeline, even if the typing showcases it as optional. 
To make sure this is not the case, when not present,we allow the `total_quantity` to be implicitly calculated from the array of products provided on the transaction.