### PR TITLE
Update GH actions to use Node.js 16 (close #1173)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
       - name: pnpm cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./common/temp/pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}

--- a/.github/workflows/change_check.yml
+++ b/.github/workflows/change_check.yml
@@ -11,17 +11,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
       - name: pnpm cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./common/temp/pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: pnpm cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./common/temp/pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: pnpm cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./common/temp/pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,14 +6,14 @@ jobs:
   security:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: pnpm cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./common/temp/pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}


### PR DESCRIPTION
Upgrade:
- `actions/checkout` to v3
- `actions/setup-node` to v3
- `actions/cache` to v3

Note:
I believe these sources to be trusted enough to not pin a commit SHA, but if anyone believes we should I am adding them in.