### PR TITLE
Fix newTracker typing to accurately return null or undefined (fix #1167)

### DIFF
--- a/common/changes/@snowplow/browser-tracker/fix-1167-correct-newTracker-function-on-browser-tracker_2023-04-17-07-28.json
+++ b/common/changes/@snowplow/browser-tracker/fix-1167-correct-newTracker-function-on-browser-tracker_2023-04-17-07-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Fix newTracker typing to accurately return null or undefined (fix #1167)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -238,10 +238,7 @@ export interface FlushBufferConfiguration {
 export function newSession(trackers?: Array<string>): void;
 
 // @public
-export function newTracker(trackerId: string, endpoint: string): BrowserTracker;
-
-// @public
-export function newTracker(trackerId: string, endpoint: string, configuration: TrackerConfiguration): BrowserTracker;
+export function newTracker(trackerId: string, endpoint: string, configuration?: TrackerConfiguration): BrowserTracker | null | undefined;
 
 // @public
 export interface PageViewEvent {

--- a/trackers/browser-tracker/src/index.ts
+++ b/trackers/browser-tracker/src/index.ts
@@ -48,21 +48,6 @@ const state = typeof window !== 'undefined' ? createSharedState() : undefined;
  *
  * @param trackerId - The tracker id - also known as tracker namespace
  * @param endpoint - Collector endpoint in the form collector.mysite.com
- */
-export function newTracker(trackerId: string, endpoint: string): BrowserTracker;
-/**
- * Initialise a new tracker
- *
- * @param trackerId - The tracker id - also known as tracker namespace
- * @param endpoint - Collector endpoint in the form collector.mysite.com
- * @param configuration - The initialisation options of the tracker
- */
-export function newTracker(trackerId: string, endpoint: string, configuration: TrackerConfiguration): BrowserTracker;
-/**
- * Initialise a new tracker
- *
- * @param trackerId - The tracker id - also known as tracker namespace
- * @param endpoint - Collector endpoint in the form collector.mysite.com
  * @param configuration - The initialisation options of the tracker
  */
 export function newTracker(trackerId: string, endpoint: string, configuration: TrackerConfiguration = {}) {


### PR DESCRIPTION
Fix correct typing issue for `newTracker` possibly returning:
- `null` when a tracker is already initialized with the same tracker id.
- `undefined` when we are not in a browser context.

(close #1167)