### PR TITLE
Fix events ignoring captureEvents config (close #1180)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1180-fix-capture-events-youtube-ready_2023-05-10-13-22.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1180-fix-capture-events-youtube-ready_2023-05-10-13-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-youtube-tracking",
+      "comment": "Fix 'captureEvents' not being respected",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-youtube-tracking"
+}

--- a/plugins/browser-plugin-youtube-tracking/src/eventGroups.ts
+++ b/plugins/browser-plugin-youtube-tracking/src/eventGroups.ts
@@ -1,6 +1,6 @@
 import { SnowplowEvent } from './snowplowEvents';
 import { EventGroup } from './types';
-import { YTPlayerEvent, YTState } from './constants';
+import { YTState } from './constants';
 import { YTEvent } from './youtubeEvents';
 
 export const AllEvents: EventGroup = [
@@ -16,8 +16,8 @@ export const DefaultEvents: EventGroup = [
   YTState.ENDED,
   SnowplowEvent.SEEK,
   SnowplowEvent.VOLUMECHANGE,
-  YTPlayerEvent.ONPLAYBACKQUALITYCHANGE,
-  YTPlayerEvent.ONPLAYBACKRATECHANGE,
+  YTEvent.PLAYBACKQUALITYCHANGE,
+  YTEvent.PLAYBACKRATECHANGE,
   SnowplowEvent.PERCENTPROGRESS,
 ];
 

--- a/plugins/browser-plugin-youtube-tracking/test/youtube.test.ts
+++ b/plugins/browser-plugin-youtube-tracking/test/youtube.test.ts
@@ -38,11 +38,11 @@ describe('config parser', () => {
   const id = 'youtube';
   const default_output: TrackingOptions = {
     mediaId: 'youtube',
+    player: undefined,
     captureEvents: DefaultEvents,
     youtubeEvents: [
       YTPlayerEvent.ONSTATECHANGE,
       YTPlayerEvent.ONPLAYBACKQUALITYCHANGE,
-      YTPlayerEvent.ONERROR,
       YTPlayerEvent.ONPLAYBACKRATECHANGE,
     ],
     updateRate: 500,
@@ -88,7 +88,7 @@ describe('config parser', () => {
       captureEvents: ['play', 'error', 'playbackratechange', 'playbackqualitychange', 'apichange'],
     };
 
-    let expectedOutput = ['onStateChange', 'onPlaybackQualityChange', 'onError', 'onPlaybackRateChange', 'onApiChange'];
+    let expectedOutput = ['onStateChange', 'onError', 'onPlaybackRateChange', 'onPlaybackQualityChange', 'onApiChange'];
     expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).toEqual(expectedOutput);
   });
 
@@ -107,6 +107,91 @@ describe('config parser', () => {
 
     let expectedOutput = DefaultEvents.concat(['ready']);
     expect(trackingOptionsParser(id, trackingOptions).captureEvents).toEqual(expectedOutput);
+  });
+
+  it("doesn't return youtube events not in capture events", () => {
+    let trackingOptions: MediaTrackingOptions = {
+      captureEvents: ['play', 'pause'],
+    };
+
+    let expectedOutput = ['onStateChange'];
+    expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).toEqual(expectedOutput);
+  });
+
+  it("Only includes YTPlayerEvent.ONERROR with 'error' event ", () => {
+    let expectedOutput = ['onError'];
+    for (let event of AllEvents) {
+      let trackingOptions: MediaTrackingOptions = {
+        captureEvents: [event],
+      };
+
+      if (event === 'error') {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).toEqual(expectedOutput);
+      } else {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).not.toEqual(expectedOutput);
+      }
+    }
+  });
+
+  it('Only includes YTPlayerEvent.ONSTATECHANGE with required events', () => {
+    let expectedOutput = ['onStateChange'];
+    const eventsUsingStateChange = ['unstarted', 'play', 'pause', 'buffering', 'cued', 'ended'];
+    for (let event of AllEvents) {
+      let trackingOptions: MediaTrackingOptions = {
+        captureEvents: [event],
+      };
+
+      if (eventsUsingStateChange.indexOf(event) !== -1) {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).toEqual(expectedOutput);
+      } else {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).not.toEqual(expectedOutput);
+      }
+    }
+  });
+
+  it("Only includes YTPlayerEvent.ONPLAYBACKRATECHANGE with 'playbackratechange' event", () => {
+    let expectedOutput = ['onPlaybackRateChange'];
+    for (let event of AllEvents) {
+      let trackingOptions: MediaTrackingOptions = {
+        captureEvents: [event],
+      };
+
+      if (event === 'playbackratechange') {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).toEqual(expectedOutput);
+      } else {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).not.toEqual(expectedOutput);
+      }
+    }
+  });
+
+  it("Only includes YTPlayerEvent.ONPLAYBACKQUALITYCHANGE only with 'playbackqualitychange' event", () => {
+    let expectedOutput = ['onPlaybackQualityChange'];
+    for (let event of AllEvents) {
+      let trackingOptions: MediaTrackingOptions = {
+        captureEvents: [event],
+      };
+
+      if (event === 'playbackqualitychange') {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).toEqual(expectedOutput);
+      } else {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).not.toEqual(expectedOutput);
+      }
+    }
+  });
+
+  it('Only includes YTPlayerEvent.ONAPICHANGE only with "apichange" event', () => {
+    let expectedOutput = ['onApiChange'];
+    for (let event of AllEvents) {
+      let trackingOptions: MediaTrackingOptions = {
+        captureEvents: [event],
+      };
+
+      if (event === 'apichange') {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).toEqual(expectedOutput);
+      } else {
+        expect(trackingOptionsParser(id, trackingOptions).youtubeEvents).not.toEqual(expectedOutput);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## `DefaultEvents`
Use `YTPlayerEvent` instead of `YTEvent` for playback quality/rate change in `DefaultEvent`

YTEvent is the "human" name for the event, which is used for user event input. Instances of `YTPlayerEvent` should only exist internally in `TrackingOptions.youtubeEvents`, as we use this to determine which listeners we attach to the YouTube player API.

## `trackingOptionsParser`

The `defaults` object included `YTPlayerEvents` which caused incorrect events to fire, along with not properly respecting what was in `conf.captureEvents`.

`TrackingOptions.youtubeEvents` is now also initialised empty, and populated by the `trackingOptionsParser`

I also took this opportunity to tidy a few bits:
- replace the `.filter` with `indexOf` for clarity
- add comments

## `addExistingPlayer`
- check if `ready` event is in `captureEvents` before firing

## Tests
- The tracking options parser now produces the youtube events in a different order (but still the correct ones), requiring `onPlaybackQualityChange` to be moved in the expected array for the  `"parses youtube events"` test
- add `player: undefined` for the expected default object, as we aren't creating an instance of `YT.Player` in unit tests