### PR TITLE
Fix 'percentprogress' events not firing without 'play' and 'pause' in 'captureEvents' (close #1183)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1183-fix-progress-without-play-pause_2023-05-11-12-03.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/issue-1183-fix-progress-without-play-pause_2023-05-11-12-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-youtube-tracking",
+      "comment": "Fix 'percentprogress' events not firing without 'play' and 'pause' in 'captureEvents'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-youtube-tracking"
+}

--- a/plugins/browser-plugin-youtube-tracking/test/youtube.test.ts
+++ b/plugins/browser-plugin-youtube-tracking/test/youtube.test.ts
@@ -135,7 +135,7 @@ describe('config parser', () => {
 
   it('Only includes YTPlayerEvent.ONSTATECHANGE with required events', () => {
     let expectedOutput = ['onStateChange'];
-    const eventsUsingStateChange = ['unstarted', 'play', 'pause', 'buffering', 'cued', 'ended'];
+    const eventsUsingStateChange = ['unstarted', 'play', 'pause', 'buffering', 'cued', 'ended', 'percentprogress'];
     for (let event of AllEvents) {
       let trackingOptions: MediaTrackingOptions = {
         captureEvents: [event],


### PR DESCRIPTION
`progressHandler`, which controls `percentprogress` events, require the `play` and `pause` events, which only got passed to `progressHandler` if `play` and `pause` were present in `captureEvents`.

This has been updated to instead listen in the `YTPlayerEvent.ONSTATECHANGE` callback, avoiding the dependence on the events in `captureEvents`.

`YTPlayerEvent.ONSTATECHANGE` is also added to `youtubeEvents`, if not present, to attach the listener.