### PR TITLE
Add onSessionUpdate callback configuration option

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/feature-1191-add-onSessionUpdate-callback_2023-05-17-13-51.json
+++ b/common/changes/@snowplow/browser-tracker-core/feature-1191-add-onSessionUpdate-callback_2023-05-17-13-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add onSessionUpdate callback configuration option",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/feature-1191-add-onSessionUpdate-callback_2023-05-17-13-58.json
+++ b/common/changes/@snowplow/browser-tracker/feature-1191-add-onSessionUpdate-callback_2023-05-17-13-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add onSessionUpdate callback configuration option",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -237,6 +237,11 @@ export type TrackerConfiguration = {
    * By default, the tracker retries on all non-success status codes except for 400, 401, 403, 410, and 422.
    */
   dontRetryStatusCodes?: number[];
+  /**
+   * Callback fired whenever the session identifier is updated.
+   * @param updatedSession - On session update, the new session information plus the previous session id.
+   */
+  onSessionUpdateCallback?: (updatedSession: ClientSession) => void;
 };
 
 /**
@@ -580,4 +585,49 @@ export interface BrowserTracker {
    * @param configuration - The plugin to add
    */
   addPlugin: (configuration: BrowserPluginConfiguration) => void;
+}
+
+/**
+ * Schema for client client session context entity
+ */
+export interface ClientSession extends Record<string, unknown> {
+  /**
+   * An identifier for the user of the session (same as domain_userid)
+   */
+  userId: string;
+
+  /**
+   * An identifier for the session (same as domain_sessionid)
+   */
+  sessionId: string;
+
+  /**
+   * The index of the current session for this user (same as domain_sessionidx)
+   */
+  sessionIndex: number;
+
+  /**
+   * Index of the current event in the session
+   */
+  eventIndex: number;
+
+  /**
+   * The previous session identifier for this user
+   */
+  previousSessionId: string | null;
+
+  /**
+   * The mechanism that the session information has been stored on the device
+   */
+  storageMechanism: string;
+
+  /**
+   * Identifier of the first event for this session
+   */
+  firstEventId: string | null;
+
+  /**
+   * Date-time timestamp of when the first event in the session was tracked
+   */
+  firstEventTimestamp: string | null;
 }

--- a/libraries/browser-tracker-core/test/id_cookie.test.ts
+++ b/libraries/browser-tracker-core/test/id_cookie.test.ts
@@ -28,6 +28,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import * as uuid from 'uuid';
+jest.mock('uuid');
+const MOCK_UUID = '123456789';
+jest.spyOn(uuid, 'v4').mockReturnValue(MOCK_UUID);
+const ANONYMOUS_USER_ID = '00000000-0000-0000-0000-000000000000';
+// jest.mock('uuid', () => ({ v4: () => MOCK_UUID }));
+
 import { payloadBuilder } from '@snowplow/tracker-core';
 import {
   clientSessionFromIdCookie,
@@ -132,9 +139,13 @@ describe('initializeDomainUserId', () => {
 });
 
 describe('startNewIdCookieSession', () => {
+  const defaultNewSessionOptions = {
+    configStateStorageStrategy: '',
+    configAnonymousTracking: false,
+  };
   it('Resets the first event references and event index', () => {
     let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9', '', '', 0);
-    startNewIdCookieSession(idCookie);
+    startNewIdCookieSession(idCookie, defaultNewSessionOptions);
 
     expect(firstEventIdFromIdCookie(idCookie)).toBeFalsy();
     expect(firstEventTsInMsFromIdCookie(idCookie)).toBeUndefined();
@@ -145,20 +156,20 @@ describe('startNewIdCookieSession', () => {
     let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262', '', '', 0);
 
     expect(visitCountFromIdCookie(idCookie)).toBe(10);
-    startNewIdCookieSession(idCookie);
+    startNewIdCookieSession(idCookie, defaultNewSessionOptions);
     expect(visitCountFromIdCookie(idCookie)).toBe(11);
   });
 
   it('Uses the passed visit count in case of disabled cookies', () => {
     let idCookie = parseIdCookie('', '', '', 0);
-    startNewIdCookieSession(idCookie, 100);
+    startNewIdCookieSession(idCookie, { ...defaultNewSessionOptions, memorizedVisitCount: 100 });
     expect(visitCountFromIdCookie(idCookie)).toBe(100);
   });
 
   it("Doesn't set the last visit timestamp if disabled cookies and keeps now timestamp", () => {
     let idCookie = parseIdCookie('', '', '', 0);
     let nowTs = nowTsFromIdCookie(idCookie);
-    startNewIdCookieSession(idCookie);
+    startNewIdCookieSession(idCookie, defaultNewSessionOptions);
     expect(lastVisitTsFromIdCookie(idCookie)).toBeUndefined();
     expect(nowTsFromIdCookie(idCookie)).toBe(nowTs);
   });
@@ -167,7 +178,9 @@ describe('startNewIdCookieSession', () => {
     let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262', '', '', 0);
 
     let before = sessionIdFromIdCookie(idCookie);
-    startNewIdCookieSession(idCookie);
+
+    jest.spyOn(uuid, 'v4').mockReturnValueOnce('another_random_uuid');
+    startNewIdCookieSession(idCookie, defaultNewSessionOptions);
     let after = sessionIdFromIdCookie(idCookie);
 
     expect(before).not.toBe(after);
@@ -176,15 +189,76 @@ describe('startNewIdCookieSession', () => {
   it('Moves current visit to last visit timestamp', () => {
     let idCookie = parseIdCookie(`def.1653632100.10.1653632200.1653632300`, '', '', 0);
 
-    startNewIdCookieSession(idCookie);
+    startNewIdCookieSession(idCookie, defaultNewSessionOptions);
     expect(lastVisitTsFromIdCookie(idCookie)).toBe(1653632200);
   });
 
   it('Sets the previous session ID', () => {
     let idCookie = parseIdCookie('def.1653632100.10.1653632200.1653632300.ses', '', '', 0);
 
-    startNewIdCookieSession(idCookie);
+    startNewIdCookieSession(idCookie, defaultNewSessionOptions);
     expect(previousSessionIdFromIdCookie(idCookie)).toBe('ses');
+  });
+
+  describe('Session Callbacks: onUpdateSession', () => {
+    it('Correctly fires the callback', () => {
+      const idCookie = parseIdCookie('def.1653632100.10.1653632200.1653632300.ses', '', '', 0);
+      const onSessionUpdateCallback = jest.fn();
+      startNewIdCookieSession(idCookie, { ...defaultNewSessionOptions, onSessionUpdateCallback });
+      expect(onSessionUpdateCallback).toHaveBeenCalledTimes(1);
+      expect(onSessionUpdateCallback).toHaveBeenCalledWith({
+        eventIndex: 0,
+        firstEventId: null,
+        firstEventTimestamp: null,
+        previousSessionId: 'ses',
+        sessionId: '123456789',
+        sessionIndex: 11,
+        storageMechanism: 'COOKIE_1',
+        userId: 'def',
+      });
+    });
+
+    it('Correctly fires the callback with anonymousTracking enabled', () => {
+      const idCookie = parseIdCookie('def.1653632100.10.1653632200.1653632300.ses', '', '', 0);
+      const onSessionUpdateCallback = jest.fn();
+      startNewIdCookieSession(idCookie, {
+        ...defaultNewSessionOptions,
+        onSessionUpdateCallback,
+        configAnonymousTracking: true,
+      });
+      expect(onSessionUpdateCallback).toHaveBeenCalledTimes(1);
+      expect(onSessionUpdateCallback).toHaveBeenCalledWith({
+        eventIndex: 0,
+        firstEventId: null,
+        firstEventTimestamp: null,
+        previousSessionId: null,
+        sessionId: '123456789',
+        sessionIndex: 11,
+        storageMechanism: 'COOKIE_1',
+        userId: ANONYMOUS_USER_ID,
+      });
+    });
+
+    it('Correctly fires the callback with different stateStorageStrategy', () => {
+      const idCookie = parseIdCookie('def.1653632100.10.1653632200.1653632300.ses', '', '', 0);
+      const onSessionUpdateCallback = jest.fn();
+      startNewIdCookieSession(idCookie, {
+        ...defaultNewSessionOptions,
+        onSessionUpdateCallback,
+        configStateStorageStrategy: 'localStorage',
+      });
+      expect(onSessionUpdateCallback).toHaveBeenCalledTimes(1);
+      expect(onSessionUpdateCallback).toHaveBeenCalledWith({
+        eventIndex: 0,
+        firstEventId: null,
+        firstEventTimestamp: null,
+        previousSessionId: 'ses',
+        sessionId: '123456789',
+        sessionIndex: 11,
+        storageMechanism: 'LOCAL_STORAGE',
+        userId: 'def',
+      });
+    });
   });
 });
 

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -128,6 +128,18 @@ export interface ClearUserDataConfiguration {
 }
 
 // @public
+export interface ClientSession extends Record<string, unknown> {
+    eventIndex: number;
+    firstEventId: string | null;
+    firstEventTimestamp: string | null;
+    previousSessionId: string | null;
+    sessionId: string;
+    sessionIndex: number;
+    storageMechanism: string;
+    userId: string;
+}
+
+// @public
 export interface CommonEventProperties {
     context?: Array<SelfDescribingJson> | null;
     // Warning: (ae-forgotten-export) The symbol "Timestamp" needs to be exported by the entry point index.module.d.ts
@@ -347,6 +359,7 @@ export type TrackerConfiguration = {
     customHeaders?: Record<string, string>;
     retryStatusCodes?: number[];
     dontRetryStatusCodes?: number[];
+    onSessionUpdateCallback?: (updatedSession: ClientSession) => void;
 };
 
 // @public

--- a/trackers/browser-tracker/src/index.ts
+++ b/trackers/browser-tracker/src/index.ts
@@ -37,6 +37,7 @@ import {
   Platform,
   EventMethod,
   StateStorageStrategy,
+  ClientSession,
 } from '@snowplow/browser-tracker-core';
 import { version } from '@snowplow/tracker-core';
 
@@ -72,6 +73,14 @@ export function newTracker(trackerId: string, endpoint: string, configuration: T
   }
 }
 
-export { BrowserTracker, TrackerConfiguration, CookieSameSite, Platform, EventMethod, StateStorageStrategy };
+export {
+  BrowserTracker,
+  TrackerConfiguration,
+  CookieSameSite,
+  Platform,
+  EventMethod,
+  StateStorageStrategy,
+  ClientSession,
+};
 export { version };
 export * from './api';


### PR DESCRIPTION
Add the `onSessionUpdate` callback configuration option. 

The callback will retrieve the first argument as the `ClientSession` object type:

⚠️  Exposed `ClientSession` type as well.

```ts
export interface ClientSession extends Record<string, unknown> {
  /**
   * An identifier for the user of the session (same as domain_userid)
   */
  userId: string;

  /**
   * An identifier for the session (same as domain_sessionid)
   */
  sessionId: string;

  /**
   * The index of the current session for this user (same as domain_sessionidx)
   */
  sessionIndex: number;

  /**
   * Index of the current event in the session
   */
  eventIndex: number;

  /**
   * The previous session identifier for this user
   */
  previousSessionId: string | null;

  /**
   * The mechanism that the session information has been stored on the device
   */
  storageMechanism: string;

  /**
   * Identifier of the first event for this session
   */
  firstEventId: string | null;

  /**
   * Date-time timestamp of when the first event in the session was tracked
   */
  firstEventTimestamp: string | null;
}

```

close #1191

_Note_
- This dependency injection can change if we think of a better way.