### PR TITLE
Release/3.12.0

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media/issue-1176-media_plugin_2023-04-17-15-11.json
+++ b/common/changes/@snowplow/browser-plugin-media/issue-1176-media_plugin_2023-04-17-15-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media",
+      "comment": "Add Snowplow Media plugin with APIs to track media events (#1176)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -188,7 +188,7 @@
     },
     {
       "name": "@types/uuid",
-      "allowedCategories": [ "libraries", "trackers" ]
+      "allowedCategories": [ "libraries", "plugins", "trackers" ]
     },
     {
       "name": "@types/youtube",
@@ -368,7 +368,7 @@
     },
     {
       "name": "uuid",
-      "allowedCategories": [ "libraries", "trackers" ]
+      "allowedCategories": [ "libraries", "plugins", "trackers" ]
     },
     {
       "name": "wdio-chromedriver-service",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -772,6 +772,59 @@ importers:
       ts-jest: 27.1.3_60149d457e34ffba7d4e845dde6a1263
       typescript: 4.6.2
 
+  ../../plugins/browser-plugin-media:
+    specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ~0.27.0
+      '@rollup/plugin-commonjs': ~21.0.2
+      '@rollup/plugin-node-resolve': ~13.1.3
+      '@snowplow/browser-tracker-core': workspace:*
+      '@snowplow/tracker-core': workspace:*
+      '@types/jest': ~27.4.1
+      '@types/jsdom': ~16.2.14
+      '@types/uuid': ~3.4.6
+      '@typescript-eslint/eslint-plugin': ~5.15.0
+      '@typescript-eslint/parser': ~5.15.0
+      eslint: ~8.11.0
+      jest: ~27.5.1
+      jest-environment-jsdom: ~27.5.1
+      jest-environment-jsdom-global: ~3.0.0
+      jest-standard-reporter: ~2.0.0
+      rollup: ~2.70.1
+      rollup-plugin-cleanup: ~3.2.1
+      rollup-plugin-license: ~2.6.1
+      rollup-plugin-terser: ~7.0.2
+      rollup-plugin-ts: ~2.0.5
+      ts-jest: ~27.1.3
+      tslib: ^2.3.1
+      typescript: ~4.6.2
+      uuid: ^3.4.0
+    dependencies:
+      '@snowplow/browser-tracker-core': link:../../libraries/browser-tracker-core
+      '@snowplow/tracker-core': link:../../libraries/tracker-core
+      tslib: 2.3.1
+      uuid: 3.4.0
+    devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.70.1
+      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
+      '@types/jest': 27.4.1
+      '@types/jsdom': 16.2.14
+      '@types/uuid': 3.4.9
+      '@typescript-eslint/eslint-plugin': 5.15.0_f2c49ce7d0e93ebcfdb4b7d25b131b28
+      '@typescript-eslint/parser': 5.15.0_eslint@8.11.0+typescript@4.6.2
+      eslint: 8.11.0
+      jest: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-jsdom-global: 3.0.0_jest-environment-jsdom@27.5.1
+      jest-standard-reporter: 2.0.0
+      rollup: 2.70.1
+      rollup-plugin-cleanup: 3.2.1_rollup@2.70.1
+      rollup-plugin-license: 2.6.1_rollup@2.70.1
+      rollup-plugin-terser: 7.0.2_rollup@2.70.1
+      rollup-plugin-ts: 2.0.5_rollup@2.70.1+typescript@4.6.2
+      ts-jest: 27.1.3_60149d457e34ffba7d4e845dde6a1263
+      typescript: 4.6.2
+
   ../../plugins/browser-plugin-media-tracking:
     specifiers:
       '@ampproject/rollup-plugin-closure-compiler': ~0.27.0
@@ -1502,7 +1555,7 @@ packages:
       '@babel/traverse': 7.12.10
       '@babel/types': 7.16.8
       convert-source-map: 1.7.0
-      debug: 4.3.3
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.1.3
       lodash: 4.17.21
@@ -1768,7 +1821,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.12.11
       '@babel/parser': 7.16.12
       '@babel/types': 7.16.8
-      debug: 4.3.3
+      debug: 4.3.4
       globals: 11.12.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -1799,7 +1852,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.3
+      debug: 4.3.4
       espree: 9.3.1
       globals: 13.12.0
       ignore: 5.2.0
@@ -1820,7 +1873,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.3
+      debug: 4.3.4
       minimatch: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -2105,17 +2158,6 @@ packages:
       '@types/istanbul-reports': 3.0.0
       '@types/node': 14.6.4
       '@types/yargs': 15.0.12
-      chalk: 4.1.2
-    dev: true
-
-  /@jest/types/27.4.2:
-    resolution: {integrity: sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.3
-      '@types/istanbul-reports': 3.0.0
-      '@types/node': 14.6.4
-      '@types/yargs': 16.0.4
       chalk: 4.1.2
     dev: true
 
@@ -4090,7 +4132,7 @@ packages:
     dev: true
 
   /co/4.6.0:
-    resolution: {integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=}
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
@@ -4497,7 +4539,7 @@ packages:
     dev: true
 
   /dedent/0.7.0:
-    resolution: {integrity: sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=}
+    resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
     dev: true
 
   /deep-is/0.1.3:
@@ -4950,7 +4992,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -5073,7 +5115,7 @@ packages:
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
       onetime: 5.1.2
-      signal-exit: 3.0.3
+      signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
 
@@ -5098,7 +5140,7 @@ packages:
     dev: true
 
   /exit/0.1.2:
-    resolution: {integrity: sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=}
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
     dev: true
 
@@ -5250,7 +5292,7 @@ packages:
     dev: true
 
   /fast-levenshtein/2.0.6:
-    resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
   /fastq/1.10.0:
@@ -6442,7 +6484,7 @@ packages:
     resolution: {integrity: sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==}
     engines: {node: '>=8'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -7045,18 +7087,6 @@ packages:
       micromatch: 4.0.2
     dev: true
 
-  /jest-util/27.4.2:
-    resolution: {integrity: sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      '@jest/types': 27.4.2
-      '@types/node': 14.6.4
-      chalk: 4.1.2
-      ci-info: 3.3.0
-      graceful-fs: 4.2.4
-      picomatch: 2.3.1
-    dev: true
-
   /jest-util/27.5.1:
     resolution: {integrity: sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -7224,7 +7254,7 @@ packages:
       form-data: 3.0.0
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.0
       parse5: 6.0.1
@@ -7275,7 +7305,7 @@ packages:
     dev: true
 
   /json-stable-stringify-without-jsonify/1.0.1:
-    resolution: {integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=}
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
   /json-stringify-safe/5.0.1:
@@ -7361,7 +7391,7 @@ packages:
     dev: true
 
   /levn/0.3.0:
-    resolution: {integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=}
+    resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.1.2
@@ -7470,7 +7500,7 @@ packages:
     dev: true
 
   /lodash.memoize/4.1.2:
-    resolution: {integrity: sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=}
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
     dev: true
 
   /lodash.merge/4.6.2:
@@ -7610,7 +7640,7 @@ packages:
     dev: true
 
   /makeerror/1.0.11:
-    resolution: {integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=}
+    resolution: {integrity: sha512-M/XvMZ6oK4edXjvg/ZYyzByg8kjpVrF/m0x3wbhOlzJfsQgFkqP1rJnLnJExOcslmLSSeLiN6NmF+cBoKJHGTg==}
     dependencies:
       tmpl: 1.0.4
     dev: true
@@ -7903,7 +7933,7 @@ packages:
     optional: true
 
   /natural-compare/1.4.0:
-    resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
   /negotiator/0.6.2:
@@ -7974,7 +8004,7 @@ packages:
     dev: true
 
   /node-int64/0.4.0:
-    resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
   /node-releases/2.0.1:
@@ -8655,7 +8685,7 @@ packages:
     dev: true
 
   /prelude-ls/1.1.2:
-    resolution: {integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=}
+    resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
     engines: {node: '>= 0.8.0'}
     dev: true
 
@@ -9391,10 +9421,6 @@ packages:
     resolution: {integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==}
     dev: true
 
-  /signal-exit/3.0.3:
-    resolution: {integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==}
-    dev: true
-
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
@@ -9657,15 +9683,6 @@ packages:
       strip-ansi: 3.0.1
     dev: true
 
-  /string-width/4.2.0:
-    resolution: {integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==}
-    engines: {node: '>=8'}
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.0
-    dev: true
-
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -9733,13 +9750,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
-    dev: true
-
-  /strip-ansi/6.0.0:
-    resolution: {integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==}
-    engines: {node: '>=8'}
-    dependencies:
-      ansi-regex: 5.0.1
     dev: true
 
   /strip-ansi/6.0.1:
@@ -9990,7 +10000,7 @@ packages:
     dev: true
 
   /tmpl/1.0.4:
-    resolution: {integrity: sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=}
+    resolution: {integrity: sha512-9tP427gQBl7Mx3vzr3mquZ+Rq+1sAqIJb5dPSYEjWMYsqitxARsFCHkZS3sDptHAmrUPCZfzXNZqSuBIHdpV5A==}
     dev: true
 
   /to-buffer/1.1.1:
@@ -9998,7 +10008,7 @@ packages:
     dev: true
 
   /to-fast-properties/2.0.0:
-    resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
     dev: true
 
@@ -10084,7 +10094,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1
-      jest-util: 27.4.2
+      jest-util: 27.5.1
       json5: 2.1.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -10157,7 +10167,7 @@ packages:
     dev: true
 
   /type-check/0.3.2:
-    resolution: {integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=}
+    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.1.2
@@ -10382,6 +10392,7 @@ packages:
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
     dependencies:
       browser-process-hrtime: 1.0.0
     dev: true
@@ -10394,7 +10405,7 @@ packages:
     dev: true
 
   /walker/1.0.7:
-    resolution: {integrity: sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=}
+    resolution: {integrity: sha512-cF4je9Fgt6sj1PKfuFt9jpQPeHosM+Ryma/hfY9U7uXGKM7pJCsF0v2r55o+Il54+i77SyYWetB4tD1dEygRkw==}
     dependencies:
       makeerror: 1.0.11
     dev: true
@@ -10598,7 +10609,7 @@ packages:
     dependencies:
       imurmurhash: 0.1.4
       is-typedarray: 1.0.0
-      signal-exit: 3.0.3
+      signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
     dev: true
 
@@ -10685,7 +10696,7 @@ packages:
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1
-      string-width: 4.2.0
+      string-width: 4.2.3
       y18n: 5.0.5
       yargs-parser: 20.2.4
     dev: true

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "1b4af3f37be662be92115c24013c6b260e74acc8",
+  "pnpmShrinkwrapHash": "5484bd61ddb42855b5228699721d75c1d5b9cb25",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/plugins/browser-plugin-media/CHANGELOG.json
+++ b/plugins/browser-plugin-media/CHANGELOG.json
@@ -1,0 +1,5 @@
+{
+  "name": "@snowplow/browser-plugin-media",
+  "entries": [
+  ]
+}

--- a/plugins/browser-plugin-media/LICENSE
+++ b/plugins/browser-plugin-media/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2023 Snowplow Analytics Ltd, 2010 Anthon Pang
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plugins/browser-plugin-media/README.md
+++ b/plugins/browser-plugin-media/README.md
@@ -1,0 +1,59 @@
+# Snowplow Media Plugin
+
+[![npm version][npm-image]][npm-url]
+[![License][license-image]](LICENSE)
+
+Browser Plugin to be used with `@snowplow/browser-tracker`.
+
+This plugin is the recommended way to track media events on your website.
+
+## Maintainer quick start
+
+Part of the Snowplow JavaScript Tracker monorepo.  
+Build with [Node.js](https://nodejs.org/en/) (14 or 16) and [Rush](https://rushjs.io/).
+
+### Setup repository
+
+```bash
+npm install -g @microsoft/rush 
+git clone https://github.com/snowplow/snowplow-javascript-tracker.git
+rush update
+```
+
+## Package Installation
+
+With npm:
+
+```bash
+npm install @snowplow/browser-plugin-media
+```
+
+## Usage
+
+Initialize your tracker with the SnowplowMediaPlugin:
+
+```js
+import { newTracker } from '@snowplow/browser-tracker';
+import { SnowplowMediaPlugin } from '@snowplow/browser-plugin-media';
+
+newTracker('sp1', '{{collector_url}}', { 
+   appId: 'my-app-id', 
+   plugins: [ SnowplowMediaPlugin() ],
+});
+```
+
+For a full API reference, you can read the plugin [documentation page](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/plugins/media/).
+
+## Copyright and license
+
+Licensed and distributed under the [BSD 3-Clause License](LICENSE) ([An OSI Approved License][osi]).
+
+Copyright (c) 2022 Snowplow Analytics Ltd.
+
+All rights reserved.
+
+[npm-url]: https://www.npmjs.com/package/@snowplow/browser-plugin-media
+[npm-image]: https://img.shields.io/npm/v/@snowplow/browser-plugin-media
+[docs]: https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/javascript-tracker/
+[osi]: https://opensource.org/licenses/BSD-3-Clause
+[license-image]: https://img.shields.io/npm/l/@snowplow/browser-plugin-media

--- a/plugins/browser-plugin-media/jest.config.js
+++ b/plugins/browser-plugin-media/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+  testEnvironment: 'jest-environment-jsdom-global',
+};

--- a/plugins/browser-plugin-media/package.json
+++ b/plugins/browser-plugin-media/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@snowplow/browser-plugin-media",
+  "version": "3.11.0",
+  "description": "Snowplow media tracking",
+  "homepage": "https://github.com/snowplow/snowplow-javascript-tracker",
+  "bugs": "https://github.com/snowplow/snowplow-javascript-tracker/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowplow/snowplow-javascript-tracker.git"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Snowplow Analytics Ltd (https://snowplow.io/)",
+  "sideEffects": false,
+  "main": "./dist/index.umd.js",
+  "module": "./dist/index.module.js",
+  "types": "./dist/index.module.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c --silent --failAfterWarnings",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@snowplow/browser-tracker-core": "workspace:*",
+    "@snowplow/tracker-core": "workspace:*",
+    "tslib": "^2.3.1",
+    "uuid": "^3.4.0"
+  },
+  "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
+    "@rollup/plugin-commonjs": "~21.0.2",
+    "@rollup/plugin-node-resolve": "~13.1.3",
+    "@types/jest": "~27.4.1",
+    "@types/jsdom": "~16.2.14",
+    "@types/uuid": "~3.4.6",
+    "@typescript-eslint/eslint-plugin": "~5.15.0",
+    "@typescript-eslint/parser": "~5.15.0",
+    "eslint": "~8.11.0",
+    "jest": "~27.5.1",
+    "jest-environment-jsdom": "~27.5.1",
+    "jest-environment-jsdom-global": "~3.0.0",
+    "jest-standard-reporter": "~2.0.0",
+    "rollup": "~2.70.1",
+    "rollup-plugin-cleanup": "~3.2.1",
+    "rollup-plugin-license": "~2.6.1",
+    "rollup-plugin-terser": "~7.0.2",
+    "rollup-plugin-ts": "~2.0.5",
+    "ts-jest": "~27.1.3",
+    "typescript": "~4.6.2"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.11.0"
+  }
+}

--- a/plugins/browser-plugin-media/rollup.config.js
+++ b/plugins/browser-plugin-media/rollup.config.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
+import { banner } from '../../banner';
+import compiler from '@ampproject/rollup-plugin-closure-compiler';
+import { terser } from 'rollup-plugin-terser';
+import cleanup from 'rollup-plugin-cleanup';
+import pkg from './package.json';
+import { builtinModules } from 'module';
+
+const umdPlugins = [nodeResolve({ browser: true }), commonjs(), ts()];
+const umdName = 'snowplowMedia';
+
+export default [
+  // CommonJS (for Node) and ES module (for bundlers) build.
+  {
+    input: './src/index.ts',
+    plugins: [...umdPlugins, banner()],
+    treeshake: { moduleSideEffects: ['sha1'] },
+    output: [{ file: pkg.main, format: 'umd', sourcemap: true, name: umdName }],
+  },
+  {
+    input: './src/index.ts',
+    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    treeshake: { moduleSideEffects: ['sha1'] },
+    output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
+  },
+  {
+    input: './src/index.ts',
+    external: [...builtinModules, ...Object.keys(pkg.dependencies), ...Object.keys(pkg.devDependencies)],
+    plugins: [
+      ts(), // so Rollup can convert TypeScript to JavaScript
+      banner(),
+    ],
+    output: [{ file: pkg.module, format: 'es', sourcemap: true }],
+  },
+];

--- a/plugins/browser-plugin-media/src/adTracking.ts
+++ b/plugins/browser-plugin-media/src/adTracking.ts
@@ -1,0 +1,65 @@
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+import { buildMediaAdBreakEntity, buildMediaAdEntity } from './core';
+import { MediaPlayer, MediaAd, MediaAdUpdate, MediaAdBreak, MediaPlayerAdBreakUpdate, MediaEventType } from './types';
+
+/** Keeps track of the ad and ad break entities and updates them according to tracked events. */
+export class MediaAdTracking {
+  ad?: MediaAd;
+  adBreak?: MediaAdBreak;
+  podPosition = 0;
+
+  updateForThisEvent(
+    eventType: MediaEventType,
+    player: MediaPlayer,
+    ad?: MediaAdUpdate,
+    adBreak?: MediaPlayerAdBreakUpdate
+  ) {
+    if (eventType == MediaEventType.AdStart) {
+      this.ad = undefined;
+      this.podPosition++;
+    } else if (eventType == MediaEventType.AdBreakStart) {
+      this.adBreak = undefined;
+      this.podPosition = 0;
+    }
+
+    if (ad !== undefined) {
+      let position = { podPosition: this.podPosition > 0 ? this.podPosition : undefined };
+      if (this.ad !== undefined) {
+        this.ad = { ...this.ad, ...position, ...ad };
+      } else {
+        this.ad = { ...position, ...ad };
+      }
+    }
+
+    if (adBreak !== undefined) {
+      let startTime = { startTime: player.currentTime };
+      if (this.adBreak !== undefined) {
+        this.adBreak = { ...startTime, ...this.adBreak, ...adBreak };
+      } else {
+        this.adBreak = { ...startTime, ...adBreak };
+      }
+    }
+  }
+
+  updateForNextEvent(eventType: MediaEventType) {
+    if (eventType == MediaEventType.AdBreakEnd) {
+      this.adBreak = undefined;
+      this.podPosition = 0;
+    }
+
+    if (eventType == MediaEventType.AdComplete || eventType == MediaEventType.AdSkip) {
+      this.ad = undefined;
+    }
+  }
+
+  getContext(): SelfDescribingJson[] {
+    let context = [];
+    if (this.ad !== undefined) {
+      context.push(buildMediaAdEntity(this.ad));
+    }
+    if (this.adBreak !== undefined) {
+      context.push(buildMediaAdBreakEntity(this.adBreak));
+    }
+    return context;
+  }
+}

--- a/plugins/browser-plugin-media/src/api.ts
+++ b/plugins/browser-plugin-media/src/api.ts
@@ -1,0 +1,726 @@
+import { BrowserPlugin, BrowserTracker, dispatchToTrackersInCollection } from '@snowplow/browser-tracker-core';
+import { buildSelfDescribingEvent, LOG, SelfDescribingJson } from '@snowplow/tracker-core';
+import { MediaTracking } from './mediaTracking';
+import { MediaPingInterval } from './pingInterval';
+import { MediaSessionTracking } from './sessionTracking';
+import {
+  CommonMediaEventProperties,
+  MediaEventType,
+  MediaAdBreakType,
+  MediaTrackArguments,
+  MediaTrackAdBreakArguments,
+  MediaTrackAdArguments,
+  MediaTrackingConfiguration,
+  MediaTrackPlaybackRateChangeArguments,
+  MediaEvent,
+  MediaTrackVolumeChangeArguments,
+  MediaTrackFullscreenChangeArguments,
+  MediaTrackPictureInPictureChangeArguments,
+  MediaTrackAdPercentProgressArguments,
+  MediaTrackQualityChangeArguments,
+  MediaTrackErrorArguments,
+  MediaTrackSelfDescribingEventArguments,
+} from './types';
+
+export { MediaAdBreakType as MediaPlayerAdBreakType };
+
+const _trackers: Record<string, BrowserTracker> = {};
+const _context: Record<string, SelfDescribingJson[]> = {};
+
+/**
+ * Adds media tracking
+ */
+export function SnowplowMediaPlugin(): BrowserPlugin {
+  let trackerId: string;
+  return {
+    activateBrowserPlugin: (tracker) => {
+      trackerId = tracker.id;
+      _trackers[trackerId] = tracker;
+      _context[trackerId] = [];
+    },
+    contexts: () => {
+      return _context[trackerId] || [];
+    },
+  };
+}
+
+const activeMedias: { [key: string]: MediaTracking } = {};
+
+/**
+ * Starts media tracking for a single media content tracked in a media player.
+ * The tracking instance is uniquely identified by a given ID.
+ * All subsequent media track calls will be processed within this media tracking if given the same ID.
+ *
+ * @param config Configuration for setting up media tracking
+ * @param trackers The tracker identifiers which ping events will be sent to
+ */
+export function startMediaTracking(
+  config: MediaTrackingConfiguration & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const pingInterval = typeof config.pings === 'boolean' ? undefined : config.pings?.pingInterval;
+  const maxPausedPings = typeof config.pings === 'boolean' ? undefined : config.pings?.maxPausedPings;
+  const pings =
+    config.pings === false || config.pings === undefined
+      ? undefined
+      : new MediaPingInterval(pingInterval, maxPausedPings, () => {
+          track({ mediaEvent: { type: MediaEventType.Ping } }, { id: config.id }, trackers);
+        });
+
+  const sessionTracking: MediaSessionTracking | undefined =
+    config.session === false ? undefined : new MediaSessionTracking(config.id, config.session?.startedAt, pingInterval);
+
+  const mediaTracking = new MediaTracking(
+    config.id,
+    config.player,
+    sessionTracking,
+    pings,
+    config.boundaries,
+    config.captureEvents,
+    config.updatePageActivityWhilePlaying,
+    config.context
+  );
+  activeMedias[mediaTracking.id] = mediaTracking;
+}
+
+/**
+ * Ends media tracking with the given ID if previously started.
+ * Clears local state for the media tracking.
+ *
+ * @param configuration Configuration with the media tracking ID
+ */
+export function endMediaTracking(configuration: { id: string }) {
+  if (activeMedias[configuration.id]) {
+    activeMedias[configuration.id].stop();
+    delete activeMedias[configuration.id];
+  }
+}
+
+/**
+ * Updates stored attributes of the media tracking such as the current playback.
+ * Use this function to continually update the player attributes so that they
+ * can be sent in the background ping events.
+ *
+ * @param args The attributes for the media entities
+ * @param trackers The tracker identifiers which any resulting event will be sent to
+ */
+export function updateMediaTracking(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({}, args, trackers);
+}
+
+/**
+ * Tracks a media player ready event that is fired when the media tracking is successfully
+ * attached to the player and can track events.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaReady(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.Ready } }, args, trackers);
+}
+
+/**
+ * Tracks a media player play event sent when the player changes state to playing from
+ * previously being paused.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaPlay(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track(
+    { mediaEvent: { type: MediaEventType.Play } },
+    {
+      ...args,
+      player: {
+        ...args.player,
+        paused: false,
+      },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player pause event sent when the user pauses the playback.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaPause(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track(
+    { mediaEvent: { type: MediaEventType.Pause } },
+    {
+      ...args,
+      player: {
+        ...args.player,
+        paused: true,
+      },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player end event sent when playback stops when end of the media
+ * is reached or because no further data is available.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaEnd(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track(
+    { mediaEvent: { type: MediaEventType.End } },
+    {
+      ...args,
+      player: {
+        ...args.player,
+        ended: true,
+        paused: true,
+      },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player seek start event sent when a seek operation begins.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaSeekStart(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.SeekStart } }, args, trackers);
+}
+
+/**
+ * Tracks a media player seek end event sent when a seek operation completes.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaSeekEnd(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.SeekEnd } }, args, trackers);
+}
+
+/**
+ * Tracks a media player playback rate change event sent when the playback rate has changed.
+ *
+ * If not passed here, the previous rate is taken from the last setting in media player.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaPlaybackRateChange(
+  args: MediaTrackArguments & MediaTrackPlaybackRateChangeArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { previousRate, newRate } = args;
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.PlaybackRateChange,
+        eventBody: {
+          previousRate: previousRate ?? getMedia(args.id)?.player.playbackRate,
+          newRate,
+        },
+      },
+    },
+    {
+      ...args,
+      player: { ...args.player, playbackRate: newRate },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player volume change event sent when the volume has changed.
+ *
+ * If not passed here, the previous volume is taken from the last setting in media player.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaVolumeChange(
+  args: MediaTrackArguments & MediaTrackVolumeChangeArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { previousVolume, newVolume } = args;
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.VolumeChange,
+        eventBody: {
+          previousVolume: previousVolume ?? getMedia(args.id)?.player.volume,
+          newVolume,
+        },
+      },
+    },
+    {
+      ...args,
+      player: { ...args.player, volume: newVolume },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player fullscreen change event fired immediately after
+ * the browser switches into or out of full-screen mode.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaFullscreenChange(
+  args: MediaTrackArguments & MediaTrackFullscreenChangeArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { fullscreen } = args;
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.FullscreenChange,
+        eventBody: { fullscreen },
+      },
+    },
+    {
+      ...args,
+      player: { ...args.player, fullscreen },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player picture-in-picture change event fired immediately
+ * after the browser switches into or out of picture-in-picture mode.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaPictureInPictureChange(
+  args: MediaTrackArguments & MediaTrackPictureInPictureChangeArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { pictureInPicture } = args;
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.PictureInPictureChange,
+        eventBody: { pictureInPicture },
+      },
+    },
+    {
+      ...args,
+      player: { ...args.player, pictureInPicture },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player ad break start event that signals the start of an ad break.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdBreakStart(
+  args: MediaTrackArguments & MediaTrackAdBreakArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.AdBreakStart } }, args, trackers);
+}
+
+/**
+ * Tracks a media player ad break end event that signals the end of an ad break.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdBreakEnd(
+  args: MediaTrackArguments & MediaTrackAdBreakArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.AdBreakEnd } }, args, trackers);
+}
+
+/**
+ * Tracks a media player ad start event that signals the start of an ad.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdStart(
+  args: MediaTrackArguments & MediaTrackAdBreakArguments & MediaTrackAdArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.AdStart } }, args, trackers);
+}
+
+/**
+ * Tracks a media player ad skip event fired when the user activated
+ * a skip control to skip the ad creative.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdSkip(
+  args: MediaTrackArguments &
+    MediaTrackAdPercentProgressArguments &
+    MediaTrackAdBreakArguments &
+    MediaTrackAdArguments &
+    CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  let { percentProgress } = args;
+  if (percentProgress !== undefined) { percentProgress = Math.floor(percentProgress); }
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.AdSkip,
+        eventBody: { percentProgress },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player ad first quartile played event fired when
+ * a quartile of ad is reached after continuous ad playback at normal speed.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdFirstQuartile(
+  args: MediaTrackArguments & MediaTrackAdBreakArguments & MediaTrackAdArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.AdFirstQuartile,
+        eventBody: { percentProgress: 25 },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player ad midpoint played event fired when a midpoint of ad is
+ * reached after continuous ad playback at normal speed.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdMidpoint(
+  args: MediaTrackArguments & MediaTrackAdBreakArguments & MediaTrackAdArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.AdMidpoint,
+        eventBody: { percentProgress: 50 },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks media player ad third quartile played event fired when a quartile
+ * of ad is reached after continuous ad playback at normal speed.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdThirdQuartile(
+  args: MediaTrackArguments & MediaTrackAdBreakArguments & MediaTrackAdArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.AdThirdQuartile,
+        eventBody: { percentProgress: 75 },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player ad complete event that signals the ad creative
+ * was played to the end at normal speed.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdComplete(
+  args: MediaTrackArguments & MediaTrackAdBreakArguments & MediaTrackAdArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.AdComplete } }, args, trackers);
+}
+
+/**
+ * Tracks a media player ad click event fired when the user clicked on the ad.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdClick(
+  args: MediaTrackArguments &
+    MediaTrackAdPercentProgressArguments &
+    MediaTrackAdBreakArguments &
+    CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  let { percentProgress } = args;
+  if (percentProgress !== undefined) { percentProgress = Math.floor(percentProgress); }
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.AdClick,
+        eventBody: { percentProgress },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player ad pause event fired when the user clicked the pause
+ * control and stopped the ad creative.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdPause(
+  args: MediaTrackArguments &
+    MediaTrackAdPercentProgressArguments &
+    MediaTrackAdBreakArguments &
+    CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  let { percentProgress } = args;
+  if (percentProgress !== undefined) { percentProgress = Math.floor(percentProgress); }
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.AdPause,
+        eventBody: { percentProgress },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player ad resume event fired when the user resumed playing the
+ * ad creative after it had been stopped or paused.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaAdResume(
+  args: MediaTrackArguments &
+    MediaTrackAdPercentProgressArguments &
+    MediaTrackAdBreakArguments &
+    MediaTrackAdArguments &
+    CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  let { percentProgress } = args;
+  if (percentProgress !== undefined) { percentProgress = Math.floor(percentProgress); }
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.AdResume,
+        eventBody: { percentProgress: percentProgress },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player buffering start event fired when the player goes
+ * into the buffering state and begins to buffer content.
+ *
+ * End of buffering can be tracked using `trackMediaBufferEnd` or `trackMediaPlay` or
+ * by updating the `currentTime` property.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaBufferStart(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.BufferStart } }, args, trackers);
+}
+
+/**
+ * Tracks a media player buffering end event fired when the the player
+ * finishes buffering content and resumes playback.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaBufferEnd(
+  args: MediaTrackArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  track({ mediaEvent: { type: MediaEventType.BufferEnd } }, args, trackers);
+}
+
+/**
+ * Tracks a media player quality change event tracked when the video
+ * playback quality changes automatically.
+ *
+ * If not passed here, the previous quality is taken from the last setting in media player.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaQualityChange(
+  args: MediaTrackArguments & MediaTrackQualityChangeArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { previousQuality, newQuality, bitrate, framesPerSecond, automatic, id } = args;
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.QualityChange,
+        eventBody: {
+          previousQuality: previousQuality ?? getMedia(id)?.player.quality,
+          newQuality,
+          bitrate,
+          framesPerSecond,
+          automatic,
+        },
+      },
+    },
+    {
+      ...args,
+      player: { ...args.player, quality: newQuality },
+    },
+    trackers
+  );
+}
+
+/**
+ * Tracks a media player error event tracked when the resource could not be loaded due to an error.
+ *
+ * @param args The attributes for the media player event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaError(
+  args: MediaTrackArguments & MediaTrackErrorArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { errorCode, errorName, errorDescription } = args;
+  track(
+    {
+      mediaEvent: {
+        type: MediaEventType.Error,
+        eventBody: { errorCode, errorName, errorDescription },
+      },
+    },
+    args,
+    trackers
+  );
+}
+
+/**
+ * Tracks a custom self-describing event within the context of the media tracking.
+ * It will attach the context entities managed by the media tracking to the event (e.g. player, session, ad).
+ *
+ * @param args The attributes for the event and entities
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackMediaSelfDescribingEvent(
+  args: MediaTrackSelfDescribingEventArguments &
+    MediaTrackArguments &
+    MediaTrackAdArguments &
+    MediaTrackAdBreakArguments &
+    CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { event } = args;
+  track({ customEvent: event }, args, trackers);
+}
+
+function getMedia(id: string): MediaTracking | undefined {
+  if (activeMedias[id] === undefined) {
+    LOG.error(`Media tracking ${id} not started.`);
+    return undefined;
+  }
+
+  return activeMedias[id];
+}
+
+function track(
+  event: { mediaEvent?: MediaEvent; customEvent?: SelfDescribingJson },
+  args: MediaTrackArguments & MediaTrackAdArguments & MediaTrackAdBreakArguments & CommonMediaEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  const { context = [], timestamp, player, ad, adBreak, id } = args;
+  const { mediaEvent, customEvent } = event;
+
+  const mediaTracking = getMedia(id);
+  if (mediaTracking === undefined) {
+    return;
+  }
+
+  const events = mediaTracking.update(mediaEvent, customEvent, player, ad, adBreak);
+
+  // Update page activity in order to keep sending page pings if needed
+  if (mediaTracking.shouldUpdatePageActivity()) {
+    dispatchToTrackersInCollection(trackers, _trackers, (t) => {
+      t.updatePageActivity();
+    });
+  }
+
+  if (events.length == 0) {
+    return;
+  }
+
+  // Send all created events to the trackers
+  dispatchToTrackersInCollection(trackers, _trackers, (t) => {
+    events.forEach((event) => {
+      t.core.track(buildSelfDescribingEvent(event), event.context.concat(context), timestamp);
+    });
+  });
+}

--- a/plugins/browser-plugin-media/src/core.ts
+++ b/plugins/browser-plugin-media/src/core.ts
@@ -1,0 +1,60 @@
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+import {
+  getMediaEventSchema,
+  MEDIA_AD_BREAK_SCHEMA,
+  MEDIA_AD_SCHEMA,
+  MEDIA_PLAYER_SCHEMA,
+  MEDIA_SESSION_SCHEMA,
+} from './schemata';
+import { MediaPlayer, MediaAd, MediaAdBreak, MediaSession, MediaEvent } from './types';
+
+export function buildMediaPlayerEvent(event: MediaEvent): SelfDescribingJson {
+  return {
+    schema: getMediaEventSchema(event.type),
+    data: removeEmptyProperties(event.eventBody ?? {}),
+  };
+}
+
+export function buildMediaPlayerEntity(mediaPlayer: MediaPlayer): SelfDescribingJson {
+  return {
+    schema: MEDIA_PLAYER_SCHEMA,
+    data: removeEmptyProperties(mediaPlayer),
+  };
+}
+
+export function buildMediaSessionEntity(session: MediaSession): SelfDescribingJson {
+  return {
+    schema: MEDIA_SESSION_SCHEMA,
+    data: removeEmptyProperties(session),
+  };
+}
+
+export function buildMediaAdEntity(ad: MediaAd): SelfDescribingJson {
+  return {
+    schema: MEDIA_AD_SCHEMA,
+    data: removeEmptyProperties(ad),
+  };
+}
+
+export function buildMediaAdBreakEntity(adBreak: MediaAdBreak): SelfDescribingJson {
+  return {
+    schema: MEDIA_AD_BREAK_SCHEMA,
+    data: removeEmptyProperties(adBreak),
+  };
+}
+
+/**
+ * Returns a copy of a JSON with undefined and null properties removed
+ *
+ * @param event - Object to clean
+ * @returns A cleaned copy of eventJson
+ */
+function removeEmptyProperties(event: Record<string, unknown>): Record<string, unknown> {
+  const ret: Record<string, unknown> = {};
+  for (const k in event) {
+    if (event[k] != null) {
+      ret[k] = event[k];
+    }
+  }
+  return ret;
+}

--- a/plugins/browser-plugin-media/src/index.ts
+++ b/plugins/browser-plugin-media/src/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/plugins/browser-plugin-media/src/mediaTracking.ts
+++ b/plugins/browser-plugin-media/src/mediaTracking.ts
@@ -1,0 +1,208 @@
+import { LOG, SelfDescribingJson } from '@snowplow/tracker-core';
+import { MediaAdTracking } from './adTracking';
+import { buildMediaPlayerEntity, buildMediaPlayerEvent } from './core';
+import { MediaPingInterval } from './pingInterval';
+import { MediaSessionTracking } from './sessionTracking';
+import {
+  MediaPlayer,
+  MediaAdUpdate,
+  MediaPlayerAdBreakUpdate,
+  MediaPlayerUpdate,
+  MediaEventType,
+  MediaEvent,
+} from './types';
+
+/**
+ * Manages the state and built-in entities for a media tracking that starts when a user
+ * call `startMediaTracking` and ends with `endMediaTracking`.
+ *
+ * It updates the internal state for each tracked event and returns context entities with
+ * properties updated based on the internal state.
+ */
+export class MediaTracking {
+  /// ID of the media tracking that is used to refer to it by the user.
+  id: string;
+  /// Percentage boundaries when to track percent progress events.
+  private boundaries?: number[];
+  /// List of boundaries for which percent progress events were already sent to avoid sending again.
+  private sentBoundaries: number[] = [];
+  /// State for the media player context entity that is updated as new events are tracked.
+  player: MediaPlayer = {
+    currentTime: 0,
+    paused: true,
+    ended: false,
+  };
+
+  /// Used to add media player session entity.
+  private session?: MediaSessionTracking;
+  /// Tracks ping events independently but stored here to stop when media tracking stops.
+  private pingInterval?: MediaPingInterval;
+  /// Manages ad entities.
+  private adTracking = new MediaAdTracking();
+  /// Used to prevent tracking seek start events multiple times.
+  private isSeeking = false;
+  /// Context entities to attach to all events
+  private customContext?: Array<SelfDescribingJson>;
+  /// Optional list of event types to allow tracking and discard others.
+  private captureEvents?: MediaEventType[];
+  // Whether to update page activity when playing media. Enabled by default.
+  private updatePageActivityWhilePlaying?: boolean;
+
+  constructor(
+    id: string,
+    player?: MediaPlayerUpdate,
+    session?: MediaSessionTracking,
+    pingInterval?: MediaPingInterval,
+    boundaries?: number[],
+    captureEvents?: MediaEventType[],
+    updatePageActivityWhilePlaying?: boolean,
+    context?: Array<SelfDescribingJson>
+  ) {
+    this.id = id;
+    this.updatePlayer(player);
+    this.session = session;
+    this.pingInterval = pingInterval;
+    this.boundaries = boundaries;
+    this.captureEvents = captureEvents;
+    this.updatePageActivityWhilePlaying = updatePageActivityWhilePlaying;
+    this.customContext = context;
+
+    // validate event names in the captureEvents list
+    captureEvents?.forEach((eventType) => {
+      if (!Object.values(MediaEventType).includes(eventType)) {
+        LOG.warn('Unknown media event ' + eventType);
+      }
+    });
+  }
+
+  /**
+   * Called when user calls `endMediaTracking()`.
+   */
+  stop() {
+    this.pingInterval?.clear();
+  }
+
+  /**
+   * Updates the internal state given the new event or new media player info and returns events to track.
+   * @param eventType Type of the event tracked or undefined when only updating player properties.
+   * @param player Updates to the media player stored entity.
+   * @param ad Updates to the ad entity.
+   * @param adBreak Updates to the ad break entity.
+   * @returns List of events with entities to track.
+   */
+  update(
+    mediaEvent?: MediaEvent,
+    customEvent?: SelfDescribingJson,
+    player?: MediaPlayerUpdate,
+    ad?: MediaAdUpdate,
+    adBreak?: MediaPlayerAdBreakUpdate
+  ): { event: SelfDescribingJson; context: SelfDescribingJson[] }[] {
+    // update state
+    this.updatePlayer(player);
+    if (mediaEvent !== undefined) {
+      this.adTracking.updateForThisEvent(mediaEvent.type, this.player, ad, adBreak);
+    }
+    this.session?.update(mediaEvent?.type, this.player, this.adTracking.adBreak);
+    this.pingInterval?.update(this.player);
+
+    // build context entities
+    let context = [buildMediaPlayerEntity(this.player)];
+    if (this.session !== undefined) {
+      context.push(this.session.getContext());
+    }
+    if (this.customContext) {
+      context = context.concat(this.customContext);
+    }
+    context = context.concat(this.adTracking.getContext());
+
+    // build event types to track
+    const mediaEventsToTrack: MediaEvent[] = [];
+    if (mediaEvent !== undefined && this.shouldTrackEvent(mediaEvent.type)) {
+      mediaEventsToTrack.push(mediaEvent);
+    }
+    if (this.shouldSendPercentProgress()) {
+      mediaEventsToTrack.push({
+        type: MediaEventType.PercentProgress,
+        eventBody: { percentProgress: this.getPercentProgress() },
+      });
+    }
+
+    // update state for events after this one
+    if (mediaEvent !== undefined) {
+      this.adTracking.updateForNextEvent(mediaEvent.type);
+    }
+
+    const eventsToTrack = mediaEventsToTrack.map((event) => {
+      return { event: buildMediaPlayerEvent(event), context: context };
+    });
+    if (customEvent !== undefined) {
+      eventsToTrack.push({ event: customEvent, context: context });
+    }
+    return eventsToTrack;
+  }
+
+  shouldUpdatePageActivity(): boolean {
+    return (this.updatePageActivityWhilePlaying ?? true) && !this.player.paused;
+  }
+
+  private updatePlayer(player?: MediaPlayerUpdate) {
+    if (player !== undefined) {
+      this.player = {
+        ...this.player,
+        ...player,
+      };
+    }
+  }
+
+  private shouldSendPercentProgress(): boolean {
+    const percentProgress = this.getPercentProgress();
+    if (this.boundaries === undefined || percentProgress === undefined || this.player.paused) {
+      return false;
+    }
+
+    let boundaries = this.boundaries.filter((b) => b <= (percentProgress ?? 0));
+    if (boundaries.length == 0) {
+      return false;
+    }
+    let boundary = Math.max(...boundaries);
+    if (!this.sentBoundaries.includes(boundary)) {
+      this.sentBoundaries.push(boundary);
+      return true;
+    }
+    return false;
+  }
+
+  private shouldTrackEvent(eventType: MediaEventType): boolean {
+    return this.updateSeekingAndCheckIfShouldTrack(eventType) && this.allowedToCaptureEventType(eventType);
+  }
+
+  /** Prevents multiple seek start events to be tracked after each other without a seek end (happens when scrubbing). */
+  private updateSeekingAndCheckIfShouldTrack(eventType: MediaEventType): boolean {
+    if (eventType == MediaEventType.SeekStart) {
+      if (this.isSeeking) {
+        return false;
+      }
+
+      this.isSeeking = true;
+    } else if (eventType == MediaEventType.SeekEnd) {
+      this.isSeeking = false;
+    }
+
+    return true;
+  }
+
+  private allowedToCaptureEventType(eventType: MediaEventType): boolean {
+    return this.captureEvents === undefined || this.captureEvents.includes(eventType);
+  }
+
+  private getPercentProgress(): number | undefined {
+    if (
+      this.player.duration === null ||
+      this.player.duration === undefined ||
+      this.player.duration == 0
+    ) {
+      return undefined;
+    }
+    return Math.floor(((this.player.currentTime ?? 0) / this.player.duration) * 100);
+  }
+}

--- a/plugins/browser-plugin-media/src/pingInterval.ts
+++ b/plugins/browser-plugin-media/src/pingInterval.ts
@@ -1,0 +1,49 @@
+import { MediaPlayer } from './types';
+
+/**
+ * Default ping interval in seconds.
+ * Changing the setting is a breaking change for downstream models that work with this setting.
+ * If a custom interval is used, it is present in the session context entity.
+ **/
+const DEFAULT_PING_INTERVAL = 30;
+
+/** Manages the timer for firing the media ping events. */
+export class MediaPingInterval {
+  private interval?: ReturnType<typeof setInterval>;
+  private paused?: boolean;
+  private numPausedPings = 0;
+  private maxPausedPings = 1;
+
+  constructor(pingIntervalSeconds: number | undefined, maxPausedPings: number | undefined, trackPing: () => void) {
+    if (maxPausedPings !== undefined) {
+      this.maxPausedPings = maxPausedPings;
+    }
+
+    this.interval = setInterval(() => {
+      if (!this.isPaused() || this.numPausedPings < this.maxPausedPings) {
+        if (this.isPaused()) {
+          this.numPausedPings++;
+        }
+        trackPing();
+      }
+    }, (pingIntervalSeconds ?? DEFAULT_PING_INTERVAL) * 1000);
+  }
+
+  update(player: MediaPlayer) {
+    this.paused = player.paused;
+    if (!this.paused) {
+      this.numPausedPings = 0;
+    }
+  }
+
+  clear() {
+    if (this.interval !== undefined) {
+      clearInterval(this.interval);
+      this.interval = undefined;
+    }
+  }
+
+  private isPaused() {
+    return this.paused === true;
+  }
+}

--- a/plugins/browser-plugin-media/src/schemata.ts
+++ b/plugins/browser-plugin-media/src/schemata.ts
@@ -1,0 +1,27 @@
+import { MediaEventType } from './types';
+
+const MEDIA_SCHEMA_PREFIX = 'iglu:com.snowplowanalytics.snowplow.media/';
+const MEDIA_SCHEMA_SUFFIX = '/jsonschema/1-0-0';
+export const MEDIA_PLAYER_SCHEMA = MEDIA_SCHEMA_PREFIX + 'player' + MEDIA_SCHEMA_SUFFIX;
+export const MEDIA_SESSION_SCHEMA = MEDIA_SCHEMA_PREFIX + 'session' + MEDIA_SCHEMA_SUFFIX;
+export const MEDIA_AD_SCHEMA = MEDIA_SCHEMA_PREFIX + 'ad' + MEDIA_SCHEMA_SUFFIX;
+export const MEDIA_AD_BREAK_SCHEMA = MEDIA_SCHEMA_PREFIX + 'ad_break' + MEDIA_SCHEMA_SUFFIX;
+
+function eventNameForEventType(eventType: MediaEventType): string {
+  /// ad first quartile, midpoint, and third quartile events share the same schema
+  switch (eventType) {
+    case MediaEventType.AdFirstQuartile:
+      return 'ad_quartile';
+    case MediaEventType.AdMidpoint:
+      return 'ad_quartile';
+    case MediaEventType.AdThirdQuartile:
+      return 'ad_quartile';
+  }
+
+  return eventType;
+}
+
+export function getMediaEventSchema(eventType: MediaEventType): string {
+  const eventName = eventNameForEventType(eventType);
+  return MEDIA_SCHEMA_PREFIX + eventName + '_event' + MEDIA_SCHEMA_SUFFIX;
+}

--- a/plugins/browser-plugin-media/src/sessionStats.ts
+++ b/plugins/browser-plugin-media/src/sessionStats.ts
@@ -1,0 +1,203 @@
+import {
+  MediaAdBreakType,
+  MediaPlayer,
+  MediaAdBreak,
+  MediaEventType,
+  MediaSessionStats,
+} from './types';
+
+/** Internal type for representing the session updates */
+type Log = {
+  eventType: MediaEventType | undefined;
+  time: number;
+  contentTime: number;
+  playbackRate?: number;
+  paused: boolean;
+  muted?: boolean;
+  linearAd: boolean;
+};
+
+const adStartTypes = [MediaEventType.AdStart, MediaEventType.AdResume];
+const adProgressTypes = [
+  MediaEventType.AdClick,
+  MediaEventType.AdFirstQuartile,
+  MediaEventType.AdMidpoint,
+  MediaEventType.AdThirdQuartile,
+];
+const adEndTypes = [MediaEventType.AdComplete, MediaEventType.AdSkip, MediaEventType.AdPause];
+const bufferingEndTypes = [MediaEventType.BufferEnd, MediaEventType.Play];
+
+/** Calculates the average playback rate based on measurements of the rate over partial durations */
+class AveragePlaybackRateCalculator {
+  private durationWithPlaybackRate = 0;
+  private duration = 0;
+
+  add(rate: number, duration: number) {
+    this.durationWithPlaybackRate += rate * duration;
+    this.duration += duration;
+  }
+
+  get(): number | undefined {
+    return this.duration > 0 ? this.durationWithPlaybackRate / this.duration : undefined;
+  }
+}
+
+/**
+ * Calculates statistics in the media player session as events are tracked.
+ */
+export class MediaSessionTrackingStats {
+  /// time for which ads were playing
+  private adPlaybackDuration = 0;
+  /// time for which the content was playing
+  private playbackDuration = 0;
+  /// time for which the content was playing on mute
+  private playbackDurationMuted = 0;
+  /// average playback rate calculator
+  private avgPlaybackRate = new AveragePlaybackRateCalculator();
+  /// time for which the playback was paused
+  private pausedDuration = 0;
+  /// number of ads
+  private ads = 0;
+  /// number of ad breaks
+  private adBreaks = 0;
+  /// number of ad skip events
+  private adsSkipped = 0;
+  /// number of ad click events
+  private adsClicked = 0;
+  /// sum of time durations between the buffer start event and end of buffering
+  private bufferingDuration = 0;
+  /// set of seconds in content time that were played used to calculate the content watched duration
+  private playedSeconds = new Set();
+
+  private lastAdUpdateAt: number | undefined;
+  private bufferingStartedAt: number | undefined;
+  private bufferingStartTime: number | undefined;
+  private lastLog: Log | undefined;
+
+  /// Update stats given a new event.
+  update(eventType: MediaEventType | undefined, player: MediaPlayer, adBreak?: MediaAdBreak) {
+    let log: Log = {
+      time: new Date().getTime() / 1000,
+      contentTime: player.currentTime,
+      eventType: eventType,
+      playbackRate: player.playbackRate,
+      paused: player.paused,
+      muted: player.muted,
+      linearAd: (adBreak?.breakType ?? MediaAdBreakType.Linear) == MediaAdBreakType.Linear,
+    };
+
+    this.updateDurationStats(log);
+    this.updateAdStats(log);
+    this.updateBufferingStats(log);
+
+    this.lastLog = log;
+  }
+
+  /// Produce part of the media session entity with the stats.
+  toSessionContextEntity(): MediaSessionStats {
+    return {
+      timePaused: this.pausedDuration > 0 ? this.round(this.pausedDuration) : undefined,
+      timePlayed: this.playbackDuration > 0 ? this.round(this.playbackDuration) : undefined,
+      timePlayedMuted: this.playbackDurationMuted > 0 ? this.round(this.playbackDurationMuted) : undefined,
+      timeSpentAds: this.adPlaybackDuration > 0 ? this.round(this.adPlaybackDuration) : undefined,
+      timeBuffering: this.bufferingDuration > 0 ? this.round(this.bufferingDuration) : undefined,
+      ads: this.ads > 0 ? this.ads : undefined,
+      adBreaks: this.adBreaks > 0 ? this.adBreaks : undefined,
+      adsSkipped: this.adsSkipped > 0 ? this.adsSkipped : undefined,
+      adsClicked: this.adsClicked > 0 ? this.adsClicked : undefined,
+      avgPlaybackRate: this.round(this.avgPlaybackRate.get()),
+      contentWatched: this.playedSeconds.size > 0 ? this.playedSeconds.size : undefined,
+    };
+  }
+
+  private updateDurationStats(log: Log) {
+    // if ad was playing until now and it was a linear ad, don't add the duration stats
+    let wasPlayingAd = this.lastAdUpdateAt !== undefined;
+    const shouldCountStats = (!wasPlayingAd || !log.linearAd) ?? true;
+    if (!shouldCountStats) {
+      return;
+    }
+
+    if (this.lastLog !== undefined) {
+      // add the time diff since last event to duration stats
+      let duration = log.time - this.lastLog.time;
+      if (this.lastLog.paused) {
+        this.pausedDuration += duration;
+      } else {
+        this.playbackDuration += duration;
+        if (this.lastLog.playbackRate !== undefined) {
+          this.avgPlaybackRate.add(this.lastLog.playbackRate, duration);
+        }
+
+        if (this.lastLog.muted) {
+          this.playbackDurationMuted += duration;
+        }
+
+        if (!log.paused) {
+          for (let i = Math.floor(this.lastLog.contentTime); i < log.contentTime; i++) {
+            this.playedSeconds.add(i);
+          }
+        }
+      }
+    }
+    if (!log.paused) {
+      this.playedSeconds.add(Math.floor(log.contentTime));
+    }
+  }
+
+  private updateAdStats(log: Log) {
+    // only works with ad event types
+    if (log.eventType === undefined) {
+      return;
+    }
+
+    // count ad actions
+    if (log.eventType == MediaEventType.AdBreakStart) {
+      this.adBreaks++;
+    } else if (log.eventType == MediaEventType.AdStart) {
+      this.ads++;
+    } else if (log.eventType == MediaEventType.AdSkip) {
+      this.adsSkipped++;
+    } else if (log.eventType == MediaEventType.AdClick) {
+      this.adsClicked++;
+    }
+
+    // update ad playback duration
+    if (this.lastAdUpdateAt === undefined) {
+      if (adStartTypes.includes(log.eventType)) {
+        this.lastAdUpdateAt = log.time;
+      }
+    } else if (adProgressTypes.includes(log.eventType)) {
+      this.adPlaybackDuration += log.time - this.lastAdUpdateAt;
+      this.lastAdUpdateAt = log.time;
+    } else if (adEndTypes.includes(log.eventType)) {
+      this.adPlaybackDuration += log.time - this.lastAdUpdateAt;
+      this.lastAdUpdateAt = undefined;
+    }
+  }
+
+  private updateBufferingStats(log: Log) {
+    if (log.eventType == MediaEventType.BufferStart) {
+      this.bufferingStartedAt = log.time;
+      this.bufferingStartTime = log.contentTime;
+    } else if (this.bufferingStartedAt !== undefined) {
+      // Either the playback moved or BufferEnd or Play events were tracked
+      if (
+        (log.contentTime != this.bufferingStartTime && !log.paused) ||
+        (log.eventType !== undefined && bufferingEndTypes.includes(log.eventType))
+      ) {
+        this.bufferingDuration += log.time - this.bufferingStartedAt;
+        this.bufferingStartedAt = undefined;
+        this.bufferingStartTime = undefined;
+      } else {
+        this.bufferingDuration += log.time - this.bufferingStartedAt;
+        this.bufferingStartedAt = log.time;
+      }
+    }
+  }
+
+  private round(n: number | undefined): number | undefined {
+    if (n === undefined) { return undefined; }
+    return Math.round(n * 1000) / 1000;
+  }
+}

--- a/plugins/browser-plugin-media/src/sessionTracking.ts
+++ b/plugins/browser-plugin-media/src/sessionTracking.ts
@@ -1,0 +1,35 @@
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+import { buildMediaSessionEntity } from './core';
+import { MediaSessionTrackingStats } from './sessionStats';
+import { MediaAdBreak, MediaPlayer, MediaEventType } from './types';
+
+/**
+ * Manages the media player session that is optionally added as a context entity
+ * in media tracking.
+ */
+export class MediaSessionTracking {
+  /// Same as the ID of the media tracking.
+  private id: string;
+  private startedAt: Date;
+  private pingInterval?: number;
+  private stats = new MediaSessionTrackingStats();
+
+  constructor(id: string, startedAt?: Date, pingInterval?: number) {
+    this.id = id;
+    this.pingInterval = pingInterval;
+    this.startedAt = startedAt ?? new Date();
+  }
+
+  update(eventType: MediaEventType | undefined, player: MediaPlayer, adBreak?: MediaAdBreak) {
+    this.stats.update(eventType, player, adBreak);
+  }
+
+  getContext(): SelfDescribingJson {
+    return buildMediaSessionEntity({
+      mediaSessionId: this.id,
+      startedAt: this.startedAt,
+      pingInterval: this.pingInterval,
+      ...this.stats.toSessionContextEntity(),
+    });
+  }
+}

--- a/plugins/browser-plugin-media/src/types.ts
+++ b/plugins/browser-plugin-media/src/types.ts
@@ -1,0 +1,382 @@
+import { CommonEventProperties, SelfDescribingJson } from '@snowplow/tracker-core';
+
+/** Type of media player event */
+export enum MediaEventType {
+  // Controlling the playback
+
+  /** Media player event fired when the media tracking is successfully attached to the player and can track events. */
+  Ready = 'ready',
+  /** Media player event sent when the player changes state to playing from previously being paused. */
+  Play = 'play',
+  /** Media player event sent when the user pauses the playback. */
+  Pause = 'pause',
+  /** Media player event sent when playback stops when end of the media is reached or because no further data is available. */
+  End = 'end',
+  /** Media player event sent when a seek operation begins. */
+  SeekStart = 'seek_start',
+  /** Media player event sent when a seek operation completes. */
+  SeekEnd = 'seek_end',
+
+  // Changes in playback settings
+
+  /** Media player event sent when the playback rate has changed. */
+  PlaybackRateChange = 'playback_rate_change',
+  /** Media player event sent when the volume has changed. */
+  VolumeChange = 'volume_change',
+  /** Media player event fired immediately after the browser switches into or out of full-screen mode. */
+  FullscreenChange = 'fullscreen_change',
+  /** Media player event fired immediately after the browser switches into or out of picture-in-picture mode. */
+  PictureInPictureChange = 'picture_in_picture_change',
+
+  // Tracking playback progress
+
+  /** Media player event fired periodically during main content playback, regardless of other API events that have been sent. */
+  Ping = 'ping',
+  /** Media player event fired when a percentage boundary set in options.boundaries is reached */
+  PercentProgress = 'percent_progress',
+
+  // Ad events
+
+  /** Media player event that signals the start of an ad break. */
+  AdBreakStart = 'ad_break_start',
+  /** Media player event that signals the end of an ad break. */
+  AdBreakEnd = 'ad_break_end',
+  /** Media player event that signals the start of an ad. */
+  AdStart = 'ad_start',
+  /** Media player event fired when a quartile of ad is reached after continuous ad playback at normal speed. */
+  AdFirstQuartile = 'ad_first_quartile',
+  /** Media player event fired when a midpoint of ad is reached after continuous ad playback at normal speed. */
+  AdMidpoint = 'ad_midpoint',
+  /** Media player event fired when a quartile of ad is reached after continuous ad playback at normal speed. */
+  AdThirdQuartile = 'ad_third_quartile',
+  /** Media player event that signals the ad creative was played to the end at normal speed. */
+  AdComplete = 'ad_complete',
+  /** Media player event fired when the user activated a skip control to skip the ad creative. */
+  AdSkip = 'ad_skip',
+  /** Media player event fired when the user clicked on the ad. */
+  AdClick = 'ad_click',
+  /** Media player event fired when the user clicked the pause control and stopped the ad creative. */
+  AdPause = 'ad_pause',
+  /** Media player event fired when the user resumed playing the ad creative after it had been stopped or paused. */
+  AdResume = 'ad_resume',
+
+  // Data quality events
+
+  /** Media player event fired when the player goes into the buffering state and begins to buffer content. */
+  BufferStart = 'buffer_start',
+  /** Media player event fired when the the player finishes buffering content and resumes playback. */
+  BufferEnd = 'buffer_end',
+  /** Media player event tracked when the video playback quality changes automatically. */
+  QualityChange = 'quality_change',
+  /** Media player event tracked when the resource could not be loaded due to an error.  */
+  Error = 'error',
+}
+
+export type MediaTrackingConfiguration = {
+  /** Unique ID of the media tracking. The same ID will be used for media player session if enabled. */
+  id: string;
+  /** Attributes for the media player context entity */
+  player?: MediaPlayerUpdate;
+  /** Attributes for the media player session context entity or false to disable it. Enabled by default. */
+  session?: {
+    /** Local date-time timestamp of when the session started. Automatically set to current time if not given. */
+    startedAt?: Date
+  } | false;
+  /** Configuration for sending ping events. Enabled by default.  */
+  pings?:
+    | {
+        /** Interval in seconds for sending ping events. Defaults to 30s. */
+        pingInterval?: number;
+        /** Maximum number of consecutive ping events to send when playback is paused. Defaults to 1. */
+        maxPausedPings?: number;
+      }
+    | boolean;
+  /** Update page activity in order to keep sending page ping events while playing. Enabled by default. */
+  updatePageActivityWhilePlaying?: boolean;
+  /** Percentage boundaries when to send percent progress events. Disabled by default. */
+  boundaries?: number[];
+  /**
+   * List of event types to allow tracking.
+   * If not specified, all tracked events will be allowed and tracked.
+   * Otherwise, tracked event types not present in the list will be discarded.
+   */
+  captureEvents?: MediaEventType[];
+};
+
+export type MediaTrackPlaybackRateChangeArguments = {
+  /** Playback rate before the change (1 is normal) */
+  previousRate?: number;
+  /** Playback rate after the change (1 is normal) */
+  newRate: number;
+};
+
+export type MediaTrackVolumeChangeArguments = {
+  /** Volume percentage before the change. */
+  previousVolume?: number;
+  /** Volume percentage after the change. */
+  newVolume: number;
+};
+
+export type MediaTrackFullscreenChangeArguments = {
+  /** Whether the video element is fullscreen after the change. */
+  fullscreen: boolean;
+};
+
+export type MediaTrackPictureInPictureChangeArguments = {
+  /** Whether the video element is showing picture-in-picture after the change. */
+  pictureInPicture: boolean;
+};
+
+export type MediaTrackAdPercentProgressArguments = {
+  /** The percent of the way through the ad. */
+  percentProgress?: number;
+};
+
+export type MediaTrackQualityChangeArguments = {
+  /** Quality level before the change (e.g., 1080p). */
+  previousQuality?: string;
+  /** Quality level after the change (e.g., 1080p). */
+  newQuality?: string;
+  /** The current bitrate in bits per second. */
+  bitrate?: number;
+  /** The current number of frames per second. */
+  framesPerSecond?: number;
+  /** Whether the change was automatic or triggered by the user. */
+  automatic?: boolean;
+};
+
+export type MediaTrackErrorArguments = {
+  /** Error-identifying code for the playback issue. E.g. E522 */
+  errorCode?: string;
+  /** Name for the type of error that occurred in the playback. E.g. forbidden */
+  errorName?: string;
+  /** Longer description for the error occurred in the playback. */
+  errorDescription?: string;
+};
+
+export type MediaTrackArguments = {
+  /** ID of the media tracking */
+  id: string;
+  /** Attributes for the media player context entity */
+  player?: MediaPlayerUpdate;
+};
+
+export type MediaTrackAdArguments = {
+  /** Attributes for the media player ad context entity */
+  ad?: MediaAdUpdate;
+};
+
+export type MediaTrackAdBreakArguments = {
+  /** Attributes for the media player ad break context entity */
+  adBreak?: MediaPlayerAdBreakUpdate;
+};
+
+export type MediaTrackSelfDescribingEventArguments = {
+  /** Self-describing event */
+  event: SelfDescribingJson;
+};
+
+/** Type for all media player events */
+export interface MediaEvent {
+  /** The event fired by the media player */
+  type: MediaEventType;
+  /** The custom media identifier given by the user */
+  eventBody?: Record<string, unknown>;
+}
+
+/** Type of media content. */
+export enum MediaType {
+  /** Audio content. */
+  Audio = 'audio',
+  /** Video content. */
+  Video = 'video',
+}
+
+/** Type/Schema for a context entity for media player events with information about the current state of the media player */
+export interface MediaPlayer extends Record<string, unknown> {
+  /** The current playback time position within the media in seconds */
+  currentTime: number;
+  /** A double-precision floating-point value indicating the duration of the media in seconds */
+  duration?: number | null;
+  /** If playback of the media has ended */
+  ended: boolean;
+  /** Whether the video element is fullscreen */
+  fullscreen?: boolean;
+  /** Whether the media is a live stream */
+  livestream?: boolean;
+  /** Human readable name given to tracked media content. */
+  label?: string;
+  /** If the video should restart after ending */
+  loop?: boolean;
+  /** Type of media content. */
+  mediaType?: MediaType;
+  /** If the media element is muted */
+  muted?: boolean;
+  /** If the media element is paused */
+  paused: boolean;
+  /** Whether the video element is showing picture-in-picture */
+  pictureInPicture?: boolean;
+  /** Type of the media player (e.g., com.youtube-youtube, com.vimeo-vimeo, org.whatwg-media_element) */
+  playerType?: string;
+  /** Playback rate (1 is normal) */
+  playbackRate?: number;
+  /** Quality level of the playback (e.g., 1080p). */
+  quality?: string;
+  /** Volume level */
+  volume?: number;
+}
+
+/** Partial type/schema for a context entity for media player events with information about the current state of the media player */
+export interface MediaPlayerUpdate {
+  /** The current playback time position within the media in seconds */
+  currentTime?: number;
+  /** A double-precision floating-point value indicating the duration of the media in seconds */
+  duration?: number | null;
+  /** If playback of the media has ended */
+  ended?: boolean;
+  /** Whether the video element is fullscreen */
+  fullscreen?: boolean;
+  /** Whether the media is a live stream */
+  livestream?: boolean;
+  /** Human readable name given to tracked media content. */
+  label?: string;
+  /** If the video should restart after ending */
+  loop?: boolean;
+  /** Type of media content. */
+  mediaType?: MediaType;
+  /** If the media element is muted */
+  muted?: boolean;
+  /** If the media element is paused */
+  paused?: boolean;
+  /** Whether the video element is showing picture-in-picture */
+  pictureInPicture?: boolean;
+  /** Type of the media player (e.g., com.youtube-youtube, com.vimeo-vimeo, org.whatwg-media_element) */
+  playerType?: string;
+  /** Playback rate (1 is normal) */
+  playbackRate?: number;
+  /** Quality level of the playback (e.g., 1080p). */
+  quality?: string;
+  /** Volume level */
+  volume?: number;
+}
+
+/** Partial type/schema for a context entity for media player events that tracks a session of a single media player usage */
+export interface MediaSession extends Record<string, unknown> {
+  /** An identifier for the media session that is kept while the media content is played in the media player. Does not reset automatically. */
+  mediaSessionId: string;
+  /** Date-time timestamp of when the session started */
+  startedAt?: Date;
+  /** Interval (seconds) in which the ping events will be sent */
+  pingInterval?: number;
+}
+
+/** Partial type/schema for a context entity for media player events that tracks a session of a single media player usage */
+export interface MediaSessionStats {
+  /** Total seconds user spent with paused content (excluding linear ads) */
+  timePaused?: number;
+  /** Total seconds user spent playing content (excluding linear ads) */
+  timePlayed?: number;
+  /** Total seconds user spent playing content on mute (excluding linear ads) */
+  timePlayedMuted?: number;
+  /** Total seconds of the content played. Each part of the content played is counted once (i.e., counts rewinding or rewatching the same content only once). Playback rate does not affect this value. */
+  contentWatched?: number;
+  /** Total seconds that ads played during the session */
+  timeSpentAds?: number;
+  /** Total seconds that playback was buffering during the session */
+  timeBuffering?: number;
+  /** Number of ads played */
+  ads?: number;
+  /** Number of ads that the user clicked on */
+  adsClicked?: number;
+  /** Number of ads that the user skipped */
+  adsSkipped?: number;
+  /** Number of ad breaks played */
+  adBreaks?: number;
+  /** Average playback rate (1 is normal speed) */
+  avgPlaybackRate?: number;
+}
+
+/** Partial type/schema for a context entity with information about the currently played ad */
+export interface MediaAdUpdate {
+  /** Friendly name of the ad */
+  name?: string;
+  /** Unique identifier for the ad */
+  adId: string;
+  /** The ID of the ad creative */
+  creativeId?: string;
+  /** The position of the ad within the ad break, starting with 1 */
+  podPosition?: number;
+  /** Length of the video ad in seconds */
+  duration?: number;
+  /** Indicating whether skip controls are made available to the end user */
+  skippable?: boolean;
+}
+
+/** Type/Schema for a context entity with information about the currently played ad */
+export interface MediaAd extends Record<string, unknown> {
+  /** Friendly name of the ad */
+  name?: string;
+  /** Unique identifier for the ad */
+  adId: string;
+  /** The ID of the ad creative */
+  creativeId?: string;
+  /** The position of the ad within the ad break, starting with 1 */
+  podPosition?: number;
+  /** Length of the video ad in seconds */
+  duration?: number;
+  /** Indicating whether skip controls are made available to the end user */
+  skippable?: boolean;
+}
+
+/** Type of ads within the break */
+export enum MediaAdBreakType {
+  /** Take full control of the video for a period of time. */
+  Linear = 'linear',
+  /** Run concurrently to the video. */
+  NonLinear = 'nonlinear',
+  /** Accompany the video but placed outside the player. */
+  Companion = 'companion',
+}
+
+/** Type/Schema for a context entity, shared with all media_player_ad events belonging to the ad break */
+export interface MediaAdBreak extends Record<string, unknown> {
+  /** Ad break name (e.g., pre-roll, mid-roll, and post-roll) */
+  name?: string;
+  /** An identifier for the ad break */
+  breakId: string;
+  /** Playback time in seconds at the start of the ad break. */
+  startTime: number;
+  /**
+   * Type of ads within the break:
+   * - linear (take full control of the video for a period of time),
+   * - nonlinear (run concurrently to the video),
+   * - companion (accompany the video but placed outside the player)
+   */
+  breakType?: MediaAdBreakType;
+  /** The number of ads to be played within the ad break */
+  podSize?: number;
+}
+
+/** Partial type/schema for a context entity, shared with all media_player_ad events belonging to the ad break */
+export interface MediaPlayerAdBreakUpdate {
+  /** Ad break name (e.g., pre-roll, mid-roll, and post-roll) */
+  name?: string;
+  /** An identifier for the ad break */
+  breakId: string;
+  /** Playback time in seconds at the start of the ad break. */
+  startTime?: number;
+  /**
+   * Type of ads within the break:
+   * - linear (take full control of the video for a period of time),
+   * - nonlinear (run concurrently to the video),
+   * - companion (accompany the video but placed outside the player)
+   */
+  breakType?: MediaAdBreakType;
+  /** The number of ads to be played within the ad break */
+  podSize?: number;
+}
+
+export interface CommonMediaEventProperties extends CommonEventProperties {
+  /** Add context entities to an event by setting an Array of Self Describing JSON */
+  context?: Array<SelfDescribingJson>;
+}

--- a/plugins/browser-plugin-media/test/api.test.ts
+++ b/plugins/browser-plugin-media/test/api.test.ts
@@ -1,0 +1,653 @@
+import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
+import { PayloadBuilder, SelfDescribingJson } from '@snowplow/tracker-core';
+import {
+  endMediaTracking,
+  SnowplowMediaPlugin,
+  startMediaTracking,
+  trackMediaAdBreakEnd,
+  trackMediaAdBreakStart,
+  trackMediaAdClick,
+  trackMediaAdComplete,
+  trackMediaAdFirstQuartile,
+  trackMediaAdMidpoint,
+  trackMediaAdPause,
+  trackMediaAdResume,
+  trackMediaAdSkip,
+  trackMediaAdStart,
+  trackMediaAdThirdQuartile,
+  trackMediaBufferEnd,
+  trackMediaBufferStart,
+  trackMediaEnd,
+  trackMediaError,
+  trackMediaFullscreenChange,
+  trackMediaPause,
+  trackMediaPictureInPictureChange,
+  trackMediaPlay,
+  trackMediaPlaybackRateChange,
+  trackMediaQualityChange,
+  trackMediaReady,
+  trackMediaSeekEnd,
+  trackMediaSeekStart,
+  trackMediaSelfDescribingEvent,
+  trackMediaVolumeChange,
+  updateMediaTracking,
+} from '../src';
+import { getMediaEventSchema, MEDIA_PLAYER_SCHEMA, MEDIA_SESSION_SCHEMA } from '../src/schemata';
+import { MediaEventType } from '../src/types';
+
+describe('Media Tracking API', () => {
+  let idx = 1;
+  let id = '';
+  let eventQueue: { event: SelfDescribingJson; context: SelfDescribingJson[] }[] = [];
+
+  beforeEach(() => {
+    addTracker(`sp${idx++}`, `sp${idx++}`, 'js-3.9.0', '', new SharedState(), {
+      stateStorageStrategy: 'cookie',
+      encodeBase64: false,
+      plugins: [
+        SnowplowMediaPlugin(),
+        {
+          beforeTrack: (pb: PayloadBuilder) => {
+            const { ue_pr, co, tna } = pb.getPayload();
+            if (tna == `sp${idx - 1}`) {
+              eventQueue.push({ event: JSON.parse(ue_pr as string).data, context: JSON.parse(co as string).data });
+            }
+          },
+        },
+      ],
+      contexts: { webPage: false },
+    });
+    id = `media-${idx}`;
+  });
+
+  afterEach(() => {
+    endMediaTracking({ id });
+    eventQueue = [];
+  });
+
+  describe('media player events', () => {
+    [
+      { api: trackMediaReady, eventType: MediaEventType.Ready },
+      { api: trackMediaPlay, eventType: MediaEventType.Play },
+      { api: trackMediaPause, eventType: MediaEventType.Pause },
+      { api: trackMediaEnd, eventType: MediaEventType.End },
+      { api: trackMediaSeekStart, eventType: MediaEventType.SeekStart },
+      { api: trackMediaSeekEnd, eventType: MediaEventType.SeekEnd },
+      { api: trackMediaAdBreakStart, eventType: MediaEventType.AdBreakStart },
+      { api: trackMediaAdBreakEnd, eventType: MediaEventType.AdBreakEnd },
+      { api: trackMediaAdStart, eventType: MediaEventType.AdStart },
+      { api: trackMediaAdComplete, eventType: MediaEventType.AdComplete },
+      { api: trackMediaBufferStart, eventType: MediaEventType.BufferStart },
+      { api: trackMediaBufferEnd, eventType: MediaEventType.BufferEnd },
+    ].forEach((test) => {
+      it(`tracks a ${test.eventType} event`, () => {
+        startMediaTracking({ id });
+
+        test.api({ id });
+
+        const { event } = eventQueue[0];
+
+        expect(event).toMatchObject({
+          schema: getMediaEventSchema(test.eventType),
+        });
+      });
+    });
+
+    it('tracks a playback rate change event and remembers the new rate', () => {
+      startMediaTracking({ id, session: false, player: { playbackRate: 0.5 } });
+
+      trackMediaPlaybackRateChange({ id, newRate: 1.5 });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.PlaybackRateChange),
+            data: {
+              previousRate: 0.5,
+              newRate: 1.5,
+            },
+          },
+          context: [{ data: { playbackRate: 1.5 } }],
+        },
+        {
+          context: [{ data: { playbackRate: 1.5 } }],
+        },
+      ]);
+    });
+
+    it('tracks a volume change event and remembers the new volume', () => {
+      startMediaTracking({ id, session: false, player: { volume: 50 } });
+
+      trackMediaVolumeChange({ id, newVolume: 70 });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.VolumeChange),
+            data: {
+              previousVolume: 50,
+              newVolume: 70,
+            },
+          },
+          context: [{ data: { volume: 70 } }],
+        },
+        {
+          context: [{ data: { volume: 70 } }],
+        },
+      ]);
+    });
+
+    it('tracks a fullscreen change event and remembers the setting', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaFullscreenChange({ id, fullscreen: true });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.FullscreenChange),
+            data: { fullscreen: true },
+          },
+          context: [{ data: { fullscreen: true } }],
+        },
+        {
+          context: [{ data: { fullscreen: true } }],
+        },
+      ]);
+    });
+
+    it('tracks a picture in picture change event and remembers the setting', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaPictureInPictureChange({ id, pictureInPicture: true });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.PictureInPictureChange),
+            data: { pictureInPicture: true },
+          },
+          context: [{ data: { pictureInPicture: true } }],
+        },
+        {
+          context: [{ data: { pictureInPicture: true } }],
+        },
+      ]);
+    });
+
+    it('tracks an ad first quartile event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaAdFirstQuartile({ id })
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.AdFirstQuartile),
+            data: { percentProgress: 25 },
+          },
+        },
+      ]);
+    });
+
+    it('tracks an ad midpoint event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaAdMidpoint({ id })
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.AdMidpoint),
+            data: { percentProgress: 50 },
+          },
+        },
+      ]);
+    });
+
+    it('tracks an ad third quartile event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaAdThirdQuartile({ id })
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.AdThirdQuartile),
+            data: { percentProgress: 75 },
+          },
+        },
+      ]);
+    });
+
+    it('tracks an ad skip event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaAdSkip({ id, percentProgress: 33.33 })
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.AdSkip),
+            data: { percentProgress: 33 },
+          },
+        },
+      ]);
+    });
+
+    it('tracks an ad click event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaAdClick({ id, percentProgress: 33.33 })
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.AdClick),
+            data: { percentProgress: 33 },
+          },
+        },
+      ]);
+    });
+
+    it('tracks an ad pause event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaAdPause({ id, percentProgress: 33.33 })
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.AdPause),
+            data: { percentProgress: 33 },
+          },
+        },
+      ]);
+    });
+
+    it('tracks an ad resume event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaAdResume({ id, percentProgress: 33.33 })
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.AdResume),
+            data: { percentProgress: 33 },
+          },
+        },
+      ]);
+    });
+
+    it('tracks quality change event and remembers the setting', () => {
+      startMediaTracking({ id, session: false, player: { quality: '720p' } });
+
+      trackMediaQualityChange({
+        id,
+        newQuality: '1080p',
+        bitrate: 1000,
+        framesPerSecond: 30,
+        automatic: false,
+      });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.QualityChange),
+            data: {
+              previousQuality: '720p',
+              newQuality: '1080p',
+              bitrate: 1000,
+              framesPerSecond: 30,
+              automatic: false,
+            },
+          },
+          context: [{ data: { quality: '1080p' } }],
+        },
+        { context: [{ data: { quality: '1080p' } }] },
+      ]);
+    });
+
+    it('tracks error event', () => {
+      startMediaTracking({ id, session: false });
+
+      trackMediaError({
+        id,
+        errorCode: '500',
+        errorName: 'forbidden',
+        errorDescription: 'Failed to load media',
+      });
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.Error),
+            data: {
+              errorCode: '500',
+              errorName: 'forbidden',
+              errorDescription: 'Failed to load media',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('sets paused to false in media context when play is tracked', () => {
+      startMediaTracking({ id, player: { paused: true }, session: false });
+      trackMediaPlay({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          context: [{ data: { paused: false } }],
+        },
+      ]);
+    });
+
+    it('sets paused to true in media context when pause is tracked', () => {
+      startMediaTracking({ id, player: { paused: false }, session: false });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          context: [{ data: { paused: true } }],
+        },
+      ]);
+    });
+
+    it('sets paused and ended to true in media context when end is tracked', () => {
+      startMediaTracking({ id, player: { paused: false }, session: false });
+      trackMediaEnd({ id });
+
+      expect(eventQueue).toMatchObject([
+        {
+          context: [{ data: { paused: true, ended: true } }],
+        },
+      ]);
+    });
+
+    it('doesnt track seek start multiple times', () => {
+      startMediaTracking({ id, player: { duration: 100 }, session: false });
+      trackMediaSeekStart({ id, player: { currentTime: 1 } });
+      trackMediaSeekStart({ id, player: { currentTime: 2 } });
+      trackMediaSeekEnd({ id, player: { currentTime: 3 } });
+      trackMediaSeekStart({ id, player: { currentTime: 3 } });
+
+      expect(eventQueue).toMatchObject([
+        { event: { schema: getMediaEventSchema(MediaEventType.SeekStart) } },
+        { event: { schema: getMediaEventSchema(MediaEventType.SeekEnd) } },
+        { event: { schema: getMediaEventSchema(MediaEventType.SeekStart) } },
+      ]);
+    });
+
+    it('adds custom context entities to all events', () => {
+      const context: Array<SelfDescribingJson> = [{ schema: 'test', data: {} }];
+      startMediaTracking({ id, context, session: false });
+
+      trackMediaPlay({ id });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([
+        { context: [{ data: { paused: false } }, { schema: 'test' }] },
+        { context: [{ data: { paused: true } }, { schema: 'test' }] },
+      ]);
+    });
+
+    it('doesnt track events not in captureEvents', () => {
+      startMediaTracking({ id, captureEvents: [MediaEventType.Pause], session: false });
+
+      trackMediaPlay({ id });
+      trackMediaPause({ id });
+
+      expect(eventQueue).toMatchObject([{ event: { schema: getMediaEventSchema(MediaEventType.Pause) } }]);
+    });
+
+    it('tracks a custom self-describing event', () => {
+      startMediaTracking({ id });
+
+      trackMediaSelfDescribingEvent({
+        id,
+        event: {
+          schema: 'iglu:com.acme/event/jsonschema/1-0-0',
+          data: { foo: 'bar' },
+        },
+      });
+
+      expect(eventQueue).toMatchObject([
+        {
+          event: {
+            schema: 'iglu:com.acme/event/jsonschema/1-0-0',
+            data: { foo: 'bar' },
+          },
+          context: [{ schema: MEDIA_PLAYER_SCHEMA }, { schema: MEDIA_SESSION_SCHEMA }],
+        },
+      ]);
+    });
+  });
+
+  describe('session', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.clearAllTimers();
+    });
+
+    it('adds media session context entity with given ID', () => {
+      startMediaTracking({ id });
+      trackMediaReady({ id });
+
+      const { context, event } = eventQueue[0];
+
+      expect(context).toMatchObject([
+        {
+          schema: MEDIA_PLAYER_SCHEMA,
+        },
+        {
+          data: { mediaSessionId: id },
+          schema: MEDIA_SESSION_SCHEMA,
+        },
+      ]);
+
+      expect(event).toMatchObject({
+        schema: getMediaEventSchema(MediaEventType.Ready),
+      });
+    });
+
+    it('adds media session context entity with given started at date', () => {
+      let startedAt = new Date(new Date().getTime() - 100 * 1000);
+      startMediaTracking({ id, session: { startedAt: startedAt } });
+      trackMediaReady({ id });
+
+      const { context, event } = eventQueue[0];
+
+      expect(context).toMatchObject([
+        {
+          schema: MEDIA_PLAYER_SCHEMA,
+        },
+        {
+          data: { startedAt: startedAt.toISOString() },
+          schema: MEDIA_SESSION_SCHEMA,
+        },
+      ]);
+
+      expect(event).toMatchObject({
+        schema: getMediaEventSchema(MediaEventType.Ready),
+      });
+    });
+
+    it('calculates session stats', () => {
+      startMediaTracking({ id, player: { duration: 10 } });
+      trackMediaPlay({ id });
+      jest.advanceTimersByTime(10 * 1000);
+      updateMediaTracking({ id, player: { currentTime: 10 } });
+      trackMediaEnd({ id, player: { currentTime: 10 } });
+
+      expect(eventQueue).toMatchObject([
+        { event: { schema: getMediaEventSchema(MediaEventType.Play) } },
+        {
+          event: { schema: getMediaEventSchema(MediaEventType.End) },
+          context: [
+            { schema: MEDIA_PLAYER_SCHEMA },
+            {
+              schema: MEDIA_SESSION_SCHEMA,
+              data: {
+                timePlayed: 10,
+                contentWatched: 11,
+              },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('ping events', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.clearAllTimers();
+    });
+
+    it('starts sending ping events after session starts', () => {
+      startMediaTracking({ id, pings: true });
+
+      jest.advanceTimersByTime(30 * 1000);
+
+      expect(eventQueue).toMatchObject([{ event: { schema: getMediaEventSchema(MediaEventType.Ping) } }]);
+    });
+
+    it('should make a ping event in a custom interval', () => {
+      startMediaTracking({ id, pings: { pingInterval: 1 } });
+
+      jest.advanceTimersByTime(1000);
+
+      expect(eventQueue).toMatchObject([{ event: { schema: getMediaEventSchema(MediaEventType.Ping) } }]);
+    });
+
+    it('should send ping events regardless of other events', () => {
+      startMediaTracking({ id, pings: { pingInterval: 1, maxPausedPings: 10 } });
+      trackMediaPlay({ id });
+      jest.advanceTimersByTime(1000);
+      trackMediaPause({ id });
+      jest.advanceTimersByTime(2000);
+
+      expect(eventQueue).toMatchObject([
+        { event: { schema: getMediaEventSchema(MediaEventType.Play) } },
+        { event: { schema: getMediaEventSchema(MediaEventType.Ping) } },
+        { event: { schema: getMediaEventSchema(MediaEventType.Pause) } },
+        { event: { schema: getMediaEventSchema(MediaEventType.Ping) } },
+        { event: { schema: getMediaEventSchema(MediaEventType.Ping) } },
+      ]);
+    });
+
+    it('should not send more ping events than max when paused', () => {
+      startMediaTracking({ id, pings: { pingInterval: 1, maxPausedPings: 1 } });
+      trackMediaPause({ id });
+      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(3000);
+
+      expect(eventQueue).toMatchObject([
+        { event: { schema: getMediaEventSchema(MediaEventType.Pause) } },
+        { event: { schema: getMediaEventSchema(MediaEventType.Ping) } },
+      ]);
+    });
+  });
+
+  describe('percent progress', () => {
+    it('should send progress events when boundaries reached', () => {
+      startMediaTracking({
+        id,
+        boundaries: [10, 50, 90],
+        player: { duration: 100 },
+        session: false,
+      });
+
+      trackMediaPlay({ id });
+      for (let i = 1; i <= 100; i++) {
+        updateMediaTracking({ id, player: { currentTime: i } });
+      }
+
+      expect(eventQueue).toMatchObject([
+        { event: { schema: getMediaEventSchema(MediaEventType.Play) } },
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.PercentProgress),
+            data: { percentProgress: 10 },
+          },
+        },
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.PercentProgress),
+            data: { percentProgress: 50 },
+          },
+        },
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.PercentProgress),
+            data: { percentProgress: 90 },
+          },
+        },
+      ]);
+    });
+
+    it('doesnt send progress events if paused', () => {
+      startMediaTracking({
+        id,
+        boundaries: [10, 50, 90],
+        player: { duration: 100 },
+        session: false,
+      });
+
+      trackMediaPause({ id });
+      for (let i = 1; i <= 100; i++) {
+        updateMediaTracking({ id, player: { currentTime: i } });
+      }
+
+      expect(eventQueue).toMatchObject([{ event: { schema: getMediaEventSchema(MediaEventType.Pause) } }]);
+    });
+
+    it('doesnt send progress event multiple times', () => {
+      startMediaTracking({
+        id,
+        boundaries: [50],
+        player: { duration: 100 },
+        session: false,
+      });
+
+      trackMediaPlay({ id });
+      for (let i = 1; i <= 100; i++) {
+        updateMediaTracking({ id, player: { currentTime: i } });
+      }
+      trackMediaSeekEnd({ id, player: { currentTime: 0 } });
+      for (let i = 1; i <= 100; i++) {
+        updateMediaTracking({ id, player: { currentTime: i } });
+      }
+
+      expect(eventQueue).toMatchObject([
+        { event: { schema: getMediaEventSchema(MediaEventType.Play) } },
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.PercentProgress),
+            data: { percentProgress: 50 },
+          },
+        },
+        {
+          event: {
+            schema: getMediaEventSchema(MediaEventType.SeekEnd),
+          },
+          context: [{ data: { currentTime: 0 } }],
+        },
+      ]);
+    });
+  });
+});

--- a/plugins/browser-plugin-media/test/pingInterval.test.ts
+++ b/plugins/browser-plugin-media/test/pingInterval.test.ts
@@ -1,0 +1,71 @@
+import { MediaPingInterval } from '../src/pingInterval';
+
+describe('PingInterval', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should fire every 30 seconds', () => {
+    let pings = 0;
+    new MediaPingInterval(undefined, undefined, () => pings++);
+
+    for (let i = 0; i < 60; i++) {
+      jest.advanceTimersByTime(1000);
+    }
+
+    expect(pings).toBe(2);
+  });
+
+  it('should fire in a custom interval', () => {
+    let pings = 0;
+    new MediaPingInterval(5, undefined, () => pings++);
+
+    for (let i = 0; i < 20; i++) {
+      jest.advanceTimersByTime(1000);
+    }
+
+    expect(pings).toBe(4);
+  });
+
+  it('should stop firing after clear', () => {
+    let pings = 0;
+    const interval = new MediaPingInterval(undefined, undefined, () => pings++);
+
+    for (let i = 0; i < 30; i++) {
+      jest.advanceTimersByTime(1000);
+    }
+
+    interval.clear();
+
+    for (let i = 0; i < 10; i++) {
+      jest.advanceTimersByTime(1000);
+    }
+
+    expect(pings).toBe(1);
+  });
+
+  it('should stop firing ping events when paused', () => {
+    let pings = 0;
+    const interval = new MediaPingInterval(1, 3, () => pings++);
+    interval.update({
+      currentTime: 0,
+      ended: false,
+      loop: false,
+      livestream: false,
+      muted: false,
+      paused: true,
+      playbackRate: 1,
+      volume: 100,
+    });
+
+    for (let i = 0; i < 30; i++) {
+      jest.advanceTimersByTime(1000);
+    }
+
+    expect(pings).toBe(3);
+  });
+});

--- a/plugins/browser-plugin-media/test/sessionStats.test.ts
+++ b/plugins/browser-plugin-media/test/sessionStats.test.ts
@@ -1,0 +1,217 @@
+import { v4 as uuid } from 'uuid';
+import { MediaSessionTrackingStats } from '../src/sessionStats';
+import { MediaAdBreakType, MediaAdBreak, MediaEventType } from '../src/types';
+
+const mediaPlayerDefaults = {
+  ended: false,
+  paused: false,
+};
+
+describe('MediaSessionTrackingStats', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.clearAllTimers();
+  });
+
+  it('calculates played duration', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    jest.advanceTimersByTime(60 * 1000);
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 60 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.contentWatched).toBe(61);
+    expect(entity.timePlayed).toBe(60);
+    expect(entity.timePlayedMuted).toBeUndefined();
+    expect(entity.timePaused).toBeUndefined();
+    expect(entity.avgPlaybackRate).toBeUndefined();
+  });
+
+  it('considers pauses', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    jest.advanceTimersByTime(10 * 1000);
+    session.update(undefined, { ...mediaPlayerDefaults, currentTime: 10 });
+    session.update(MediaEventType.Pause, { ...mediaPlayerDefaults, currentTime: 10, paused: true });
+
+    jest.advanceTimersByTime(10 * 1000);
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 10 });
+
+    jest.advanceTimersByTime(50 * 1000);
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 60 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.contentWatched).toBe(61);
+    expect(entity.timePlayed).toBe(60);
+    expect(entity.timePlayedMuted).toBeUndefined();
+    expect(entity.timePaused).toBe(10);
+    expect(entity.avgPlaybackRate).toBeUndefined();
+  });
+
+  it('calculates play on mute', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0, muted: false });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.VolumeChange, { ...mediaPlayerDefaults, currentTime: 30, muted: true });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 60 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.contentWatched).toBe(61);
+    expect(entity.timePlayed).toBe(60);
+    expect(entity.timePlayedMuted).toBe(30);
+    expect(entity.timePaused).toBeUndefined();
+    expect(entity.avgPlaybackRate).toBeUndefined();
+  });
+
+  it('calculates average playback rate', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0, playbackRate: 1 });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.PlaybackRateChange, {
+      ...mediaPlayerDefaults,
+      currentTime: 30,
+      playbackRate: 2,
+    });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 90 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.contentWatched).toBe(91);
+    expect(entity.timePlayed).toBe(60);
+    expect(entity.timePlayedMuted).toBeUndefined();
+    expect(entity.timePaused).toBeUndefined();
+    expect(entity.avgPlaybackRate).toBe(1.5);
+  });
+
+  it('calculates stats for linear ads', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.AdStart, { ...mediaPlayerDefaults, currentTime: 30 });
+
+    jest.advanceTimersByTime(5 * 1000);
+    session.update(MediaEventType.AdClick, { ...mediaPlayerDefaults, currentTime: 30 });
+
+    jest.advanceTimersByTime(10 * 1000);
+    session.update(MediaEventType.AdComplete, { ...mediaPlayerDefaults, currentTime: 30 });
+
+    session.update(MediaEventType.AdStart, { ...mediaPlayerDefaults, currentTime: 30 });
+
+    jest.advanceTimersByTime(15 * 1000);
+    session.update(MediaEventType.AdComplete, { ...mediaPlayerDefaults, currentTime: 30 });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 60 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.timeSpentAds).toBe(30);
+    expect(entity.ads).toBe(2);
+    expect(entity.adsClicked).toBe(1);
+    expect(entity.adBreaks).toBeUndefined();
+    expect(entity.contentWatched).toBe(61);
+    expect(entity.timePlayed).toBe(60);
+  });
+
+  it('calculate stats for non-linear ads', () => {
+    let session = new MediaSessionTrackingStats();
+    let adBreak: MediaAdBreak = { breakId: uuid(), startTime: 0, breakType: MediaAdBreakType.NonLinear };
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.AdBreakStart, { ...mediaPlayerDefaults, currentTime: 30 }, adBreak);
+    session.update(MediaEventType.AdStart, { ...mediaPlayerDefaults, currentTime: 30 }, adBreak);
+
+    jest.advanceTimersByTime(15 * 1000);
+    session.update(MediaEventType.AdComplete, { ...mediaPlayerDefaults, currentTime: 45 }, adBreak);
+    session.update(MediaEventType.AdBreakEnd, { ...mediaPlayerDefaults, currentTime: 45 }, adBreak);
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 75 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.timeSpentAds).toBe(15);
+    expect(entity.ads).toBe(1);
+    expect(entity.adBreaks).toBe(1);
+    expect(entity.contentWatched).toBe(76);
+    expect(entity.timePlayed).toBe(75);
+  });
+
+  it('counts rewatched content once in contentWatched', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.SeekStart, { ...mediaPlayerDefaults, currentTime: 30 });
+    session.update(MediaEventType.SeekEnd, { ...mediaPlayerDefaults, currentTime: 15 });
+
+    jest.advanceTimersByTime(45 * 1000);
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 60 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.contentWatched).toBe(61);
+    expect(entity.timePlayed).toBe(75);
+  });
+
+  it('considers changes in ping events', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    for (let i = 0; i < 60; i++) {
+      session.update(MediaEventType.Ping, { ...mediaPlayerDefaults, currentTime: i, muted: i % 2 == 0 });
+      jest.advanceTimersByTime(1 * 1000);
+    }
+
+    session.update(MediaEventType.End, { ...mediaPlayerDefaults, currentTime: 60 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.contentWatched).toBe(61);
+    expect(entity.timePlayed).toBe(60);
+    expect(entity.timePlayedMuted).toBe(30);
+  });
+
+  it('calculates buffering time', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.BufferStart, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    jest.advanceTimersByTime(30 * 1000);
+    session.update(MediaEventType.BufferEnd, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.timeBuffering).toBe(30);
+  });
+
+  it('ends buffering when playback time moves', () => {
+    let session = new MediaSessionTrackingStats();
+
+    session.update(MediaEventType.BufferStart, { ...mediaPlayerDefaults, currentTime: 0 });
+
+    jest.advanceTimersByTime(15 * 1000);
+    session.update(undefined, { ...mediaPlayerDefaults, currentTime: 1 });
+
+    jest.advanceTimersByTime(15 * 1000);
+    session.update(MediaEventType.Play, { ...mediaPlayerDefaults, currentTime: 15 });
+
+    let entity = session.toSessionContextEntity();
+    expect(entity.timeBuffering).toBe(15);
+  });
+});

--- a/plugins/browser-plugin-media/tsconfig.json
+++ b/plugins/browser-plugin-media/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/rush.json
+++ b/rush.json
@@ -547,6 +547,12 @@
       "projectFolder": "plugins/browser-plugin-performance-navigation-timing",
       "reviewCategory": "plugins",
       "versionPolicyName": "tracker"
+    },
+    {
+      "packageName": "@snowplow/browser-plugin-media",
+      "projectFolder": "plugins/browser-plugin-media",
+      "reviewCategory": "plugins",
+      "versionPolicyName": "tracker"
     }
   ]
 }


### PR DESCRIPTION
This release introduces the new Media plugin for the Snowplow JavaScript tracker!

The plugin enables tracking of media events from video or audio playback. Compared to our existing media tracking plugins (for HTML5 and YouTube), the new plugin builds on top of new event and entity schemas and provides new tracking APIs that are aimed to be more universal and cover more use cases.

**Key Features**:

1. **Integrate with any media player**: Instead of integrating with a specific media player, the plugin provides universal media tracking APIs that can be utilized to track media events regardless of the media player being used to play the content.
2. **Media session tracking**: The plugin adds a new [media session context entity](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow.media/session/jsonschema/1-0-0) to tracked events that identifies the media playback. The entity also adds statistics calculated using edge analytics on the tracker such as the time spent playing, buffering or the number of ads played.
3. **Support for tracking live video**: With the addition of media ping events, the plugin now supports periodically tracking the progress within a live streamed video. The media ping events are fired periodically when the media is being played with configurable frequency and settings. Moreover, the plugin also makes sure that page ping events are being tracked during playback even if the user is not interacting with the page.
5. **Tracking ads during playback**: The plugin provides out-of-the-box events and entities for tracking ads within linear, non-linear and companion ad breaks during playback.
6. **New media event schemas**: The tracked events follow new schemas with additional properties. New events and entities for data quality and error tracking have been added.
7. **Customizable**: The plugin supports tracking custom media events and custom entities to meet your specific requirements.

Simplified example usage of the media tracking APIs:

```javascript
newTracker("ns1", "https://...", { plugins: [SnowplowMediaPlugin()] });
const id = "media-tracking-id";

// Initialize the media tracking identified by the `id`. It will start tracking media ping events.
startMediaTracking({ id, player: { duration: 100 } });
// Track a media play event within the media tracking.
trackMediaPlay({ id });
// Update the current playback position without tracking any events.
updateMediaTracking({ id, player: { currentTime: 50 } });
// Track the start of an ad.
trackMediaAdStart({ id, ad: { adId: "ad-id", name: "Ad 1" duration: 4 } });
// End and clear the state for the media tracking.
endMediaTracking({ id });
```

To learn more about the plugin, see the documentation for [the browser tracker](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/plugins/media/), or the [JavaScript tag tracker](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/plugins/media/), or see the [media events tracked live in this demo app](https://snowplow-incubator.github.io/snowplow-javascript-tracker-examples/media).

## Changelog

* Add Snowplow Media plugin with APIs to track media events (#1176)