### PR TITLE
Properly prevent NaN session index parameter 'vid' 

### DIFF
--- a/common/changes/@snowplow/node-tracker/fix-1204-properly-prevent-NaN-vid_2023-06-15-08-02.json
+++ b/common/changes/@snowplow/node-tracker/fix-1204-properly-prevent-NaN-vid_2023-06-15-08-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Properly prevent NaN session index parameter 'vid' (fix #1204)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/trackers/node-tracker/src/tracker.ts
+++ b/trackers/node-tracker/src/tracker.ts
@@ -94,7 +94,7 @@ export function tracker(
     payload.add('duid', domainUserId);
     payload.add('nuid', networkUserId);
     payload.add('sid', sessionId);
-    payload.add('vid', Number(sessionIndex));
+    payload.add('vid', sessionIndex && Number(sessionIndex));
   };
 
   /**

--- a/trackers/node-tracker/test/tracker.ts
+++ b/trackers/node-tracker/test/tracker.ts
@@ -95,6 +95,7 @@ function checkPayload(payloadDict: Payload, expected: Payload, t: ExecutionConte
   t.deepEqual(payloadDict['co'], completedContext, 'a custom context should be attached');
   t.truthy(payloadDict['dtm'], 'a timestamp should be attached');
   t.truthy(payloadDict['eid'], 'a UUID should be attached');
+  t.falsy(typeof payloadDict['vid'] === 'string' && payloadDict['vid'] === 'NaN', 'Session index should not be NaN');
 }
 
 test.before(() => {


### PR DESCRIPTION
Properly prevent `vid` (sessionIndex) from being set as `NaN`.

fix #1204 