### PR TITLE
Allow events to be tracked on the onSessionUpdate callback (close #1213)

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "./libraries/browser-tracker-core/dist/index.module.js",
-      "maxSize": "25kb",
+      "maxSize": "26kb",
       "maxPercentIncrease": 10
     },
     {

--- a/common/changes/@snowplow/browser-tracker-core/issue-1213-allow-events-on-session-update-callback_2023-06-27-07-36.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1213-allow-events-on-session-update-callback_2023-06-27-07-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Allow events to be tracked on the onSessionUpdate callback",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1213-allow-events-on-session-update-callback_2023-06-28-15-24.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1213-allow-events-on-session-update-callback_2023-06-28-15-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Added onSessionUpdate callback integration test",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2506,8 +2506,8 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
-  /@testim/chrome-version/1.1.2:
-    resolution: {integrity: sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==}
+  /@testim/chrome-version/1.1.3:
+    resolution: {integrity: sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==}
     dev: true
 
   /@tootallnate/once/1.1.2:
@@ -3195,7 +3195,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3204,7 +3204,7 @@ packages:
     resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       depd: 1.1.2
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -3496,7 +3496,7 @@ packages:
   /axios/0.24.0:
     resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
     dependencies:
-      follow-redirects: 1.14.5
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: true
@@ -3753,7 +3753,7 @@ packages:
     dev: true
 
   /buffer-crc32/0.2.13:
-    resolution: {integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=}
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: true
 
   /buffer-fill/1.0.0:
@@ -4054,11 +4054,11 @@ packages:
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@testim/chrome-version': 1.1.2
+      '@testim/chrome-version': 1.1.3
       axios: 0.24.0
       del: 6.0.0
       extract-zip: 2.0.1
-      https-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
       proxy-from-env: 1.1.0
       tcp-port-used: 1.0.2
     transitivePeerDependencies:
@@ -4594,7 +4594,7 @@ packages:
     dev: true
 
   /deep-is/0.1.3:
-    resolution: {integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=}
+    resolution: {integrity: sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==}
     dev: true
 
   /deepmerge-ts/4.3.0:
@@ -4735,7 +4735,7 @@ packages:
     resolution: {integrity: sha512-Tgkn2a+yiNP9FoZgMa/D9Wk+D2Db///0KOyKSYZRJa8w4+DzKyzQMkczKSdR/adQ0x46BOpeNkoyEOKjPhCzjw==}
     engines: {node: '>= 8.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       readable-stream: 3.6.0
       split-ca: 1.0.1
       ssh2: 1.5.0
@@ -5301,7 +5301,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -5359,7 +5359,7 @@ packages:
     dev: true
 
   /fd-slicer/1.1.0:
-    resolution: {integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=}
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
       pend: 1.2.0
     dev: true
@@ -5509,8 +5509,8 @@ packages:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
     dev: true
 
-  /follow-redirects/1.14.5:
-    resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -6066,16 +6066,6 @@ packages:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
-    dev: true
-
-  /https-proxy-agent/5.0.0:
-    resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
-    engines: {node: '>= 6'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /https-proxy-agent/5.0.1:
@@ -7674,7 +7664,7 @@ packages:
       cacache: 15.3.0
       http-cache-semantics: 4.1.0
       http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
       is-lambda: 1.0.1
       lru-cache: 6.0.0
       minipass: 3.3.4
@@ -8275,7 +8265,7 @@ packages:
     dev: true
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
 
@@ -8642,7 +8632,7 @@ packages:
     dev: true
 
   /pend/1.2.0:
-    resolution: {integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=}
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
     dev: true
 
   /perf-regexes/1.0.1:
@@ -9531,7 +9521,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
       socks: 2.7.0
     transitivePeerDependencies:
       - supports-color
@@ -10657,7 +10647,7 @@ packages:
     dev: true
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   /write-file-atomic/3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
@@ -10793,7 +10783,7 @@ packages:
     dev: true
 
   /yauzl/2.10.0:
-    resolution: {integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=}
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "1a9deb48a8d2843fb67d9c93ff618d8373ca31c8",
+  "pnpmShrinkwrapHash": "b3670fdd35939880fb5506b045e5826aeab84996",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/browser-tracker-core/src/tracker/id_cookie.ts
+++ b/libraries/browser-tracker-core/src/tracker/id_cookie.ts
@@ -171,10 +171,7 @@ export function initializeDomainUserId(idCookie: ParsedIdCookie, configAnonymous
 }
 
 type NewSessionOptions = {
-  memorizedVisitCount?: number;
-  onSessionUpdateCallback?: (sessionState: ClientSession) => void;
-  configStateStorageStrategy: string;
-  configAnonymousTracking: boolean;
+  memorizedVisitCount: number;
 };
 
 /**
@@ -189,11 +186,11 @@ type NewSessionOptions = {
  * @param options.onSessionUpdateCallback Session callback triggered on every session update
  * @returns New session ID
  */
-export function startNewIdCookieSession(idCookie: ParsedIdCookie, options: NewSessionOptions) {
-  const { memorizedVisitCount, configStateStorageStrategy, configAnonymousTracking, onSessionUpdateCallback } = {
-    memorizedVisitCount: 1,
-    ...options,
-  };
+export function startNewIdCookieSession(
+  idCookie: ParsedIdCookie,
+  options: NewSessionOptions = { memorizedVisitCount: 1 }
+) {
+  const { memorizedVisitCount } = options;
 
   // If cookies are enabled, base visit count and session ID on the cookies
   if (cookiesEnabledInIdCookie(idCookie)) {
@@ -215,10 +212,6 @@ export function startNewIdCookieSession(idCookie: ParsedIdCookie, options: NewSe
   idCookie[eventIndexIndex] = 0;
   idCookie[firstEventIdIndex] = '';
   idCookie[firstEventTsInMsIndex] = undefined;
-
-  if (onSessionUpdateCallback) {
-    onSessionUpdateCallback(clientSessionFromIdCookie(idCookie, configStateStorageStrategy, configAnonymousTracking));
-  }
 
   return sessionId;
 }

--- a/libraries/browser-tracker-core/test/tracker/__snapshots__/session_data.test.ts.snap
+++ b/libraries/browser-tracker-core/test/tracker/__snapshots__/session_data.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tracker API:  onSessionUpdateCallback functionality properly calls onSessionUpdateCallback 1`] = `
+Object {
+  "eventIndex": 1,
+  "firstEventId": "123456789",
+  "firstEventTimestamp": "2023-01-01T00:00:00.000Z",
+  "previousSessionId": null,
+  "sessionId": "123456789",
+  "sessionIndex": 1,
+  "storageMechanism": "COOKIE_1",
+  "userId": "123456789",
+}
+`;
+
+exports[`Tracker API:  onSessionUpdateCallback functionality properly calls onSessionUpdateCallback with anonymousTracking and withSessionTracking 1`] = `
+Object {
+  "eventIndex": 1,
+  "firstEventId": "123456789",
+  "firstEventTimestamp": "2023-01-01T00:00:00.000Z",
+  "previousSessionId": null,
+  "sessionId": "123456789",
+  "sessionIndex": 1,
+  "storageMechanism": "COOKIE_1",
+  "userId": "00000000-0000-0000-0000-000000000000",
+}
+`;
+
+exports[`Tracker API:  onSessionUpdateCallback functionality properly calls onSessionUpdateCallback with correct storage strategy 1`] = `
+Object {
+  "eventIndex": 1,
+  "firstEventId": "123456789",
+  "firstEventTimestamp": "2023-01-01T00:00:00.000Z",
+  "previousSessionId": null,
+  "sessionId": "123456789",
+  "sessionIndex": 1,
+  "storageMechanism": "LOCAL_STORAGE",
+  "userId": "123456789",
+}
+`;

--- a/trackers/javascript-tracker/test/integration/onSessionUpdate.test.ts
+++ b/trackers/javascript-tracker/test/integration/onSessionUpdate.test.ts
@@ -1,0 +1,63 @@
+import F from 'lodash/fp';
+import { DockerWrapper, clearCache, fetchResults, start, stop } from '../micro';
+import { waitUntil } from './helpers';
+
+describe('onSessionUpdate callback feature', () => {
+  if (
+    browser.capabilities.browserName === 'internet explorer' &&
+    (browser.capabilities.version === '9' || browser.capabilities.browserVersion === '10')
+  ) {
+    fit('Skip IE 9 and 10', () => true);
+    return;
+  }
+
+  if (browser.capabilities.browserName === 'safari' && browser.capabilities.version === '8.0') {
+    fit('Skip Safari 8', () => true);
+    return;
+  }
+
+  let log: Array<unknown> = [];
+  let docker: DockerWrapper;
+
+  const logContains = (ev: unknown) => F.some(F.isMatch(ev as object), log);
+
+  const loadUrlAndWait = async (url: string) => {
+    await browser.url(url);
+    await browser.waitUntil(async () => (await $('#init').getText()) === 'true', {
+      timeout: 5000,
+      timeoutMsg: 'expected init after 5s',
+      interval: 250,
+    });
+  };
+
+  beforeAll(async () => {
+    await browser.call(async () => (docker = await start()));
+    await waitUntil(browser, async () => {
+      return await browser.call(async () => await clearCache(docker.url));
+    });
+    await browser.url('/index.html');
+    await browser.setCookies({ name: 'container', value: docker.url });
+    await loadUrlAndWait('/session-update-callback.html');
+    await browser.pause(2000);
+    log = await browser.call(async () => await fetchResults(docker.url));
+    await browser.pause(2000);
+  });
+
+  afterAll(async () => {
+    await browser.call(async () => await stop(docker?.container));
+  });
+
+  it(`properly runs the onSessionCallback`, async () => {
+    expect(
+      logContains({
+        event: {
+          app_id: `onSessionCallback`,
+          event: 'struct',
+          se_category: 'session_callback',
+          se_action: 'called',
+        },
+      })
+    ).toBe(true);
+    expect(log.length).toEqual(2);
+  });
+});

--- a/trackers/javascript-tracker/test/pages/session-update-callback.html
+++ b/trackers/javascript-tracker/test/pages/session-update-callback.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>onSessionUpdateCallback test page</title>
+  </head>
+
+  <body>
+    <p id="title">Page for testing onSessionUpdateCallback with Snowplow Micro</p>
+    <div id="init"></div>
+
+    <script>
+      var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      document.body.className += ' loaded';
+    </script>
+
+    <script>
+      (function (p, l, o, w, i, n, g) {
+        if (!p[i]) {
+          p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
+          p.GlobalSnowplowNamespace.push(i);
+          p[i] = function () {
+            (p[i].q = p[i].q || []).push(arguments);
+          };
+          p[i].q = p[i].q || [];
+          n = l.createElement(o);
+          g = l.getElementsByTagName(o)[0];
+          n.async = 1;
+          n.src = w;
+          g.parentNode.insertBefore(n, g);
+        }
+      })(window, document, 'script', './snowplow.js', 'snowplow');
+
+      document.write(collector_endpoint);
+
+      snowplow('newTracker', 'sp', collector_endpoint, {
+        appId: 'onSessionCallback',
+        cookieSameSite: 'Lax',
+        cookieSecure: false,
+        onSessionUpdateCallback: function (session) {
+          snowplow('trackStructEvent:sp', {
+            category: 'session_callback',
+            action: 'called',
+          });
+        },
+      });
+
+      snowplow(function () {
+        document.getElementById('init').innerText = 'true';
+      });
+
+      snowplow('trackPageView');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Move the `onSessionUpdate` callback logic from the `startNewIdCookieSession` which just creates a new session id to the `startNewIdCookieSession` function to make sure persistence is there before trying to call any other events after a session update.

