### PR TITLE
Add tracker.getQueueName method

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/feature-1215-expose-queue-name_2023-06-29-15-53.json
+++ b/common/changes/@snowplow/browser-tracker-core/feature-1215-expose-queue-name_2023-06-29-15-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Expose getQueueName method",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/feature-1215-expose-queue-name_2023-06-29-15-54.json
+++ b/common/changes/@snowplow/browser-tracker/feature-1215-expose-queue-name_2023-06-29-15-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add getQueueName tracker method",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -1283,6 +1283,8 @@ export function Tracker(
       },
 
       clearUserData: clearUserDataAndCookies,
+
+      getQueueName: outQueue.getName,
     };
 
     return {

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -581,6 +581,11 @@ export interface BrowserTracker {
   clearUserData: (configuration?: ClearUserDataConfiguration) => void;
 
   /**
+   * Returns the currently used queue name or if the `eventMethod` argument is provided, the queue name for the eventMethod.
+   */
+  getQueueName: (eventMethod?: Exclude<EventMethod, 'beacon'>) => string;
+
+  /**
    * Add a plugin into the plugin collection after Tracker has already been initialised
    * @param configuration - The plugin to add
    */

--- a/libraries/browser-tracker-core/test/out_queue.test.ts
+++ b/libraries/browser-tracker-core/test/out_queue.test.ts
@@ -57,6 +57,54 @@ describe('OutQueueManager', () => {
     (xhrMock as any).onreadystatechange();
   };
 
+  describe('API', () => {
+    it('returns the correct queue name', () => {
+      const postOutQueue = OutQueueManager(
+        'sp',
+        new SharedState(),
+        true,
+        'post',
+        '/com.snowplowanalytics.snowplow/tp2',
+        1,
+        40000,
+        0, // maxGetBytes – 0 for no limit
+        false,
+        maxQueueSize,
+        5000,
+        false,
+        {},
+        true,
+        [401], // retry status codes - override don't retry ones
+        [401, 505] // don't retry status codes
+      );
+
+      expect(postOutQueue.getName()).toBe('snowplowOutQueue_sp_post2');
+      expect(postOutQueue.getName('get')).toBe('snowplowOutQueue_sp_get');
+
+      const getOutQueue = OutQueueManager(
+        'sp',
+        new SharedState(),
+        true,
+        'get',
+        '/com.snowplowanalytics.snowplow/tp2',
+        1,
+        40000,
+        0,
+        false,
+        maxQueueSize,
+        5000,
+        false,
+        {},
+        true,
+        [],
+        []
+      );
+
+      expect(getOutQueue.getName()).toBe('snowplowOutQueue_sp_get');
+      expect(getOutQueue.getName('post')).toBe('snowplowOutQueue_sp_post2');
+    });
+  });
+
   describe('POST requests', () => {
     var outQueue: OutQueue;
 

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -75,6 +75,7 @@ export interface BrowserTracker {
     getDomainUserId: () => void;
     getDomainUserInfo: () => void;
     getPageViewId: () => string;
+    getQueueName: (eventMethod?: Exclude<EventMethod, "beacon">) => string;
     getTabId: () => string | null;
     getUserId: () => void;
     id: string;

--- a/trackers/browser-tracker/test/helpers/index.ts
+++ b/trackers/browser-tracker/test/helpers/index.ts
@@ -1,0 +1,6 @@
+import { SharedState, TrackerConfiguration, addTracker } from '@snowplow/browser-tracker-core';
+
+export function createTracker(configuration?: TrackerConfiguration) {
+  const id = 'sp-' + Math.random();
+  return addTracker(id, id, '', '', new SharedState(), configuration);
+}

--- a/trackers/browser-tracker/test/tracker.test.ts
+++ b/trackers/browser-tracker/test/tracker.test.ts
@@ -30,6 +30,7 @@
 
 import { SharedState, addTracker } from '@snowplow/browser-tracker-core';
 import F from 'lodash/fp';
+import { createTracker } from './helpers';
 
 jest.useFakeTimers('modern');
 
@@ -274,5 +275,28 @@ describe('Activity tracker behaviour', () => {
 
     expect(firstPageId).toBe(extractPageId(pph));
     expect(secondPageId).toBe(extractPageId(ppl));
+  });
+});
+
+describe('API', () => {
+  describe('getQueueName', () => {
+    it('does return the queue name', () => {
+      let rand = Math.random();
+      const mathSpy = jest.spyOn(global.Math, 'random');
+      mathSpy.mockReturnValueOnce(rand);
+
+      const postTracker = createTracker();
+      expect(postTracker?.getQueueName()).toBe(`snowplowOutQueue_sp-${rand}_post2`);
+      expect(postTracker?.getQueueName('get')).toBe(`snowplowOutQueue_sp-${rand}_get`);
+
+      rand = Math.random();
+      mathSpy.mockReturnValueOnce(rand);
+
+      const getTracker = createTracker({ eventMethod: 'get' });
+      expect(getTracker?.getQueueName()).toBe(`snowplowOutQueue_sp-${rand}_get`);
+      expect(getTracker?.getQueueName('post')).toBe(`snowplowOutQueue_sp-${rand}_post2`);
+
+      mathSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
Add the `tracker.getQueueName` method.

This method will return the currently used queue name or if provided arguments will return the one that would be used with the provided `eventMethod`.

close #1215