### PR TITLE
Filter out repeated seek and volume change events happening when user holds down the player controls (close #1218)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media/issue-1218-filter_out_repeated_media_events_2023-06-30-20-36.json
+++ b/common/changes/@snowplow/browser-plugin-media/issue-1218-filter_out_repeated_media_events_2023-06-30-20-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media",
+      "comment": "Filter out repeated seek and volume change events happening when user holds down the player controls (#1218)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media"
+}

--- a/plugins/browser-plugin-media/src/mediaTracking.ts
+++ b/plugins/browser-plugin-media/src/mediaTracking.ts
@@ -83,9 +83,9 @@ export class MediaTracking {
   /**
    * Called when user calls `endMediaTracking()`.
    */
-  flushAndStop(): EventWithContext[] {
+  flushAndStop() {
     this.pingInterval?.clear();
-    return this.repeatedEventFilter.flush();
+    this.repeatedEventFilter.flush();
   }
 
   /**
@@ -97,12 +97,13 @@ export class MediaTracking {
    * @returns List of events with entities to track.
    */
   update(
+    trackEvent: (event: EventWithContext) => void,
     mediaEvent?: MediaEvent,
     customEvent?: SelfDescribingJson,
     player?: MediaPlayerUpdate,
     ad?: MediaAdUpdate,
     adBreak?: MediaPlayerAdBreakUpdate
-  ): EventWithContext[] {
+  ) {
     // update state
     this.updatePlayer(player);
     if (mediaEvent !== undefined) {
@@ -144,11 +145,8 @@ export class MediaTracking {
     if (customEvent !== undefined) {
       eventsToTrack.push({ event: customEvent, context: context });
     }
-    return eventsToTrack;
-  }
 
-  filterRepeatedEvents(events: EventWithContext[]): EventWithContext[] {
-    return this.repeatedEventFilter.filterEventsToTrack(events);
+    this.repeatedEventFilter.trackFilteredEvents(eventsToTrack, trackEvent);
   }
 
   shouldUpdatePageActivity(): boolean {

--- a/plugins/browser-plugin-media/src/mediaTracking.ts
+++ b/plugins/browser-plugin-media/src/mediaTracking.ts
@@ -11,7 +11,7 @@ import {
   MediaEventType,
   MediaEvent,
   EventWithContext,
-  FilterOutRepeatedEvents
+  FilterOutRepeatedEvents,
 } from './types';
 import { RepeatedEventFilter } from './repeatedEventFilter';
 
@@ -144,7 +144,11 @@ export class MediaTracking {
     if (customEvent !== undefined) {
       eventsToTrack.push({ event: customEvent, context: context });
     }
-    return this.repeatedEventFilter.filterEventsToTrack(eventsToTrack);
+    return eventsToTrack;
+  }
+
+  filterRepeatedEvents(events: EventWithContext[]): EventWithContext[] {
+    return this.repeatedEventFilter.filterEventsToTrack(events);
   }
 
   shouldUpdatePageActivity(): boolean {

--- a/plugins/browser-plugin-media/src/repeatedEventFilter.ts
+++ b/plugins/browser-plugin-media/src/repeatedEventFilter.ts
@@ -1,0 +1,62 @@
+import { getMediaEventSchema } from './schemata';
+import { FilterOutRepeatedEvents, MediaEventType, EventWithContext } from './types';
+
+/**
+ * This class filters out repeated events that are sent by the media player.
+ * This applies to seek and volume change events.
+ */
+export class RepeatedEventFilter {
+  private aggregateEventsWithOrder: { [schema: string]: boolean } = {};
+  private eventsToAggregate: { [schema: string]: EventWithContext[] } = {};
+
+  constructor(configuration?: FilterOutRepeatedEvents) {
+    let allFiltersEnabled = configuration === undefined || configuration === true;
+    if (allFiltersEnabled || (typeof configuration === 'object' && configuration.seekEvents !== false)) {
+      this.aggregateEventsWithOrder[getMediaEventSchema(MediaEventType.SeekStart)] = true;
+      this.aggregateEventsWithOrder[getMediaEventSchema(MediaEventType.SeekEnd)] = false;
+    }
+    if (allFiltersEnabled || (typeof configuration === 'object' && configuration.volumeChangeEvents !== false)) {
+      this.aggregateEventsWithOrder[getMediaEventSchema(MediaEventType.VolumeChange)] = false;
+    }
+
+    Object.keys(this.aggregateEventsWithOrder).forEach((schema) => {
+      this.eventsToAggregate[schema] = [];
+    });
+  }
+
+  filterEventsToTrack(events: EventWithContext[]): EventWithContext[] {
+    let eventsToTrack: EventWithContext[] = [];
+
+    events.forEach(({ event, context }) => {
+      if (this.eventsToAggregate[event.schema] !== undefined) {
+        this.eventsToAggregate[event.schema].push({ event, context });
+      } else {
+        // flush any events waiting
+        let flushed = this.flush();
+        if (flushed.length > 0) {
+          eventsToTrack = eventsToTrack.concat(flushed);
+        }
+
+        eventsToTrack.push({ event, context });
+      }
+    });
+
+    return eventsToTrack;
+  }
+
+  flush(): EventWithContext[] {
+    let flushed: EventWithContext[] = [];
+    Object.keys(this.eventsToAggregate).forEach((schema) => {
+      let eventsToAggregate = this.eventsToAggregate[schema];
+      if (eventsToAggregate.length > 0) {
+        if (this.aggregateEventsWithOrder[schema]) {
+          flushed.push(eventsToAggregate[0]);
+        } else {
+          flushed.push(eventsToAggregate[eventsToAggregate.length - 1]);
+        }
+        this.eventsToAggregate[schema] = [];
+      }
+    });
+    return flushed;
+  }
+}

--- a/plugins/browser-plugin-media/src/types.ts
+++ b/plugins/browser-plugin-media/src/types.ts
@@ -86,9 +86,13 @@ export type FilterOutRepeatedEvents =
        * Whether to filter out volume change events tracked after each other.
        */
       volumeChangeEvents?: boolean;
+      /**
+       * Timeout in milliseconds after which to send the events that are queued for filtering.
+       * Defaults to 5000 ms.
+       */
+      flushTimeoutMs?: number;
     }
   | boolean;
-
 
 export type MediaTrackingConfiguration = {
   /** Unique ID of the media tracking. The same ID will be used for media player session if enabled. */
@@ -410,4 +414,4 @@ export interface CommonMediaEventProperties extends CommonEventProperties {
 
 export interface EventWithContext extends CommonEventProperties {
   event: SelfDescribingJson;
-};
+}

--- a/plugins/browser-plugin-media/src/types.ts
+++ b/plugins/browser-plugin-media/src/types.ts
@@ -408,7 +408,6 @@ export interface CommonMediaEventProperties extends CommonEventProperties {
   context?: Array<SelfDescribingJson>;
 }
 
-export type EventWithContext = {
+export interface EventWithContext extends CommonEventProperties {
   event: SelfDescribingJson;
-  context: SelfDescribingJson[];
 };

--- a/plugins/browser-plugin-media/src/types.ts
+++ b/plugins/browser-plugin-media/src/types.ts
@@ -72,16 +72,36 @@ export enum MediaEventType {
   Error = 'error',
 }
 
+/**
+ * Configuration for filtering out repeated events of the same type tracked after each other.
+ * By default, the seek start, seek end and volume change events are filtered out.
+ */
+export type FilterOutRepeatedEvents =
+  | {
+      /**
+       * Whether to filter out seek start and end events tracked after each other.
+       */
+      seekEvents?: boolean;
+      /**
+       * Whether to filter out volume change events tracked after each other.
+       */
+      volumeChangeEvents?: boolean;
+    }
+  | boolean;
+
+
 export type MediaTrackingConfiguration = {
   /** Unique ID of the media tracking. The same ID will be used for media player session if enabled. */
   id: string;
   /** Attributes for the media player context entity */
   player?: MediaPlayerUpdate;
   /** Attributes for the media player session context entity or false to disable it. Enabled by default. */
-  session?: {
-    /** Local date-time timestamp of when the session started. Automatically set to current time if not given. */
-    startedAt?: Date
-  } | false;
+  session?:
+    | {
+        /** Local date-time timestamp of when the session started. Automatically set to current time if not given. */
+        startedAt?: Date;
+      }
+    | false;
   /** Configuration for sending ping events. Enabled by default.  */
   pings?:
     | {
@@ -101,6 +121,13 @@ export type MediaTrackingConfiguration = {
    * Otherwise, tracked event types not present in the list will be discarded.
    */
   captureEvents?: MediaEventType[];
+  /**
+   * Whether to filter out repeated events of the same type tracked after each other.
+   * Useful to filter out repeated seek and volume change events tracked when the user holds down the seek or volume control.
+   * Only applies to seek and volume change events.
+   * Defaults to true.
+   */
+  filterOutRepeatedEvents?: FilterOutRepeatedEvents;
 };
 
 export type MediaTrackPlaybackRateChangeArguments = {
@@ -380,3 +407,8 @@ export interface CommonMediaEventProperties extends CommonEventProperties {
   /** Add context entities to an event by setting an Array of Self Describing JSON */
   context?: Array<SelfDescribingJson>;
 }
+
+export type EventWithContext = {
+  event: SelfDescribingJson;
+  context: SelfDescribingJson[];
+};

--- a/plugins/browser-plugin-media/test/api.test.ts
+++ b/plugins/browser-plugin-media/test/api.test.ts
@@ -467,6 +467,16 @@ describe('Media Tracking API', () => {
 
         expect(eventQueue).toMatchObject([{ context: [{ schema: MEDIA_PLAYER_SCHEMA }, { schema: 'entity' }] }]);
       });
+
+      it('flushes events that are waiting to be filtered automatically after timeout', (done) => {
+        startMediaTracking({ id, filterOutRepeatedEvents: { flushTimeoutMs: 0 } });
+        trackMediaVolumeChange({ id, newVolume: 50 });
+
+        setTimeout(() => {
+          expect(eventQueue.length).toBe(1);
+          done();
+        }, 0);
+      });
     });
 
     it('adds custom context entities to all events', () => {

--- a/plugins/browser-plugin-media/test/api.test.ts
+++ b/plugins/browser-plugin-media/test/api.test.ts
@@ -457,6 +457,16 @@ describe('Media Tracking API', () => {
           },
         ]);
       });
+
+      it('remembers context entities on flush', () => {
+        startMediaTracking({ id, session: false });
+        trackMediaVolumeChange({ id, newVolume: 50 });
+        trackMediaVolumeChange({ id, newVolume: 60 });
+        trackMediaVolumeChange({ id, newVolume: 70, context: [{ schema: 'entity', data: {} }] });
+        endMediaTracking({ id });
+
+        expect(eventQueue).toMatchObject([{ context: [{ schema: MEDIA_PLAYER_SCHEMA }, { schema: 'entity' }] }]);
+      });
     });
 
     it('adds custom context entities to all events', () => {


### PR DESCRIPTION
Issue #1218

This PR adds the ability to filter out repeated seek and volume change events in the media plugin that occur frequently when the user is scrubbing the controls in players (e.g., in the Vimeo or HTML5 players).

The algorithm to filter out the events is very simple – if a seek event is tracked, it is kept in a buffer (not tracked) until an event other than a seek event is tracked or until the media tracking ends (`endMediaTracking` is called).

So if the following events are tracked:

* play
* seek start 1
* seek end 2
* seek start 2
* seek end 2
* pause

By filtering events, the result will be:

* play
* seek start 1
* seek end 2
* pause

Filtering out repeated seek and volume change events is enabled by default, but it is possible to disable as follows:

```js
startMediaTracking({ id, filterOutRepeatedEvents: false });
```

or like this:

```js
startMediaTracking({ id, filterOutRepeatedEvents: { seekEvents: false });
```