### PR TITLE
E2E minor improvements

### DIFF
--- a/common/changes/@snowplow/javascript-tracker/feature-minor-e2e-orchestration-improvement_2023-07-13-08-16.json
+++ b/common/changes/@snowplow/javascript-tracker/feature-minor-e2e-orchestration-improvement_2023-07-13-08-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "End to end test changes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -179,6 +179,10 @@
       "allowedCategories": [ "libraries", "plugins", "trackers" ]
     },
     {
+      "name": "@types/node-fetch",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
       "name": "@types/randomcolor",
       "allowedCategories": [ "plugins" ]
     },
@@ -196,7 +200,7 @@
     },
     {
       "name": "@types/youtube",
-      "allowedCategories": [ "plugins" ]
+      "allowedCategories": [ "plugins", "trackers" ]
     },
     {
       "name": "@typescript-eslint/eslint-plugin",
@@ -211,6 +215,10 @@
       "allowedCategories": [ "trackers" ]
     },
     {
+      "name": "@wdio/globals",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
       "name": "@wdio/jasmine-framework",
       "allowedCategories": [ "trackers" ]
     },
@@ -220,6 +228,10 @@
     },
     {
       "name": "@wdio/sauce-service",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
+      "name": "@wdio/shared-store-service",
       "allowedCategories": [ "trackers" ]
     },
     {
@@ -248,6 +260,10 @@
     },
     {
       "name": "dockerode",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
+      "name": "edgedriver",
       "allowedCategories": [ "trackers" ]
     },
     {
@@ -300,6 +316,10 @@
     },
     {
       "name": "nock",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
+      "name": "node-fetch",
       "allowedCategories": [ "trackers" ]
     },
     {
@@ -376,6 +396,14 @@
     },
     {
       "name": "wdio-chromedriver-service",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
+      "name": "wdio-edgedriver-service",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
+      "name": "wdio-safaridriver-service",
       "allowedCategories": [ "trackers" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1422,21 +1422,26 @@ importers:
       '@types/jsdom': ~16.2.14
       '@types/lodash': ~4.14.180
       '@types/node': ~14.6.0
+      '@types/node-fetch': '2'
+      '@types/youtube': ~0.0.46
       '@wdio/cli': ~8.3.3
+      '@wdio/globals': ~8.11.2
       '@wdio/jasmine-framework': ~8.3.3
       '@wdio/local-runner': ~8.3.3
       '@wdio/sauce-service': ~8.3.3
+      '@wdio/shared-store-service': ~8.11.2
       '@wdio/spec-reporter': ~8.3.0
       '@wdio/static-server-service': ~8.3.0
       '@wdio/types': ~8.3.0
       chalk: 4.1.2
-      chromedriver: ~99.0.0
+      chromedriver: ~114.0.0
       dockerode: ~3.3.1
       jest: ~27.5.1
       jest-environment-jsdom: ~27.5.1
       jest-environment-jsdom-global: ~3.0.0
       jest-standard-reporter: ~2.0.0
       lodash: ~4.17.21
+      node-fetch: '2'
       npm-run-all: ~4.1.5
       rollup: ~2.70.1
       rollup-plugin-cleanup: ~3.2.1
@@ -1451,6 +1456,8 @@ importers:
       tslib: ^2.3.1
       typescript: ~4.6.2
       wdio-chromedriver-service: ~8.0.1
+      wdio-edgedriver-service: ~3.0.2
+      wdio-safaridriver-service: ~2.1.0
       webdriverio: ~8.3.3
     dependencies:
       '@snowplow/browser-plugin-ad-tracking': link:../../plugins/browser-plugin-ad-tracking
@@ -1489,21 +1496,26 @@ importers:
       '@types/jsdom': 16.2.14
       '@types/lodash': 4.14.180
       '@types/node': 14.6.4
-      '@wdio/cli': 8.3.5
-      '@wdio/jasmine-framework': 8.3.5
-      '@wdio/local-runner': 8.3.5
+      '@types/node-fetch': 2.6.4
+      '@types/youtube': 0.0.46
+      '@wdio/cli': 8.3.5_typescript@4.6.2
+      '@wdio/globals': 8.11.2_typescript@4.6.2
+      '@wdio/jasmine-framework': 8.3.5_typescript@4.6.2
+      '@wdio/local-runner': 8.3.5_typescript@4.6.2
       '@wdio/sauce-service': 8.3.5
+      '@wdio/shared-store-service': 8.11.2_typescript@4.6.2
       '@wdio/spec-reporter': 8.3.0
       '@wdio/static-server-service': 8.3.0
       '@wdio/types': 8.3.0
       chalk: 4.1.2
-      chromedriver: 99.0.0
+      chromedriver: 114.0.2
       dockerode: 3.3.1
       jest: 27.5.1_ts-node@10.9.1
       jest-environment-jsdom: 27.5.1
       jest-environment-jsdom-global: 3.0.0_jest-environment-jsdom@27.5.1
       jest-standard-reporter: 2.0.0
       lodash: 4.17.21
+      node-fetch: 2.6.12
       npm-run-all: 4.1.5
       rollup: 2.70.1
       rollup-plugin-cleanup: 3.2.1_rollup@2.70.1
@@ -1516,7 +1528,9 @@ importers:
       ts-jest: 27.1.3_60149d457e34ffba7d4e845dde6a1263
       ts-node: 10.9.1_3a45c3db8dee5edcd277f201fb244988
       typescript: 4.6.2
-      wdio-chromedriver-service: 8.0.1_e79f2276e99de797e09d92ea93561b2e
+      wdio-chromedriver-service: 8.0.1_004e92621c7fa5837873d8fdb8947671
+      wdio-edgedriver-service: 3.0.2_@wdio+types@8.3.0
+      wdio-safaridriver-service: 2.1.0_38e69deb68987ddd418b1267598e302e
       webdriverio: 8.3.5
 
   ../../trackers/node-tracker:
@@ -1584,6 +1598,15 @@ packages:
       magic-string: 0.25.7
       rollup: 2.70.1
       uuid: 8.1.0
+    dev: true
+
+  /@arr/every/1.0.1:
+    resolution: {integrity: sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /@assemblyscript/loader/0.10.1:
+    resolution: {integrity: sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==}
     dev: true
 
   /@babel/code-frame/7.16.7:
@@ -1934,6 +1957,18 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@isaacs/cliui/8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width/4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi/6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi/7.0.0
+    dev: true
+
   /@istanbuljs/load-nyc-config/1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -2081,6 +2116,14 @@ packages:
       jest-get-type: 29.4.2
     dev: true
 
+  /@jest/expect-utils/29.6.1:
+    resolution: {integrity: sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.4.3
+    dev: true
+    optional: true
+
   /@jest/fake-timers/27.5.1:
     resolution: {integrity: sha512-/aPowoolwa07k7/oM3aASneNeBGCmGQsc3ugN4u6s4C/+s5M64MFo/+djTdiwcbQlRfFElGuDXWzaWj6QgKObQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2146,6 +2189,14 @@ packages:
     dependencies:
       '@sinclair/typebox': 0.25.21
     dev: true
+
+  /@jest/schemas/29.6.0:
+    resolution: {integrity: sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+    optional: true
 
   /@jest/source-map/27.5.1:
     resolution: {integrity: sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==}
@@ -2234,6 +2285,19 @@ packages:
       '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
+
+  /@jest/types/29.6.1:
+    resolution: {integrity: sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
+      '@types/istanbul-lib-coverage': 2.0.3
+      '@types/istanbul-reports': 3.0.0
+      '@types/node': 14.6.4
+      '@types/yargs': 17.0.22
+      chalk: 4.1.2
+    dev: true
+    optional: true
 
   /@jridgewell/gen-mapping/0.3.2:
     resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
@@ -2365,6 +2429,45 @@ packages:
       read-package-json-fast: 2.0.3
     dev: true
 
+  /@pkgjs/parseargs/0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@polka/parse/1.0.0-next.0:
+    resolution: {integrity: sha512-zcPNrc3PNrRLSCQ7ca8XR7h18VxdPIXhn+yvrYMdUFCHM7mhXGSPw5xBdbcf/dQ1cI4uE8pDfmm5uU+HX+WfFg==}
+    dev: true
+
+  /@polka/url/0.5.0:
+    resolution: {integrity: sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==}
+    dev: true
+
+  /@puppeteer/browsers/1.3.0_typescript@4.6.2:
+    resolution: {integrity: sha512-an3QdbNPkuU6qpxpbssxAbjRLJcF+eP4L8UqIY3+6n0sbaVxw5pz7PiCLy9g32XEZuoamUlV5ZQPnA6FxvkIHA==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.7.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+      extract-zip: 2.0.1
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      tar-fs: 2.1.1
+      typescript: 4.6.2
+      unbzip2-stream: 1.4.3
+      yargs: 17.7.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@rollup/plugin-alias/3.1.9_rollup@2.70.1:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
@@ -2449,6 +2552,11 @@ packages:
     resolution: {integrity: sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==}
     dev: true
 
+  /@sinclair/typebox/0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+    optional: true
+
   /@sindresorhus/is/0.7.0:
     resolution: {integrity: sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==}
     engines: {node: '>=4'}
@@ -2513,6 +2621,11 @@ packages:
   /@tootallnate/once/1.1.2:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /@tootallnate/once/2.0.0:
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
     dev: true
 
   /@tsconfig/node10/1.0.8:
@@ -2651,6 +2764,13 @@ packages:
     resolution: {integrity: sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==}
     dev: true
 
+  /@types/node-fetch/2.6.4:
+    resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
+    dependencies:
+      '@types/node': 14.6.4
+      form-data: 3.0.0
+    dev: true
+
   /@types/node/14.6.4:
     resolution: {integrity: sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==}
 
@@ -2660,6 +2780,10 @@ packages:
 
   /@types/node/18.13.0:
     resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
+    dev: true
+
+  /@types/node/20.3.3:
+    resolution: {integrity: sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -2713,6 +2837,12 @@ packages:
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
     dev: true
 
+  /@types/split2/3.2.1:
+    resolution: {integrity: sha512-7uz3yU+LooBq4yNOzlZD9PU9/1Eu0rTD1MjQ6apOVEoHsPrMUrFw7W8XrvWtesm2vK67SBK9AyJcOXtMpl9bgQ==}
+    dependencies:
+      '@types/node': 14.6.4
+    dev: true
+
   /@types/ssh2-streams/0.1.9:
     resolution: {integrity: sha512-I2J9jKqfmvXLR5GomDiCoHrEJ58hAOmFrekfFqmCFd+A6gaEStvWnPykoWUwld1PNg4G5ag1LwdA+Lz1doRJqg==}
     dependencies:
@@ -2728,6 +2858,10 @@ packages:
 
   /@types/stack-utils/2.0.0:
     resolution: {integrity: sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==}
+    dev: true
+
+  /@types/tcp-port-used/1.0.1:
+    resolution: {integrity: sha512-6pwWTx8oUtWvsiZUCrhrK/53MzKVLnuNSSaZILPy3uMes9QnTrLMar9BDlJArbMOjDcjb3QXFk6Rz8qmmuySZw==}
     dev: true
 
   /@types/tough-cookie/4.0.0:
@@ -2912,14 +3046,14 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@wdio/cli/8.3.5:
+  /@wdio/cli/8.3.5_typescript@4.6.2:
     resolution: {integrity: sha512-xg/03aYpMCEWdcc9dY/GmPePfzTR/yMRJLwtp5WWYrCl6eEAeViSpf4PLC6ieC5O6IMLWVR/2Os8DrC5PKQq/Q==}
     engines: {node: ^16.13 || >=18}
     hasBin: true
     dependencies:
       '@types/node': 18.13.0
       '@wdio/config': 8.3.2
-      '@wdio/globals': 8.3.5
+      '@wdio/globals': 8.3.5_typescript@4.6.2
       '@wdio/logger': 8.1.0
       '@wdio/protocols': 8.3.5
       '@wdio/types': 8.3.0
@@ -2945,7 +3079,22 @@ packages:
       - bufferutil
       - encoding
       - supports-color
+      - typescript
       - utf-8-validate
+    dev: true
+
+  /@wdio/config/8.11.0:
+    resolution: {integrity: sha512-nBQXsXbPCjddtI/3rAK5yFs3eD3f0T3lZMivweTkLLR7GKBxGjiFoBjXtfqUrHJYa+2uwfXrwxo6y+dA6fVbuw==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@wdio/logger': 8.11.0
+      '@wdio/types': 8.10.4
+      '@wdio/utils': 8.11.0
+      decamelize: 6.0.0
+      deepmerge-ts: 5.1.0
+      glob: 10.3.1
+      import-meta-resolve: 3.0.0
+      read-pkg-up: 9.1.0
     dev: true
 
   /@wdio/config/8.3.2:
@@ -2962,45 +3111,61 @@ packages:
       read-pkg-up: 9.1.0
     dev: true
 
-  /@wdio/globals/8.3.5:
+  /@wdio/globals/8.11.2_typescript@4.6.2:
+    resolution: {integrity: sha512-oaPyGLmWOHQLYtT6Jn3mtZBSYyWxau6ncBDLPJDUwOxufi3tfT9DOen+65OGBK55GfjrCAZOSGAJ13mN/swIQQ==}
+    engines: {node: ^16.13 || >=18}
+    optionalDependencies:
+      expect-webdriverio: 4.2.6_typescript@4.6.2
+      webdriverio: 8.11.2_typescript@4.6.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /@wdio/globals/8.3.5_typescript@4.6.2:
     resolution: {integrity: sha512-w8JZ2seRMe9iPfMYCiKHT1LJIZBUhgT+2ROBDd4ZUP75RzyC0ayZn9CqA6sNCPL6Iq0DSgpqx0U7YVJQCwzwMA==}
     engines: {node: ^16.13 || >=18}
     optionalDependencies:
-      expect-webdriverio: 4.1.1
+      expect-webdriverio: 4.2.6_typescript@4.6.2
       webdriverio: 8.3.5
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - supports-color
+      - typescript
       - utf-8-validate
     dev: true
 
-  /@wdio/jasmine-framework/8.3.5:
+  /@wdio/jasmine-framework/8.3.5_typescript@4.6.2:
     resolution: {integrity: sha512-HOWq5/nsvkFwx5OJ7ZxmCLTA80k9jVOU/5eImaI3b0b5Ewy6WOtEnQi6B1F+i8X7/G+QRotPk4qZeht/Y1NIyQ==}
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/node': 18.13.0
-      '@wdio/globals': 8.3.5
+      '@wdio/globals': 8.3.5_typescript@4.6.2
       '@wdio/logger': 8.1.0
       '@wdio/types': 8.3.0
       '@wdio/utils': 8.3.0
-      expect-webdriverio: 4.1.1
+      expect-webdriverio: 4.1.1_typescript@4.6.2
       jasmine: 4.5.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - supports-color
+      - typescript
       - utf-8-validate
     dev: true
 
-  /@wdio/local-runner/8.3.5:
+  /@wdio/local-runner/8.3.5_typescript@4.6.2:
     resolution: {integrity: sha512-Sg53i8KHAgvc55VsAZ7uZC/IQ5uPtlOY5rKY+XCjemQ5Y3KqqMxHc+X4VFmlsflB43K9CWzizkzq2ukctqKDXQ==}
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/node': 18.13.0
       '@wdio/logger': 8.1.0
       '@wdio/repl': 8.1.0
-      '@wdio/runner': 8.3.5
+      '@wdio/runner': 8.3.5_typescript@4.6.2
       '@wdio/types': 8.3.0
       async-exit-hook: 2.0.1
       split2: 4.1.0
@@ -3009,6 +3174,7 @@ packages:
       - bufferutil
       - encoding
       - supports-color
+      - typescript
       - utf-8-validate
     dev: true
 
@@ -3022,6 +3188,20 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
+  /@wdio/logger/8.11.0:
+    resolution: {integrity: sha512-IsuKSaYi7NKEdgA57h8muzlN/MVp1dQG+V4C//7g4m03YJUnNQLvDhJzLjdeNTfvZy61U7foQSyt+3ktNzZkXA==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      chalk: 5.2.0
+      loglevel: 1.7.1
+      loglevel-plugin-prefix: 0.8.4
+      strip-ansi: 7.1.0
+    dev: true
+
+  /@wdio/protocols/8.11.0:
+    resolution: {integrity: sha512-eXTMYt/XoaX53H/Q2qmsn1uWthIC5aSTGtX9YyXD/AkagG2hXeX3lLmzNWBaSIvKR+vWXRYbg3Y/7IvL2s25Wg==}
+    dev: true
+
   /@wdio/protocols/8.3.5:
     resolution: {integrity: sha512-/zWz+ok6gIB1/L/VEOCoD8nCB8inNF+rsVOYps3FgNbrliQ782YLfA1uAVJTw3U6CaO+7zZ8aJw82EswpoxWjg==}
     dev: true
@@ -3031,6 +3211,13 @@ packages:
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/node': 18.13.0
+    dev: true
+
+  /@wdio/repl/8.10.1:
+    resolution: {integrity: sha512-VZ1WFHTNKjR8Ga97TtV2SZM6fvRjWbYI2i/f4pJB4PtusorKvONAMJf2LQcUBIyzbVobqr7KSrcjmSwRolI+yw==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@types/node': 20.3.3
     dev: true
 
   /@wdio/reporter/8.3.0:
@@ -3045,18 +3232,18 @@ packages:
       supports-color: 9.3.1
     dev: true
 
-  /@wdio/runner/8.3.5:
+  /@wdio/runner/8.3.5_typescript@4.6.2:
     resolution: {integrity: sha512-W0h1U90zGFmYvqfWsmtb3myDqFsHhHy6z9ngQDLOCKg6iwKWFvMW2Db3BJ1D641/lA2dRWFH5XklQqD6trsydg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/node': 18.13.0
       '@wdio/config': 8.3.2
-      '@wdio/globals': 8.3.5
+      '@wdio/globals': 8.3.5_typescript@4.6.2
       '@wdio/logger': 8.1.0
       '@wdio/types': 8.3.0
       '@wdio/utils': 8.3.0
       deepmerge-ts: 4.3.0
-      expect-webdriverio: 4.1.1
+      expect-webdriverio: 4.1.1_typescript@4.6.2
       gaze: 1.1.3
       webdriver: 8.3.5
       webdriverio: 8.3.5
@@ -3064,6 +3251,7 @@ packages:
       - bufferutil
       - encoding
       - supports-color
+      - typescript
       - utf-8-validate
     dev: true
 
@@ -3081,6 +3269,24 @@ packages:
       - bufferutil
       - encoding
       - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@wdio/shared-store-service/8.11.2_typescript@4.6.2:
+    resolution: {integrity: sha512-NLt7HFmHfe43yfG1QymWcUSzUxe9j5Wq9ak/N7Q9MYJXZoqGiMi4pXuYVVmbaFC6/QPT1Ix6yssFo3cKIT8oUA==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@polka/parse': 1.0.0-next.0
+      '@wdio/logger': 8.11.0
+      '@wdio/types': 8.10.4
+      got: 12.6.1
+      polka: 0.5.2
+      webdriverio: 8.11.2_typescript@4.6.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
       - utf-8-validate
     dev: true
 
@@ -3105,11 +3311,28 @@ packages:
       morgan: 1.10.0
     dev: true
 
+  /@wdio/types/8.10.4:
+    resolution: {integrity: sha512-aLJ1QQW+hhALeRK3bvMLjIrlUVyhOs3Od+91pR4Z4pLwyeNG1bJZCJRD5bAJK/mm7CnFa0NsdixPS9jJxZcRrw==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@types/node': 20.3.3
+    dev: true
+
   /@wdio/types/8.3.0:
     resolution: {integrity: sha512-TTs3ETVOJtooTIY/u2+feeBnMBx2Hb4SEItN31r0pFncn37rnIZXE/buywLNf5wvZW9ukxoCup5hCnohOR27eQ==}
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/node': 18.13.0
+    dev: true
+
+  /@wdio/utils/8.11.0:
+    resolution: {integrity: sha512-XBl1zalk5UPu8QKZ7LZIA82Ad363fpNHZHP5uI5OxUFnk4ZPWgY9eCWpeD+4f9a0DS0w2Dro15E4PORNX84pIw==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@wdio/logger': 8.11.0
+      '@wdio/types': 8.10.4
+      import-meta-resolve: 3.0.0
+      p-iteration: 1.1.8
     dev: true
 
   /@wdio/utils/8.3.0:
@@ -3257,7 +3480,7 @@ packages:
     dev: true
 
   /ansi-regex/2.1.1:
-    resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=}
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -3493,10 +3716,12 @@ packages:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: true
 
-  /axios/0.24.0:
-    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
+  /axios/1.4.0:
+    resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
     dependencies:
       follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
     dev: true
@@ -3595,9 +3820,21 @@ packages:
       tweetnacl: 0.14.5
     dev: true
 
+  /big-integer/1.6.51:
+    resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
+    engines: {node: '>=0.6'}
+    dev: true
+
   /binary-extensions/2.1.0:
     resolution: {integrity: sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /binary/0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
     dev: true
 
   /bl/1.2.3:
@@ -3621,6 +3858,10 @@ packages:
       buffer: 6.0.3
       inherits: 2.0.4
       readable-stream: 3.6.0
+    dev: true
+
+  /bluebird/3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
     dev: true
 
   /blueimp-md5/2.18.0:
@@ -3764,6 +4005,11 @@ packages:
     resolution: {integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==}
     dev: true
 
+  /buffer-indexof-polyfill/1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+    dev: true
+
   /buffer/5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
     dependencies:
@@ -3776,6 +4022,11 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: true
+
+  /buffers/0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
     dev: true
 
   /builtin-modules/3.2.0:
@@ -3838,6 +4089,19 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
+  /cacheable-request/10.2.12:
+    resolution: {integrity: sha512-qtWGB5kn2OLjx47pYUkWicyOpK1vy9XZhq8yRTXOy+KAmjjESSRLx6SiExnnaGGUP1NM6/vmygMu0fGylNh9tw==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      '@types/http-cache-semantics': 4.0.1
+      get-stream: 6.0.1
+      http-cache-semantics: 4.1.1
+      keyv: 4.5.2
+      mimic-response: 4.0.0
+      normalize-url: 8.0.0
+      responselike: 3.0.0
+    dev: true
+
   /cacheable-request/10.2.7:
     resolution: {integrity: sha512-I4SA6mKgDxcxVbSt/UmIkb9Ny8qSkg6ReBHtAAXnZHk7KOSx5g3DTiAOaYzcHCs6oOdHn+bip9T48E6tMvK9hw==}
     engines: {node: '>=14.16'}
@@ -3892,6 +4156,13 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
+  /camaro/6.2.0:
+    resolution: {integrity: sha512-81zTKgZb2LnkZKtLbIqLqBzQ6stWSlWC3I/lZd5u4NJVljDgMcsZqn9zZ+Yij/yNyiVpko0EhOKdYa6YAbOWrA==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      piscina: 3.2.0
+    dev: true
+
   /camel-case/4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
@@ -3943,6 +4214,12 @@ packages:
     engines: {node: '>=12.19'}
     dependencies:
       nofilter: 3.1.0
+    dev: true
+
+  /chainsaw/0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
+    dependencies:
+      traverse: 0.3.9
     dev: true
 
   /chalk/1.1.3:
@@ -4048,15 +4325,15 @@ packages:
       lighthouse-logger: 1.2.0
     dev: true
 
-  /chromedriver/99.0.0:
-    resolution: {integrity: sha512-pyB+5LuyZdb7EBPL3i5D5yucZUD+SlkdiUtmpjaEnLd9zAXp+SvD/hP5xF4l/ZmWvUo/1ZLxAI1YBdhazGTpgA==}
-    engines: {node: '>=10'}
+  /chromedriver/114.0.2:
+    resolution: {integrity: sha512-v0qrXRBknbxqmtklG7RWOe3TJ/dLaHhtB0jVxE7BAdYERxUjEaNRyqBwoGgVfQDibHCB0swzvzsj158nnfPgZw==}
+    engines: {node: '>=16'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@testim/chrome-version': 1.1.3
-      axios: 0.24.0
-      del: 6.0.0
+      axios: 1.4.0
+      compare-versions: 5.0.3
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
       proxy-from-env: 1.1.0
@@ -4064,6 +4341,15 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
+    dev: true
+
+  /chromium-bidi/0.4.9_devtools-protocol@0.0.1120988:
+    resolution: {integrity: sha512-u3DC6XwgLCA9QJ5ak1voPslCmacQdulZNCPsI3qNXxSnEcZS7DFIbww+5RM2bznMEje7cc0oydavRLRvOIZtHw==}
+    peerDependencies:
+      devtools-protocol: '*'
+    dependencies:
+      devtools-protocol: 0.0.1120988
+      mitt: 3.0.0
     dev: true
 
   /chunkd/2.0.1:
@@ -4240,6 +4526,11 @@ packages:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
+  /commander/9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: true
+
   /commenting/1.1.0:
     resolution: {integrity: sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==}
     dev: true
@@ -4250,6 +4541,10 @@ packages:
 
   /commondir/1.0.1:
     resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
+    dev: true
+
+  /compare-versions/5.0.3:
+    resolution: {integrity: sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==}
     dev: true
 
   /compatfactory/0.0.12_typescript@4.6.2:
@@ -4335,7 +4630,7 @@ packages:
     dev: true
 
   /core-util-is/1.0.2:
-    resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     dev: true
 
   /cpu-features/0.0.2:
@@ -4372,6 +4667,14 @@ packages:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
       node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /cross-fetch/3.1.6:
+    resolution: {integrity: sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==}
+    dependencies:
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -4449,6 +4752,11 @@ packages:
     engines: {node: '>=0.10'}
     dependencies:
       assert-plus: 1.0.0
+    dev: true
+
+  /data-uri-to-buffer/4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
     dev: true
 
   /data-urls/2.0.0:
@@ -4602,6 +4910,11 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
+  /deepmerge-ts/5.1.0:
+    resolution: {integrity: sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==}
+    engines: {node: '>=16.0.0'}
+    dev: true
+
   /deepmerge/4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
     engines: {node: '>=0.10.0'}
@@ -4679,6 +4992,40 @@ packages:
     resolution: {integrity: sha512-3ph1q/ShAKFNnc7quSsAKTKAkQW/32gR4tRNAoqVzdAbyT8PjQFW/HzVWDm5mqP7zBd9nP1nd9jA1JHTHrJCXg==}
     dev: true
 
+  /devtools-protocol/0.0.1120988:
+    resolution: {integrity: sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q==}
+    dev: true
+
+  /devtools-protocol/0.0.1152884:
+    resolution: {integrity: sha512-9eP6OmCoU1cWArpXLuzyZQcBJ2PkINOh8Nwx8W5i8u6NDigDE5/mPlLLBAfshwn5YVvIz6ZQ9jbs0PZvKGccdQ==}
+    dev: true
+
+  /devtools/8.11.0_typescript@4.6.2:
+    resolution: {integrity: sha512-j1wXFQyjswJ6doAV1+h4Bxl8+Oeb8SMpWTpBVa0DurGsxfft8sU2OhDlMo5tx/zbX82X5sGyJDMnKHqBJ2XRvQ==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@types/node': 20.3.3
+      '@wdio/config': 8.11.0
+      '@wdio/logger': 8.11.0
+      '@wdio/protocols': 8.11.0
+      '@wdio/types': 8.10.4
+      '@wdio/utils': 8.11.0
+      chrome-launcher: 0.15.0
+      edge-paths: 3.0.5
+      import-meta-resolve: 3.0.0
+      puppeteer-core: 20.3.0_typescript@4.6.2
+      query-selector-shadow-dom: 1.0.0
+      ua-parser-js: 1.0.2
+      uuid: 9.0.0
+      which: 3.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+    dev: true
+
   /devtools/8.3.5:
     resolution: {integrity: sha512-ncMUl1CKH6hWyxHMfVCRnzKkVvviXJhqy1GIE2SialdUh68CsfEibzmDof+a2E9stkN1vVdmMKYeC5LAQv2i5g==}
     engines: {node: ^16.13 || >=18}
@@ -4696,7 +5043,7 @@ packages:
       query-selector-shadow-dom: 1.0.0
       ua-parser-js: 1.0.2
       uuid: 9.0.0
-      which: 3.0.0
+      which: 3.0.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -4713,6 +5060,12 @@ packages:
     resolution: {integrity: sha512-R6P0Y6PrsH3n4hUXxL3nns0rbRk6Q33js3ygJBeEpbzLzgcNuJ61+u0RXasFpTKISw99TxUzFnumSnRLsjhLaw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
+
+  /diff-sequences/29.4.3:
+    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+    optional: true
 
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -4799,6 +5152,12 @@ packages:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
 
+  /duplexer2/0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+    dependencies:
+      readable-stream: 2.3.7
+    dev: true
+
   /duplexer3/0.1.4:
     resolution: {integrity: sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==}
     dev: true
@@ -4828,6 +5187,20 @@ packages:
     dependencies:
       '@types/which': 2.0.1
       which: 2.0.2
+    dev: true
+
+  /edgedriver/5.2.1:
+    resolution: {integrity: sha512-H8mF7UYMR/r6izCPgQA5d+pHdIF47wncoTS2KWogoZ4hbNeFz9VbCPxPFoGPCCfizk/e4H5DhXapcYX0yyZqjg==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@wdio/logger': 8.11.0
+      camaro: 6.2.0
+      decamelize: 6.0.0
+      edge-paths: 3.0.5
+      node-fetch: 3.3.1
+      unzipper: 0.10.14
+      which: 3.0.1
     dev: true
 
   /ee-first/1.1.1:
@@ -5155,6 +5528,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /eventemitter-asyncresource/1.0.0:
+    resolution: {integrity: sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ==}
+    dev: true
+
   /execa/5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -5195,21 +5572,41 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /expect-webdriverio/4.1.1:
+  /expect-webdriverio/4.1.1_typescript@4.6.2:
     resolution: {integrity: sha512-Qx29DagUJ8DDsEJe2aT1S+OdEcidIO+A2uRxjJqM3i7cI+wUiC85MBWmupSwuvyEAoCOoEJUiRbA0NPpXXViCg==}
     engines: {node: '>=16 || >=18 || >=20'}
     dependencies:
       expect: 29.4.2
       jest-matcher-utils: 29.4.2
     optionalDependencies:
-      '@wdio/globals': 8.3.5
+      '@wdio/globals': 8.11.2_typescript@4.6.2
       webdriverio: 8.3.5
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - supports-color
+      - typescript
       - utf-8-validate
     dev: true
+
+  /expect-webdriverio/4.2.6_typescript@4.6.2:
+    resolution: {integrity: sha512-/7wImWgef6ooZSoivXq6jkCDE1vvDC42WcM7Iyguspah/h384nprUdpQPLIUkkvTCorSQdYtRftNvHJjEpVUmA==}
+    engines: {node: '>=16 || >=18 || >=20'}
+    requiresBuild: true
+    dependencies:
+      expect: 29.6.1
+      jest-matcher-utils: 29.6.1
+    optionalDependencies:
+      '@wdio/globals': 8.11.2_typescript@4.6.2
+      webdriverio: 8.11.2_typescript@4.6.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+    dev: true
+    optional: true
 
   /expect/27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
@@ -5231,6 +5628,19 @@ packages:
       jest-message-util: 29.4.2
       jest-util: 29.4.2
     dev: true
+
+  /expect/29.6.1:
+    resolution: {integrity: sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/expect-utils': 29.6.1
+      '@types/node': 14.6.4
+      jest-get-type: 29.4.3
+      jest-matcher-utils: 29.6.1
+      jest-message-util: 29.6.1
+      jest-util: 29.6.1
+    dev: true
+    optional: true
 
   /express/4.17.1:
     resolution: {integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==}
@@ -5362,6 +5772,14 @@ packages:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
       pend: 1.2.0
+    dev: true
+
+  /fetch-blob/3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
     dev: true
 
   /figures/4.0.0:
@@ -5519,6 +5937,14 @@ packages:
         optional: true
     dev: true
 
+  /foreground-child/3.1.1:
+    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.0.2
+    dev: true
+
   /forever-agent/0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
@@ -5553,6 +5979,13 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.27
+    dev: true
+
+  /formdata-polyfill/4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
     dev: true
 
   /forwarded/0.1.2:
@@ -5603,6 +6036,16 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /fstream/1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      graceful-fs: 4.2.9
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
+    dev: true
 
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
@@ -5655,6 +6098,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: true
 
+  /get-port/7.0.0:
+    resolution: {integrity: sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==}
+    engines: {node: '>=16'}
+    dev: true
+
   /get-stream/2.3.1:
     resolution: {integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==}
     engines: {node: '>=0.10.0'}
@@ -5704,6 +6152,18 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
+    dev: true
+
+  /glob/10.3.1:
+    resolution: {integrity: sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 2.2.1
+      minimatch: 9.0.2
+      minipass: 6.0.2
+      path-scurry: 1.10.0
     dev: true
 
   /glob/7.1.6:
@@ -5860,6 +6320,23 @@ packages:
       responselike: 3.0.0
     dev: true
 
+  /got/12.6.1:
+    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      '@sindresorhus/is': 5.3.0
+      '@szmarczak/http-timer': 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.12
+      decompress-response: 6.0.0
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.0
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
+    dev: true
+
   /got/8.3.2:
     resolution: {integrity: sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==}
     engines: {node: '>=4'}
@@ -5966,6 +6443,18 @@ packages:
       minimalistic-assert: 1.0.1
     dev: true
 
+  /hdr-histogram-js/2.0.3:
+    resolution: {integrity: sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==}
+    dependencies:
+      '@assemblyscript/loader': 0.10.1
+      base64-js: 1.5.1
+      pako: 1.0.11
+    dev: true
+
+  /hdr-histogram-percentiles-obj/3.0.0:
+    resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
+    dev: true
+
   /header-case/2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
@@ -6040,6 +6529,17 @@ packages:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
       debug: 4.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /http-proxy-agent/5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6148,6 +6648,10 @@ packages:
 
   /import-meta-resolve/2.2.1:
     resolution: {integrity: sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==}
+    dev: true
+
+  /import-meta-resolve/3.0.0:
+    resolution: {integrity: sha512-4IwhLhNNA8yy445rPjD/lWh++7hMDOml2eHtd58eG7h+qK3EryMuuRbsHGPikCoAgIkkDnckKfWSk2iDla/ejg==}
     dev: true
 
   /import-modules/2.1.0:
@@ -6478,7 +6982,7 @@ packages:
     dev: true
 
   /isarray/1.0.0:
-    resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
     dev: true
 
   /isbot/3.3.4:
@@ -6487,7 +6991,7 @@ packages:
     dev: true
 
   /isexe/2.0.0:
-    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
   /isstream/0.1.2:
@@ -6546,6 +7050,15 @@ packages:
     dependencies:
       has-to-string-tag-x: 1.4.1
       is-object: 1.0.2
+    dev: true
+
+  /jackspeak/2.2.1:
+    resolution: {integrity: sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
     dev: true
 
   /jake/10.8.5:
@@ -6768,6 +7281,17 @@ packages:
       pretty-format: 29.4.2
     dev: true
 
+  /jest-diff/29.6.1:
+    resolution: {integrity: sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.4.3
+      jest-get-type: 29.4.3
+      pretty-format: 29.6.1
+    dev: true
+    optional: true
+
   /jest-docblock/27.5.1:
     resolution: {integrity: sha512-rl7hlABeTsRYxKiUfpHrQrG4e2obOiTQWfMEH3PxPjOtdsfLQO4ReWSZaQ7DETm4xu07rl4q/h4zcKXyU0/OzQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -6834,6 +7358,12 @@ packages:
     resolution: {integrity: sha512-vERN30V5i2N6lqlFu4ljdTqQAgrkTFMC9xaIIfOPYBw04pufjXRty5RuXBiB1d72tGbURa/UgoiHB90ruOSivg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
+
+  /jest-get-type/29.4.3:
+    resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+    optional: true
 
   /jest-haste-map/27.5.1:
     resolution: {integrity: sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==}
@@ -6908,6 +7438,17 @@ packages:
       pretty-format: 29.4.2
     dev: true
 
+  /jest-matcher-utils/29.6.1:
+    resolution: {integrity: sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.6.1
+      jest-get-type: 29.4.3
+      pretty-format: 29.6.1
+    dev: true
+    optional: true
+
   /jest-message-util/26.6.2:
     resolution: {integrity: sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==}
     engines: {node: '>= 10.14.2'}
@@ -6952,6 +7493,22 @@ packages:
       slash: 3.0.0
       stack-utils: 2.0.5
     dev: true
+
+  /jest-message-util/29.6.1:
+    resolution: {integrity: sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@jest/types': 29.6.1
+      '@types/stack-utils': 2.0.0
+      chalk: 4.1.2
+      graceful-fs: 4.2.9
+      micromatch: 4.0.4
+      pretty-format: 29.6.1
+      slash: 3.0.0
+      stack-utils: 2.0.5
+    dev: true
+    optional: true
 
   /jest-mock/27.5.1:
     resolution: {integrity: sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==}
@@ -7151,6 +7708,19 @@ packages:
       graceful-fs: 4.2.9
       picomatch: 2.3.1
     dev: true
+
+  /jest-util/29.6.1:
+    resolution: {integrity: sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.1
+      '@types/node': 14.6.4
+      chalk: 4.1.2
+      ci-info: 3.3.0
+      graceful-fs: 4.2.9
+      picomatch: 2.3.1
+    dev: true
+    optional: true
 
   /jest-validate/27.5.1:
     resolution: {integrity: sha512-thkNli0LYTmOI1tDB3FI1S1RTp/Bqyd9pTarJwL87OIBFuqEb5Apv5EaApEudYg4g86e3CT6kM0RowkhtEnCBQ==}
@@ -7458,6 +8028,10 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
+  /listenercount/1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+    dev: true
+
   /load-json-file/1.1.0:
     resolution: {integrity: sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==}
     engines: {node: '>=0.10.0'}
@@ -7610,6 +8184,11 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
+  /lru-cache/10.0.0:
+    resolution: {integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==}
+    engines: {node: 14 || >=16.14}
+    dev: true
+
   /lru-cache/4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
     dependencies:
@@ -7707,6 +8286,13 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       escape-string-regexp: 5.0.0
+    dev: true
+
+  /matchit/1.1.0:
+    resolution: {integrity: sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@arr/every': 1.0.1
     dev: true
 
   /md5-hex/3.0.1:
@@ -7842,8 +8428,19 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch/9.0.2:
+    resolution: {integrity: sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist/1.2.5:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
+    dev: true
+
+  /minimist/1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
   /minipass-collect/1.0.2:
@@ -7899,6 +8496,11 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /minipass/6.0.2:
+    resolution: {integrity: sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
+
   /minizlib/2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
@@ -7907,8 +8509,19 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /mitt/3.0.0:
+    resolution: {integrity: sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==}
+    dev: true
+
   /mkdirp-classic/0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: true
+
+  /mkdirp/0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
     dev: true
 
   /mkdirp/1.0.4:
@@ -7982,6 +8595,16 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /nice-napi/1.0.2:
+    resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
+    os: ['!win32']
+    requiresBuild: true
+    dependencies:
+      node-addon-api: 3.2.1
+      node-gyp-build: 4.6.0
+    dev: true
+    optional: true
+
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
@@ -8015,6 +8638,28 @@ packages:
       - supports-color
     dev: true
 
+  /node-addon-api/3.2.1:
+    resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+    dev: true
+    optional: true
+
+  /node-domexception/1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: true
+
+  /node-fetch/2.6.12:
+    resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
+
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -8026,6 +8671,21 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
     dev: true
+
+  /node-fetch/3.3.1:
+    resolution: {integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+    dev: true
+
+  /node-gyp-build/4.6.0:
+    resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
+    hasBin: true
+    dev: true
+    optional: true
 
   /node-gyp/7.1.2:
     resolution: {integrity: sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==}
@@ -8318,7 +8978,7 @@ packages:
       is-interactive: 2.0.0
       is-unicode-supported: 1.1.0
       log-symbols: 5.1.0
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
       wcwidth: 1.0.1
     dev: true
 
@@ -8481,6 +9141,10 @@ packages:
       - supports-color
     dev: true
 
+  /pako/1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: true
+
   /param-case/3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
@@ -8593,6 +9257,14 @@ packages:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
+  /path-scurry/1.10.0:
+    resolution: {integrity: sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 10.0.0
+      minipass: 6.0.2
+    dev: true
+
   /path-to-regexp/0.1.7:
     resolution: {integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=}
     dev: true
@@ -8696,6 +9368,16 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /piscina/3.2.0:
+    resolution: {integrity: sha512-yn/jMdHRw+q2ZJhFhyqsmANcbF6V2QwmD84c6xRau+QpQOmtrBCoRGdvTfeuFDYXB5W2m6MfLkjkvQa9lUSmIA==}
+    dependencies:
+      eventemitter-asyncresource: 1.0.0
+      hdr-histogram-js: 2.0.3
+      hdr-histogram-percentiles-obj: 3.0.0
+    optionalDependencies:
+      nice-napi: 1.0.2
+    dev: true
+
   /pkg-conf/4.0.0:
     resolution: {integrity: sha512-7dmgi4UY4qk+4mj5Cd8v/GExPo0K+SlY+hulOSdfZ/T6jVH6//y7NtzZo5WrfhDBxuQ0jCa7fLZmNaNh7EWL/w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -8723,6 +9405,13 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       irregular-plurals: 3.3.0
+    dev: true
+
+  /polka/0.5.2:
+    resolution: {integrity: sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==}
+    dependencies:
+      '@polka/url': 0.5.0
+      trouter: 2.0.1
     dev: true
 
   /prelude-ls/1.1.2:
@@ -8768,6 +9457,16 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /pretty-format/29.6.1:
+    resolution: {integrity: sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
+    optional: true
+
   /pretty-ms/7.0.1:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
@@ -8788,6 +9487,11 @@ packages:
   /process/0.11.10:
     resolution: {integrity: sha1-czIwDoQBYb2j5podHZGn1LwW8YI=}
     engines: {node: '>= 0.6.0'}
+    dev: true
+
+  /progress/2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /promise-inflight/1.0.1:
@@ -8860,6 +9564,29 @@ packages:
       tar-fs: 2.1.1
       unbzip2-stream: 1.4.3
       ws: 8.11.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /puppeteer-core/20.3.0_typescript@4.6.2:
+    resolution: {integrity: sha512-264pBrIui5bO6NJeOcbJrLa0OCwmA4+WK00JMrLIKTfRiqe2gx8KWTzLsjyw/bizErp3TKS7vt/I0i5fTC+mAw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      typescript: '>= 4.7.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@puppeteer/browsers': 1.3.0_typescript@4.6.2
+      chromium-bidi: 0.4.9_devtools-protocol@0.0.1120988
+      cross-fetch: 3.1.6
+      debug: 4.3.4
+      devtools-protocol: 0.0.1120988
+      typescript: 4.6.2
+      ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -9162,6 +9889,13 @@ packages:
     resolution: {integrity: sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==}
     dev: true
 
+  /rimraf/2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.0
+    dev: true
+
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
@@ -9305,6 +10039,10 @@ packages:
       tslib: 2.3.1
     dev: true
 
+  /safaridriver/0.0.4:
+    resolution: {integrity: sha512-EgK9Vc2Bk4WaECq1E7ti9GyeQ6JKKQNs40vNOE/b5Ul5dDEt429G0Kj5Nzs4FRS5ZIVa7nBck1TyHuinOYdz2Q==}
+    dev: true
+
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
     dev: true
@@ -9423,6 +10161,10 @@ packages:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: true
 
+  /setimmediate/1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+    dev: true
+
   /setprototypeof/1.1.1:
     resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
     dev: true
@@ -9464,6 +10206,11 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
+
+  /signal-exit/4.0.2:
+    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
+    engines: {node: '>=14'}
     dev: true
 
   /sinon/13.0.1:
@@ -9639,6 +10386,11 @@ packages:
     engines: {node: '>= 10.x'}
     dev: true
 
+  /split2/4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+    dev: true
+
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
     dev: true
@@ -9748,7 +10500,7 @@ packages:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: true
 
   /string.prototype.padend/3.1.1:
@@ -9787,7 +10539,7 @@ packages:
     dev: true
 
   /strip-ansi/3.0.1:
-    resolution: {integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=}
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
@@ -9802,6 +10554,13 @@ packages:
 
   /strip-ansi/7.0.1:
     resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.0.1
+    dev: true
+
+  /strip-ansi/7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
@@ -10083,7 +10842,7 @@ packages:
     dev: true
 
   /tr46/0.0.3:
-    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
 
   /tr46/2.1.0:
@@ -10093,11 +10852,22 @@ packages:
       punycode: 2.1.1
     dev: true
 
+  /traverse/0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
+    dev: true
+
   /trim-repeated/1.0.0:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       escape-string-regexp: 1.0.5
+    dev: true
+
+  /trouter/2.0.1:
+    resolution: {integrity: sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      matchit: 1.1.0
     dev: true
 
   /ts-clone-node/0.3.30_typescript@4.6.2:
@@ -10309,6 +11079,21 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /unzipper/0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
+    dependencies:
+      big-integer: 1.6.51
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.9
+      listenercount: 1.0.1
+      readable-stream: 2.3.7
+      setimmediate: 1.0.5
+    dev: true
+
   /upper-case-first/2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
@@ -10340,7 +11125,7 @@ packages:
     dev: true
 
   /util-deprecate/1.0.2:
-    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
   /util/0.10.4:
@@ -10445,6 +11230,18 @@ packages:
       xml-name-validator: 3.0.0
     dev: true
 
+  /wait-port/1.0.4:
+    resolution: {integrity: sha512-w8Ftna3h6XSFWWc2JC5gZEgp64nz8bnaTp5cvzbJSZ53j+omktWTDdwXxEF0jM8YveviLgFWvNGrSvRHnkyHyw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      commander: 9.5.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /walker/1.0.7:
     resolution: {integrity: sha512-cF4je9Fgt6sj1PKfuFt9jpQPeHosM+Ryma/hfY9U7uXGKM7pJCsF0v2r55o+Il54+i77SyYWetB4tD1dEygRkw==}
     dependencies:
@@ -10458,7 +11255,7 @@ packages:
       defaults: 1.0.3
     dev: true
 
-  /wdio-chromedriver-service/8.0.1_e79f2276e99de797e09d92ea93561b2e:
+  /wdio-chromedriver-service/8.0.1_004e92621c7fa5837873d8fdb8947671:
     resolution: {integrity: sha512-nLjJmUBlng8RtnTM/ZJt1rzwAY1QqsMZbmNDxX7/AuSZEu88URTjjUhGPHY0d9al33GSiVoF606P0QSQT6B1ag==}
     engines: {node: ^16.13 || >=18}
     peerDependencies:
@@ -10473,7 +11270,7 @@ packages:
     dependencies:
       '@wdio/logger': 8.1.0
       '@wdio/types': 8.3.0
-      chromedriver: 99.0.0
+      chromedriver: 114.0.2
       fs-extra: 11.1.0
       split2: 4.1.0
       tcp-port-used: 1.0.2
@@ -10482,9 +11279,76 @@ packages:
       - supports-color
     dev: true
 
+  /wdio-edgedriver-service/3.0.2_@wdio+types@8.3.0:
+    resolution: {integrity: sha512-7rDzeG1Dpcbx28w5fpHX5MOm9bteiWeTVdeVvRVIqukVdgPyjS0Ej/pU4952wZBFWqnja4er0B90x6BYU1KiIw==}
+    engines: {node: ^16.13 || >=18}
+    peerDependencies:
+      '@wdio/types': ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@wdio/types':
+        optional: true
+    dependencies:
+      '@wdio/logger': 8.11.0
+      '@wdio/types': 8.3.0
+      edgedriver: 5.2.1
+      get-port: 7.0.0
+      split2: 4.2.0
+      wait-port: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /wdio-safaridriver-service/2.1.0_38e69deb68987ddd418b1267598e302e:
+    resolution: {integrity: sha512-Zg0aZn8KJo+MwvdOTje2cja4OcrkpoCBhQSzVlhZ3SszMnwhi4VQ1p5TdHB9mWZpuVtsLHWpmx/G7ceJWendVw==}
+    engines: {node: ^16.13 || >=18}
+    peerDependencies:
+      '@wdio/types': ^7.0.0 || ^8.0.0-alpha.219
+      webdriverio: ^7.0.0 || ^8.0.0-alpha.219
+    peerDependenciesMeta:
+      '@wdio/types':
+        optional: true
+    dependencies:
+      '@types/split2': 3.2.1
+      '@types/tcp-port-used': 1.0.1
+      '@wdio/logger': 8.11.0
+      '@wdio/types': 8.3.0
+      fs-extra: 11.1.0
+      safaridriver: 0.0.4
+      split2: 4.1.0
+      tcp-port-used: 1.0.2
+      webdriverio: 8.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /web-streams-polyfill/3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /web-vitals/3.3.2:
     resolution: {integrity: sha512-qRkpmSeKfEWAzNhtX541xA8gCJ+pqCqBmUlDVkVDSCSYUvfvNqF+k9g8I+uyreRcDBdfiJrd0/aLbTy5ydo49Q==}
     dev: false
+
+  /webdriver/8.11.1:
+    resolution: {integrity: sha512-hSpUZYzUA65t4DDtKujCHUX6hpFTUleb7lWMcf5xjPz8sxWrK9R8NIw7pXt/GU6PVS331nGAaYkzoXrqz2VB8w==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@types/node': 20.3.3
+      '@types/ws': 8.5.4
+      '@wdio/config': 8.11.0
+      '@wdio/logger': 8.11.0
+      '@wdio/protocols': 8.11.0
+      '@wdio/types': 8.10.4
+      '@wdio/utils': 8.11.0
+      deepmerge-ts: 5.1.0
+      got: 12.6.1
+      ky: 0.33.2
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
 
   /webdriver/8.3.5:
     resolution: {integrity: sha512-TNlvRtX4OVDzkrLSH5vAVpzTRbpOEYKyU80S8wVx9OddTFgs4fc4SLEqZobdSc1W/IvKjoTNa8TkFx9M237tOw==}
@@ -10503,6 +11367,43 @@ packages:
       ws: 8.11.0
     transitivePeerDependencies:
       - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /webdriverio/8.11.2_typescript@4.6.2:
+    resolution: {integrity: sha512-e/9WkdNTfWeoaSo2UzK0Giec/nQX3i7U9J8esimhozH/EpwSqIaEJ2pRRlxRVafEhe2OBG1QDhnLnDjdCC5Hxg==}
+    engines: {node: ^16.13 || >=18}
+    dependencies:
+      '@types/node': 20.3.3
+      '@wdio/config': 8.11.0
+      '@wdio/logger': 8.11.0
+      '@wdio/protocols': 8.11.0
+      '@wdio/repl': 8.10.1
+      '@wdio/types': 8.10.4
+      '@wdio/utils': 8.11.0
+      archiver: 5.1.0
+      aria-query: 5.0.0
+      css-shorthand-properties: 1.1.1
+      css-value: 0.0.1
+      devtools: 8.11.0_typescript@4.6.2
+      devtools-protocol: 0.0.1152884
+      grapheme-splitter: 1.0.4
+      import-meta-resolve: 3.0.0
+      is-plain-obj: 4.1.0
+      lodash.clonedeep: 4.5.0
+      lodash.zip: 4.2.0
+      minimatch: 9.0.2
+      puppeteer-core: 20.3.0_typescript@4.6.2
+      query-selector-shadow-dom: 1.0.0
+      resq: 1.10.0
+      rgb2hex: 0.2.5
+      serialize-error: 8.0.1
+      webdriver: 8.11.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
       - utf-8-validate
     dev: true
 
@@ -10543,7 +11444,7 @@ packages:
     dev: true
 
   /webidl-conversions/3.0.1:
-    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: true
 
   /webidl-conversions/5.0.0:
@@ -10572,7 +11473,7 @@ packages:
     dev: true
 
   /whatwg-url/5.0.0:
-    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
@@ -10602,8 +11503,8 @@ packages:
       isexe: 2.0.0
     dev: true
 
-  /which/3.0.0:
-    resolution: {integrity: sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==}
+  /which/3.0.1:
+    resolution: {integrity: sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
     dependencies:
@@ -10643,7 +11544,7 @@ packages:
     dependencies:
       ansi-styles: 6.1.0
       string-width: 5.1.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: true
 
   /wrappy/1.0.2:
@@ -10685,6 +11586,19 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /ws/8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -10761,6 +11675,19 @@ packages:
 
   /yargs/17.6.2:
     resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.5
+      yargs-parser: 21.1.1
+    dev: true
+
+  /yargs/17.7.1:
+    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "b3670fdd35939880fb5506b045e5826aeab84996",
+  "pnpmShrinkwrapHash": "c0609797f2587b31945d0f4e1ef5755136269ae6",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/rush.json
+++ b/rush.json
@@ -59,7 +59,7 @@
      * The default value is false to avoid legacy compatibility issues.
      * It is strongly recommended to set strictPeerDependencies=true.
      */
-    "strictPeerDependencies": true,
+    "strictPeerDependencies": false,
 
     /**
      * Configures the strategy used to select versions during installation.

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "docker:micro": "docker pull snowplow/snowplow-micro:1.4.0",
+    "docker:micro": "docker pull snowplow/snowplow-micro:latest",
     "test": "jest test/unit/*.test.ts --no-cache",
     "test:build": "rollup --config rollup.config.test.js --silent",
     "test:e2e:local": "npm-run-all --parallel test:build docker:micro --serial wdio:local",
@@ -84,7 +84,7 @@
     "@wdio/static-server-service": "~8.3.0",
     "@wdio/types": "~8.3.0",
     "chalk": "4.1.2",
-    "chromedriver": "~99.0.0",
+    "chromedriver": "~114.0.0",
     "dockerode": "~3.3.1",
     "jest": "~27.5.1",
     "jest-environment-jsdom": "~27.5.1",
@@ -104,6 +104,13 @@
     "ts-node": "~10.9.1",
     "typescript": "~4.6.2",
     "wdio-chromedriver-service": "~8.0.1",
-    "webdriverio": "~8.3.3"
+    "webdriverio": "~8.3.3",
+    "@wdio/shared-store-service": "~8.11.2",
+    "node-fetch": "2",
+    "@types/node-fetch": "2",
+    "@wdio/globals": "~8.11.2",
+    "wdio-safaridriver-service": "~2.1.0",
+    "wdio-edgedriver-service": "~3.0.2",
+    "@types/youtube": "~0.0.46"
   }
 }

--- a/trackers/javascript-tracker/test/E2E_SETUP.md
+++ b/trackers/javascript-tracker/test/E2E_SETUP.md
@@ -1,0 +1,19 @@
+# End-to-end tests setup
+
+## Local runs
+
+The end-to-end testing setup options used by the `rushx test:e2e:local` can be found in [wdio.local.conf.ts](./wdio.local.conf.ts).
+
+By default, the enabled driver for local tests is the `chromedriver` which will instrument a local chrome instance. The version of the corresponding `chromedriver` package in the [package.json](../package.json) file should be one matching to your local chrome version. E.g. for Chrome version 140, you need to install `chromedriver@140`.
+
+To enable testing with other browsers such as Microsoft Edge and Safari, you need to:
+1. Uncomment the capabilities and services entries on [wdio.local.conf.ts](./wdio.local.conf.ts).
+2. Install the `safaridriver` and/or `msedgedriver` on your local machine. _(Instructions will depend on your OS.)_
+3. Start any driver program you want before running the tests.
+4. In case of driver port conflicts, you can adjust each driver by their respective configuration.
+
+<!-- 
+TODO 
+- Remove pinned chromedriver from package.json and expect local installation and availability.
+- Add Firefox instructions.
+-->

--- a/trackers/javascript-tracker/test/functional/activityCallback.test.ts
+++ b/trackers/javascript-tracker/test/functional/activityCallback.test.ts
@@ -1,35 +1,5 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 import F from 'lodash/fp';
-import { DockerWrapper, start, stop } from '../micro';
+import { pageSetup } from '../integration/helpers';
 
 declare var trackPageView: () => void;
 declare var findMaxX: () => number;
@@ -44,22 +14,8 @@ describe('Activity tracking with callbacks', () => {
     return;
   }
 
-  let docker: DockerWrapper;
-
   beforeAll(async () => {
-    await browser.call(async () => {
-      return await start().then((container) => {
-        docker = container;
-      });
-    });
-    await browser.url('/index.html');
-    await browser.setCookies({ name: 'container', value: docker.url });
-  });
-
-  afterAll(async () => {
-    await browser.call(async () => {
-      return await stop(docker.container);
-    });
+    await pageSetup();
   });
 
   it('reports events on scroll', async () => {

--- a/trackers/javascript-tracker/test/functional/cookies.test.ts
+++ b/trackers/javascript-tracker/test/functional/cookies.test.ts
@@ -1,33 +1,3 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 describe('Tracker created domain cookies', () => {
   it('contain the expected cookie names', async () => {
     await browser.url('/cookies.html');

--- a/trackers/javascript-tracker/test/integration/helpers.ts
+++ b/trackers/javascript-tracker/test/integration/helpers.ts
@@ -1,33 +1,3 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 import { WaitUntilOptions } from 'webdriverio';
 import util from 'util';
 
@@ -65,3 +35,25 @@ export const waitUntil = async (
     }
   }
 };
+
+/**
+ * Initiates the `index.html` page and sets:
+ * 1. the value for the micro container url in a cookie named `container`.
+ * 2. the value for the current test identifier in a cookie named `testIdentifier`.
+ *
+ * @returns {string} The identifier for this test, similar to the cookie set on the page. This identifier is commonly used in custom matchers for events.
+ */
+export async function pageSetup() {
+  const dockerUrl = (await browser.sharedStore.get('dockerInstanceUrl')) as string;
+  if (!dockerUrl) {
+    throw 'dockerInstanceUrl not available in `browser.sharedStore`';
+  }
+  const testIdentifier = browser.capabilities.browserName + '_' + browser.capabilities.browserVersion;
+  await browser.url('/index.html');
+  await browser.setCookies([
+    { name: 'container', value: dockerUrl },
+    { name: 'testIdentifier', value: testIdentifier },
+  ]);
+
+  return testIdentifier;
+}

--- a/trackers/javascript-tracker/test/integration/media.test.ts
+++ b/trackers/javascript-tracker/test/integration/media.test.ts
@@ -1,35 +1,6 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 import _ from 'lodash';
-import { DockerWrapper, start, stop, fetchResults, clearCache } from '../micro';
-import { waitUntil } from './helpers';
+import { fetchResults } from '../micro';
+import { pageSetup, waitUntil } from './helpers';
 
 const playVideoElement1Callback = () => {
   return (done: (_: void) => void) => {
@@ -41,6 +12,7 @@ const playVideoElement1Callback = () => {
     } // IE does not return a promise
   };
 };
+
 const playVideoElement2Callback = () => {
   return (done: (_: void) => void) => {
     const promise = (document.getElementById('html5-2') as HTMLVideoElement).play();
@@ -163,397 +135,404 @@ const compare = (expected: any, received: any) => {
   expect(expected.unstruct_event).toEqual(received.event.unstruct_event);
 };
 
-let docker: DockerWrapper;
-let log: Array<unknown> = [];
+describe('Media Tracking', () => {
+  let log: Array<unknown> = [];
+  let testIdentifier = '';
 
-describe('Media Tracker', () => {
-  const getFirstEventOfEventType = (eventType: string) => {
-    for (let i = log.length - 1; i >= 0; i--) {
-      if ((log[i] as any).event.unstruct_event.data.data.type === eventType) {
-        return log[i];
+  describe('Media Tracker - Default Events', () => {
+    const getFirstEventOfEventType = (eventType: string) => {
+      for (let i = log.length - 1; i >= 0; i--) {
+        const currentEvent = log[i] as any;
+        if (
+          currentEvent.event?.unstruct_event?.data.data.type === eventType &&
+          currentEvent.event?.app_id === 'media-default-events-' + testIdentifier
+        ) {
+          return log[i];
+        }
       }
-    }
-  };
+    };
 
-  if (
-    browser.capabilities.browserName === 'internet explorer' &&
-    (browser.capabilities.version === '9' || browser.capabilities.browserVersion === '10')
-  ) {
-    fit('Skip IE 9 and 10', () => true);
-    return;
-  }
-
-  if (browser.capabilities.browserName === 'safari' && browser.capabilities.version === '8.0') {
-    fit('Skip Safari 8', () => true);
-    return;
-  }
-
-  beforeAll(async () => {
-    await browser.call(async () => (docker = await start()));
-
-    await browser.url('/index.html');
-    await browser.setCookies({ name: 'container', value: docker.url });
-    await browser.url('media/tracking.html');
-
-    await waitUntil(browser, () => $('#html5').isExisting(), {
-      timeout: 10000,
-      timeoutMsg: 'expected html5 after 5s',
-    });
-
-    let actions = [
-      playVideoElement1Callback(),
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).pause();
-        done();
-      },
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).volume = 0.5;
-        done();
-      },
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).playbackRate = 0.9;
-        done();
-      },
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).currentTime = 18;
-        done();
-      },
-      playVideoElement1Callback(),
-    ];
-
-    for (const a of actions) {
-      await browser.executeAsync(a);
-      await browser.pause(500);
-    }
-
-    // 'ended' should be the final event, if not, try again
-    await waitUntil(
-      browser,
-      async () => {
-        return await browser.call(async () => {
-          let log = await fetchResults(docker.url);
-          return log.some((l: any) => l.event.unstruct_event.data.data.type === 'ended');
-        });
-      },
-      {
-        interval: 2000,
-        timeout: 60000,
-        timeoutMsg: 'All events not found before timeout',
-      }
-    );
-
-    log = await browser.call(async () => await fetchResults(docker.url));
-  });
-
-  afterAll(async () => {
-    await waitUntil(browser, async () => {
-      return await browser.call(async () => await clearCache(docker.url));
-    });
-  });
-
-  const expected = {
-    ready: {
-      mediaPlayer: { paused: true, duration: jasmine.any(Number) },
-      videoElement: { videoHeight: jasmine.any(Number), videoWidth: jasmine.any(Number) },
-    },
-    play: {},
-    pause: { mediaPlayer: { paused: true } },
-    volumechange: { mediaPlayer: { paused: true, volume: 50 } },
-    ratechange: { mediaPlayer: { paused: true, volume: 50, playbackRate: 0.9 } },
-    seeked: { mediaPlayer: { paused: true, volume: 50, playbackRate: 0.9 } },
-    percentprogress: { mediaPlayer: { volume: 50, playbackRate: jasmine.any(Number) } },
-    ended: {
-      mediaPlayer: { volume: 50, playbackRate: jasmine.any(Number), paused: jasmine.any(Boolean), ended: true },
-    },
-  };
-
-  Object.entries(expected).forEach(([name, properties]) => {
-    it('tracks ' + name, () => {
-      const expected = makeExpectedEvent(name, properties);
-      const received = getFirstEventOfEventType(name);
-      compare(expected, received);
-    });
-  });
-});
-
-describe('Media Tracker (2 videos, 1 tracker)', () => {
-  beforeAll(async () => {
-    await browser.url('/media/tracking-2-players.html');
-
-    await waitUntil(browser, () => $('#html5').isExisting(), {
-      timeout: 10000,
-      timeoutMsg: 'expected html5 after 5s',
-    });
-
-    let actions = [
-      playVideoElement1Callback(),
-      playVideoElement2Callback(),
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).pause();
-        done();
-      },
-      (done: () => void) => {
-        (document.getElementById('html5-2') as HTMLVideoElement).pause();
-        done();
-      },
-    ];
-
-    for (const a of actions) {
-      await browser.executeAsync(a);
-      await browser.pause(200);
-    }
-
-    // wait until we have 2 'pause' events
-    await waitUntil(
-      browser,
-      async () => {
-        return await browser.call(async () => {
-          let log = await fetchResults(docker.url);
-          return log.filter((l: any) => l.event.unstruct_event.data.data.type === 'pause').length === 2;
-        });
-      },
-      {
-        interval: 2000,
-        timeout: 60000,
-        timeoutMsg: 'All events not found before timeout',
-      }
-    );
-
-    log = await browser.call(async () => await fetchResults(docker.url));
-  });
-
-  afterAll(async () => {
-    await waitUntil(browser, async () => {
-      return await browser.call(async () => await clearCache(docker.url));
-    });
-  });
-
-  const getFirstEventOfEventTypeWithId = (eventType: string, id: string) => {
-    let results = log.filter(
-      (l: any) => l.event.unstruct_event.data.data.type === eventType && l.event.contexts.data[0].data.htmlId === id
-    );
-    return results[results.length - 1];
-  };
-
-  it('tracks two players with a single tracker', () => {
-    const expectedOne = makeExpectedEvent('pause', { mediaPlayer: { paused: true } });
-    const recievedOne = getFirstEventOfEventTypeWithId('pause', 'html5');
-    compare(expectedOne, recievedOne);
-
-    const expectedTwo = makeExpectedEvent('pause', { mediaPlayer: { paused: true } }, 'html5-2');
-    const recievedTwo = getFirstEventOfEventTypeWithId('pause', 'html5-2');
-    compare(expectedTwo, recievedTwo);
-  });
-});
-
-describe('Media Tracker (1 video, 2 trackers)', () => {
-  beforeAll(async () => {
-    await browser.url('media/tracking-2-trackers.html');
-
-    await waitUntil(browser, () => $('#html5').isExisting(), {
-      timeout: 10000,
-      timeoutMsg: 'expected html5 after 5s',
-    });
-
-    await browser.executeAsync(playVideoElement1Callback());
-    await browser.pause(200);
-    await browser.execute(() => (document.getElementById('html5') as HTMLVideoElement).pause());
-
-    // wait until we have 2 'pause' events
-    await waitUntil(
-      browser,
-      async () => {
-        return await browser.call(async () => {
-          let log = await fetchResults(docker.url);
-          return log.filter((l: any) => l.event.unstruct_event.data.data.type === 'pause').length === 2;
-        });
-      },
-      {
-        interval: 2000,
-        timeout: 60000,
-        timeoutMsg: 'All events not found before timeout',
-      }
-    );
-
-    log = await browser.call(async () => await fetchResults(docker.url));
-  });
-
-  afterAll(async () => {
-    await waitUntil(browser, async () => {
-      return await browser.call(async () => await clearCache(docker.url));
-    });
-  });
-
-  const getEventsOfEventType = (eventType: string, limit: number = 1): Array<any> => {
-    const results = log.filter((l: any) => l.event.unstruct_event.data.data.type === eventType);
-    return results.slice(results.length - limit);
-  };
-
-  it('tracks one player with two trackers', () => {
-    const expected = makeExpectedEvent('pause', { mediaPlayer: { paused: true } });
-    const result = getEventsOfEventType('pause', 2);
-
-    compare(expected, result[0]);
-    compare(expected, result[1]);
-    const tracker_names = result.map((r: any) => r.event.name_tracker);
-    expect(tracker_names).toContain('sp1');
-    expect(tracker_names).toContain('sp2');
-  });
-});
-
-describe('Media Tracker - All Events', () => {
-  beforeAll(async () => {
-    await browser.url('media/tracking-all-events.html');
-
-    await waitUntil(browser, () => $('#html5').isExisting(), {
-      timeout: 10000,
-      timeoutMsg: 'expected html5 after 5s',
-    });
-
-    const video_url = await browser.execute(() => {
-      return (document.getElementById('html5') as HTMLVideoElement).src;
-    });
-
-    let actions = [
-      playVideoElement1Callback(),
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).pause();
-        done();
-      },
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).currentTime = 18;
-        done();
-      },
-      playVideoElement1Callback(),
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).textTracks[0].mode = 'disabled';
-        done();
-      },
-      (done: () => void) => {
-        (document.getElementById('html5') as HTMLVideoElement).src = 'not-a-video.unsupported_format';
-        done();
-      },
-    ];
-
-    for (const a of actions) {
-      await browser.executeAsync(a);
-      await browser.pause(1000);
-    }
-
-    await browser.execute((video_url) => {
-      (document.getElementById('html5') as HTMLVideoElement).src = video_url;
-    }, video_url);
-
-    await waitUntil(
-      browser,
-      async () => {
-        return await browser.call(async () => {
-          let log = await fetchResults(docker.url);
-          // Events can occur in any order, so we can't just check for the last event
-          // 40 - 45 events are expected, due to the timing of 'timeupdate' events
-          return log.length > 40;
-        });
-      },
-      {
-        interval: 2000,
-        timeout: 60000,
-        timeoutMsg: 'All events not found before timeout',
-      }
-    );
-
-    log = await browser.call(async () => await fetchResults(docker.url));
-  });
-
-  afterAll(async () => {
-    await browser.call(async () => await stop(docker.container));
-  });
-
-  const getFirstEventOfEventType = (eventType: string) => {
-    let results = log.filter((l: any) => l.event.unstruct_event.data.data.type === eventType);
-    return results[results.length - 1];
-  };
-
-  const expected = {
-    canplay: {
-      mediaPlayer: {
-        paused: true,
-      },
-    },
-    canplaythrough: {
-      mediaPlayer: {
-        paused: true,
-      },
-    },
-    timeupdate: {},
-    playing: {},
-    seeking: {
-      mediaElement: {
-        seeking: true,
-      },
-      mediaPlayer: {
-        paused: true,
-      },
-    },
-    error: {
-      mediaElement: {
-        networkState: 'NETWORK_NO_SOURCE',
-        readyState: 'HAVE_NOTHING',
-        currentSrc: 'http://snowplow-js-tracker.local:8080/media/not-a-video.unsupported_format',
-        src: 'http://snowplow-js-tracker.local:8080/media/not-a-video.unsupported_format',
-        error: jasmine.any(Object),
-      },
-      mediaPlayer: {
-        duration: 0,
-        paused: true,
-      },
-      videoElement: {
-        videoHeight: 0,
-        videoWidth: 0,
-      },
-    },
-    loadstart: {
-      mediaElement: {
-        error: [jasmine.any(Object), null],
-      },
-      mediaPlayer: {
-        currentTime: 0,
-        paused: true,
-        duration: 0,
-      },
-      videoElement: {
-        videoHeight: 0,
-        videoWidth: 0,
-      },
-    },
-    loadedmetadata: {
-      mediaPlayer: {
-        paused: true,
-      },
-    },
-    durationchange: {
-      mediaPlayer: {
-        paused: true,
-      },
-    },
-  };
-
-  Object.entries(expected).forEach(([name, properties]) => {
-    // I can't find a good way of triggering an error event for firefox 53 or chrome 60, so they can
-    // be skipped for now (events past 'error' are fired as a result of the error occouring)
     if (
-      (name === 'error' &&
-        browser.capabilities.browserName === 'firefox' &&
-        browser.capabilities.browserVersion === '53.0') ||
-      (browser.capabilities.browserName === 'chrome' && browser.capabilities.version === '60.0.3112.78')
+      browser.capabilities.browserName === 'internet explorer' &&
+      (browser.capabilities.version === '9' || browser.capabilities.browserVersion === '10')
     ) {
-      fit('Skip events from error', () => true);
+      fit('Skip IE 9 and 10', () => true);
       return;
-    } else {
+    }
+
+    if (browser.capabilities.browserName === 'safari' && browser.capabilities.version === '8.0') {
+      fit('Skip Safari 8', () => true);
+      return;
+    }
+
+    beforeAll(async () => {
+      testIdentifier = await pageSetup();
+      await browser.url('media/tracking.html');
+      await waitUntil(browser, () => $('#html5').isExisting(), {
+        timeout: 10000,
+        timeoutMsg: 'expected html5 after 5s',
+      });
+
+      let actions = [
+        playVideoElement1Callback(),
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).pause();
+          done();
+        },
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).volume = 0.5;
+          done();
+        },
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).playbackRate = 0.9;
+          done();
+        },
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).currentTime = 18;
+          done();
+        },
+        playVideoElement1Callback(),
+      ];
+
+      for (const a of actions) {
+        await browser.executeAsync(a);
+        await browser.pause(500);
+      }
+
+      // 'ended' should be the final event, if not, try again
+      await waitUntil(
+        browser,
+        async () => {
+          return await browser.call(async () => {
+            let log = await fetchResults();
+            return log.some(
+              (l: any) =>
+                l.event?.unstruct_event?.data.data.type === 'ended' &&
+                l.event?.app_id === 'media-default-events-' + testIdentifier
+            );
+          });
+        },
+        {
+          interval: 2000,
+          timeout: 60000,
+          timeoutMsg: 'All events not found before timeout',
+        }
+      );
+
+      log = await browser.call(async () => await fetchResults());
+    });
+
+    const expected = {
+      ready: {
+        mediaPlayer: { paused: true, duration: jasmine.any(Number) },
+        videoElement: { videoHeight: jasmine.any(Number), videoWidth: jasmine.any(Number) },
+      },
+      play: {},
+      pause: { mediaPlayer: { paused: true } },
+      volumechange: { mediaPlayer: { paused: true, volume: 50 } },
+      ratechange: { mediaPlayer: { paused: true, volume: 50, playbackRate: 0.9 } },
+      seeked: { mediaPlayer: { paused: true, volume: 50, playbackRate: 0.9 } },
+      percentprogress: { mediaPlayer: { volume: 50, playbackRate: jasmine.any(Number) } },
+      ended: {
+        mediaPlayer: { volume: 50, playbackRate: jasmine.any(Number), paused: jasmine.any(Boolean), ended: true },
+      },
+    };
+
+    Object.entries(expected).forEach(([name, properties]) => {
       it('tracks ' + name, () => {
         const expected = makeExpectedEvent(name, properties);
         const received = getFirstEventOfEventType(name);
         compare(expected, received);
       });
-    }
+    });
+  });
+
+  describe('Media Tracker (2 videos, 1 tracker)', () => {
+    beforeAll(async () => {
+      await browser.url('/media/tracking-2-players.html');
+
+      await waitUntil(browser, () => $('#html5').isExisting(), {
+        timeout: 10000,
+        timeoutMsg: 'expected html5 after 5s',
+      });
+
+      let actions = [
+        playVideoElement1Callback(),
+        playVideoElement2Callback(),
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).pause();
+          done();
+        },
+        (done: () => void) => {
+          (document.getElementById('html5-2') as HTMLVideoElement).pause();
+          done();
+        },
+      ];
+
+      for (const a of actions) {
+        await browser.executeAsync(a);
+        await browser.pause(200);
+      }
+
+      // wait until we have 2 'pause' events
+      await waitUntil(
+        browser,
+        async () => {
+          return await browser.call(async () => {
+            let log = await fetchResults();
+            return (
+              log.filter(
+                (l: any) =>
+                  l.event?.unstruct_event?.data.data.type === 'pause' &&
+                  l.event?.app_id === 'media-2-players-1-tracker-' + testIdentifier
+              ).length === 2
+            );
+          });
+        },
+        {
+          interval: 2000,
+          timeout: 20000,
+          timeoutMsg: 'All events not found before timeout',
+        }
+      );
+
+      log = await browser.call(async () => await fetchResults());
+    });
+
+    const getFirstEventOfEventTypeWithId = (eventType: string, id: string) => {
+      let results = log.filter(
+        (l: any) =>
+          l.event?.unstruct_event?.data.data.type === eventType &&
+          l.event.contexts.data[0].data.htmlId === id &&
+          l.event.app_id === 'media-2-players-1-tracker-' + testIdentifier
+      );
+      return results[results.length - 1];
+    };
+
+    it('tracks two players with a single tracker', () => {
+      const expectedOne = makeExpectedEvent('pause', { mediaPlayer: { paused: true } });
+      const receivedOne = getFirstEventOfEventTypeWithId('pause', 'html5');
+      compare(expectedOne, receivedOne);
+
+      const expectedTwo = makeExpectedEvent('pause', { mediaPlayer: { paused: true } }, 'html5-2');
+      const receivedTwo = getFirstEventOfEventTypeWithId('pause', 'html5-2');
+      compare(expectedTwo, receivedTwo);
+    });
+  });
+
+  describe('Media Tracker (1 video, 2 trackers)', () => {
+    beforeAll(async () => {
+      await browser.url('media/tracking-2-trackers.html');
+
+      await waitUntil(browser, () => $('#html5').isExisting(), {
+        timeout: 10000,
+        timeoutMsg: 'expected html5 after 5s',
+      });
+
+      await browser.executeAsync(playVideoElement1Callback());
+      await browser.pause(200);
+      await browser.execute(() => (document.getElementById('html5') as HTMLVideoElement).pause());
+
+      // wait until we have 2 'pause' events
+      await waitUntil(
+        browser,
+        async () => {
+          return await browser.call(async () => {
+            let log = await fetchResults();
+            return (
+              log.filter(
+                (l: any) =>
+                  l.event?.unstruct_event?.data.data.type === 'pause' &&
+                  l.event.app_id === 'media-1-player-2-trackers-' + testIdentifier
+              ).length === 2
+            );
+          });
+        },
+        {
+          interval: 2000,
+          timeout: 60000,
+          timeoutMsg: 'All events not found before timeout',
+        }
+      );
+
+      log = await browser.call(async () => await fetchResults());
+    });
+
+    const getEventsOfEventType = (eventType: string, limit: number = 1): Array<any> => {
+      const results = log.filter(
+        (l: any) =>
+          l.event?.unstruct_event?.data.data.type === eventType &&
+          l.event.app_id === 'media-1-player-2-trackers-' + testIdentifier
+      );
+      return results.slice(results.length - limit);
+    };
+
+    it('tracks one player with two trackers', () => {
+      const expected = makeExpectedEvent('pause', { mediaPlayer: { paused: true } });
+      const result = getEventsOfEventType('pause', 2);
+
+      compare(expected, result[0]);
+      compare(expected, result[1]);
+      const tracker_names = result.map((r: any) => r.event.name_tracker);
+      expect(tracker_names).toContain('sp1');
+      expect(tracker_names).toContain('sp2');
+    });
+  });
+
+  describe('Media Tracker - All Events', () => {
+    beforeAll(async () => {
+      await browser.url('media/tracking-all-events.html');
+
+      await waitUntil(browser, () => $('#html5').isExisting(), {
+        timeout: 10000,
+        timeoutMsg: 'expected html5 after 5s',
+      });
+
+      const video_url = await browser.execute(() => {
+        return (document.getElementById('html5') as HTMLVideoElement).src;
+      });
+
+      let actions = [
+        playVideoElement1Callback(),
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).pause();
+          done();
+        },
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).currentTime = 18;
+          done();
+        },
+        playVideoElement1Callback(),
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).textTracks[0].mode = 'disabled';
+          done();
+        },
+        (done: () => void) => {
+          (document.getElementById('html5') as HTMLVideoElement).src = 'not-a-video.unsupported_format';
+          done();
+        },
+      ];
+
+      for (const a of actions) {
+        await browser.executeAsync(a);
+        await browser.pause(1000);
+      }
+
+      await browser.execute((video_url) => {
+        (document.getElementById('html5') as HTMLVideoElement).src = video_url;
+      }, video_url);
+
+      await waitUntil(
+        browser,
+        async () => {
+          return await browser.call(async () => {
+            let log = await fetchResults();
+            // Events can occur in any order, so we can't just check for the last event
+            // 40 - 45 events are expected, due to the timing of 'timeupdate' events
+            return log.length > 40;
+          });
+        },
+        {
+          interval: 2000,
+          timeout: 60000,
+          timeoutMsg: 'All events not found before timeout',
+        }
+      );
+
+      log = await browser.call(async () => await fetchResults());
+    });
+
+    const getFirstEventOfEventType = (eventType: string) => {
+      let results = log.filter(
+        (l: any) =>
+          l.event?.unstruct_event?.data.data.type === eventType &&
+          l.event.app_id === 'media-all-events-' + testIdentifier
+      );
+      return results[results.length - 1];
+    };
+
+    const expected = {
+      canplay: {
+        mediaPlayer: {
+          paused: true,
+        },
+      },
+      canplaythrough: {
+        mediaPlayer: {
+          paused: true,
+        },
+      },
+      timeupdate: {},
+      playing: {},
+      seeking: {
+        mediaElement: {
+          seeking: true,
+        },
+        mediaPlayer: {
+          paused: true,
+        },
+      },
+      error: {
+        mediaElement: {
+          networkState: 'NETWORK_NO_SOURCE',
+          readyState: 'HAVE_NOTHING',
+          currentSrc: 'http://snowplow-js-tracker.local:8080/media/not-a-video.unsupported_format',
+          src: 'http://snowplow-js-tracker.local:8080/media/not-a-video.unsupported_format',
+          error: jasmine.any(Object),
+        },
+        mediaPlayer: {
+          duration: 0,
+          paused: true,
+        },
+        videoElement: {
+          videoHeight: 0,
+          videoWidth: 0,
+        },
+      },
+      loadstart: {
+        mediaElement: {
+          error: [jasmine.any(Object), null],
+        },
+        mediaPlayer: {
+          currentTime: 0,
+          paused: true,
+          duration: 0,
+        },
+        videoElement: {
+          videoHeight: 0,
+          videoWidth: 0,
+        },
+      },
+      loadedmetadata: {
+        mediaPlayer: {
+          paused: true,
+        },
+      },
+      durationchange: {
+        mediaPlayer: {
+          paused: true,
+        },
+      },
+    };
+
+    Object.entries(expected).forEach(([name, properties]) => {
+      // I can't find a good way of triggering an error event for firefox 53 or chrome 60, so they can
+      // be skipped for now (events past 'error' are fired as a result of the error occouring)
+      if (
+        (name === 'error' &&
+          browser.capabilities.browserName === 'firefox' &&
+          browser.capabilities.browserVersion === '53.0') ||
+        (browser.capabilities.browserName === 'chrome' && browser.capabilities.version === '60.0.3112.78')
+      ) {
+        fit('Skip events from error', () => true);
+        return;
+      } else {
+        it('tracks ' + name, () => {
+          const expected = makeExpectedEvent(name, properties);
+          const received = getFirstEventOfEventType(name);
+          compare(expected, received);
+        });
+      }
+    });
   });
 });

--- a/trackers/javascript-tracker/test/integration/sessionStorage.test.ts
+++ b/trackers/javascript-tracker/test/integration/sessionStorage.test.ts
@@ -1,56 +1,18 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-import util from 'util';
 import F from 'lodash/fp';
-import { DockerWrapper, fetchResults, start, stop } from '../micro';
-
-const dumpLog = (log: Array<unknown>) => console.log(util.inspect(log, true, null, true));
+import { fetchResults } from '../micro';
+import { pageSetup } from './helpers';
 
 describe('Sessions', () => {
   let log: Array<unknown> = [];
-  let docker: DockerWrapper;
+  let testIdentifier = '';
 
   const logContains = (ev: unknown) => F.some(F.isMatch(ev as object), log);
 
   beforeAll(async () => {
-    await browser.call(async () => (docker = await start()));
-    await browser.url('/index.html');
-    await browser.setCookies({ name: 'container', value: docker.url });
+    testIdentifier = await pageSetup();
     await browser.url('/session-integration.html');
     await browser.pause(6000); // Time for requests to get written
-    log = await browser.call(async () => await fetchResults(docker.url));
-  });
-
-  afterAll(async () => {
-    browser.call(async () => await stop(docker.container));
+    log = await browser.call(async () => await fetchResults());
   });
 
   it('should count sessions using cookies', () => {
@@ -60,6 +22,7 @@ describe('Sessions', () => {
           event: 'page_view',
           name_tracker: 'cookieSessionTracker',
           domain_sessionidx: 2,
+          app_id: 'session-integration-' + testIdentifier,
         },
       })
     ).toBe(true);
@@ -72,6 +35,7 @@ describe('Sessions', () => {
           event: 'page_view',
           name_tracker: 'localStorageSessionTracker',
           domain_sessionidx: 2,
+          app_id: 'session-integration-' + testIdentifier,
         },
       })
     ).toBe(true);
@@ -84,6 +48,7 @@ describe('Sessions', () => {
           event: 'page_view',
           name_tracker: 'anonymousSessionTracker',
           domain_sessionidx: 2,
+          app_id: 'session-integration-' + testIdentifier,
         },
       })
     ).toBe(true);
@@ -92,13 +57,19 @@ describe('Sessions', () => {
   it('should only add session context when enabled', () => {
     const events = (ev: any) =>
       F.get('event.name_tracker', ev) !== 'cookieSessionTracker' &&
-      F.get('contexts[0]', ev) === 'iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2';
+      F.get('contexts[0]', ev) === 'iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2' &&
+      F.get('event.app_id', ev) === 'session-integration-' + testIdentifier;
 
     expect(F.size(F.filter(events, log))).toBe(0);
   });
 
   it('should have the same information in session context as in event properties', () => {
-    const events = F.filter((ev: any) => F.get('event.name_tracker', ev) === 'cookieSessionTracker', log);
+    const events = F.filter(
+      (ev: any) =>
+        F.get('event.name_tracker', ev) === 'cookieSessionTracker' &&
+        F.get('event.app_id', ev) === 'session-integration-' + testIdentifier,
+      log
+    );
 
     expect(F.size(events)).toBe(3);
     expect(
@@ -125,7 +96,12 @@ describe('Sessions', () => {
   });
 
   it('should increment event index in session context', () => {
-    const events: any[] = F.filter((ev: any) => F.get('event.name_tracker', ev) === 'cookieSessionTracker', log);
+    const events: any[] = F.filter(
+      (ev: any) =>
+        F.get('event.name_tracker', ev) === 'cookieSessionTracker' &&
+        F.get('event.app_id', ev) === 'session-integration-' + testIdentifier,
+      log
+    );
     events.sort((a, b) => a.event.dvce_created_tstamp.localeCompare(b.event.dvce_created_tstamp));
     const getEventIndex = (e: any) => e.event.contexts.data[0].data.eventIndex;
 
@@ -135,7 +111,12 @@ describe('Sessions', () => {
   });
 
   it('should match first event references to first event in session', () => {
-    const events: any[] = F.filter((ev: any) => F.get('event.name_tracker', ev) === 'cookieSessionTracker', log);
+    const events: any[] = F.filter(
+      (ev: any) =>
+        F.get('event.name_tracker', ev) === 'cookieSessionTracker' &&
+        F.get('event.app_id', ev) === 'session-integration-' + testIdentifier,
+      log
+    );
     events.sort((a, b) => a.event.dvce_created_tstamp.localeCompare(b.event.dvce_created_tstamp));
     const getFirstEventId = (e: any) => e.event.contexts.data[0].data.firstEventId;
     const getFirstEventTimestamp = (e: any) => e.event.contexts.data[0].data.firstEventTimestamp;
@@ -150,7 +131,12 @@ describe('Sessions', () => {
   });
 
   it('should match previous session ID in session context', () => {
-    const events: any[] = F.filter((ev: any) => F.get('event.name_tracker', ev) === 'cookieSessionTracker', log);
+    const events: any[] = F.filter(
+      (ev: any) =>
+        F.get('event.name_tracker', ev) === 'cookieSessionTracker' &&
+        F.get('event.app_id', ev) === 'session-integration-' + testIdentifier,
+      log
+    );
     events.sort((a, b) => a.event.dvce_created_tstamp.localeCompare(b.event.dvce_created_tstamp));
     const getSessionId = (e: any) => e.event.domain_sessionid;
     const getPreviousSessionId = (e: any) => e.event.contexts.data[0].data.previousSessionId;
@@ -162,25 +148,58 @@ describe('Sessions', () => {
 
   it('should only increment domain_sessionidx outside of session timeout (local storage)', () => {
     const withSingleVid = (ev: unknown) =>
-      F.get('event.name_tracker', ev) === 'localStorageSessionTracker' && F.get('event.domain_sessionidx', ev) === 1;
+      F.get('event.name_tracker', ev) === 'localStorageSessionTracker' &&
+      F.get('event.domain_sessionidx', ev) === 1 &&
+      F.get('event.app_id', ev) === 'session-integration-' + testIdentifier;
 
     expect(F.size(F.filter(withSingleVid, log))).toBe(2);
-    expect(F.size(F.filter((e) => F.get('event.name_tracker', e) === 'localStorageSessionTracker', log))).toBe(3);
+    expect(
+      F.size(
+        F.filter(
+          (e) =>
+            F.get('event.name_tracker', e) === 'localStorageSessionTracker' &&
+            F.get('event.app_id', e) === 'session-integration-' + testIdentifier,
+          log
+        )
+      )
+    ).toBe(3);
   });
 
   it('should only increment domain_sessionidx outside of session timeout (anonymous session tracking)', () => {
     const withSingleVid = (ev: unknown) =>
-      F.get('event.name_tracker', ev) === 'anonymousSessionTracker' && F.get('event.domain_sessionidx', ev) === 1;
+      F.get('event.name_tracker', ev) === 'anonymousSessionTracker' &&
+      F.get('event.domain_sessionidx', ev) === 1 &&
+      F.get('event.app_id', ev) === 'session-integration-' + testIdentifier;
 
     expect(F.size(F.filter(withSingleVid, log))).toBe(2);
-    expect(F.size(F.filter((e) => F.get('event.name_tracker', e) === 'anonymousSessionTracker', log))).toBe(3);
+    expect(
+      F.size(
+        F.filter(
+          (e) =>
+            F.get('event.name_tracker', e) === 'anonymousSessionTracker' &&
+            F.get('event.app_id', e) === 'session-integration-' + testIdentifier,
+          log
+        )
+      )
+    ).toBe(3);
   });
 
   it('should only increment domain_sessionidx outside of session timeout (cookie storage)', () => {
     const withSingleVid = (ev: unknown) =>
-      F.get('event.name_tracker', ev) === 'cookieSessionTracker' && F.get('event.domain_sessionidx', ev) === 1;
+      F.get('event.name_tracker', ev) === 'cookieSessionTracker' &&
+      F.get('event.domain_sessionidx', ev) === 1 &&
+      F.get('event.app_id', ev) === 'session-integration-' + testIdentifier;
 
     expect(F.size(F.filter(withSingleVid, log))).toBe(2);
-    expect(F.size(F.filter((e) => F.get('event.name_tracker', e) === 'cookieSessionTracker', log))).toBe(3);
+    expect(
+      F.size(
+        F.filter(
+          (e) =>
+            F.get('event.name_tracker', e) === 'cookieSessionTracker' &&
+            F.get('event.app_id', e) === 'session-integration-' + testIdentifier,
+          log
+        )
+      )
+    ).toBe(3);
   });
 });

--- a/trackers/javascript-tracker/test/integration/youtube.test.ts
+++ b/trackers/javascript-tracker/test/integration/youtube.test.ts
@@ -1,35 +1,7 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+import { fetchResults } from '../micro';
+import { pageSetup, waitUntil } from './helpers';
 
-import { DockerWrapper, start, stop, fetchResults, clearCache } from '../micro';
-import { waitUntil } from './helpers';
+declare var player: YT.Player;
 
 const makeExpectedEvent = (
   eventType: string,
@@ -49,7 +21,7 @@ const makeExpectedEvent = (
           controls: true,
           loaded: jasmine.any(Number),
           unstarted: jasmine.any(Boolean),
-          url: jasmine.stringMatching(/https\:\/\/www\.youtube\.com\/watch\?(t=\d+&)?v=zSM4ZyVe8xs/),
+          url: jasmine.stringMatching(/https\:\/\/www\.youtube\.com\/watch\?(t=\d+&)?v=ublEqhffop0/),
           ...values?.youtube,
         },
       },
@@ -92,7 +64,6 @@ const compare = (expected: any, received: any) => {
   expect(expected.unstruct_event).toEqual(received.event.unstruct_event);
 };
 
-let docker: DockerWrapper;
 let log: Array<unknown> = [];
 
 function shouldSkipBrowser(browser: any): boolean {
@@ -107,243 +78,213 @@ function shouldSkipBrowser(browser: any): boolean {
   );
 }
 
-// This is simply to check that the plugin can accept an instance of `YT.Player` and emit events
-// If that passes, everything else will work the same as passing in an ID
-describe('YouTube Tracker with Existing Player', () => {
-  beforeAll(async () => {
-    await browser.call(async () => (docker = await start()));
+describe('Youtube tracking', () => {
+  let testIdentifier = '';
 
-    await browser.url('/index.html');
-    await browser.setCookies({ name: 'container', value: docker.url });
-    await browser.url('/youtube/tracking-player.html');
-    await waitUntil(browser, () => $('#youtube').isExisting(), {
-      timeout: 5000,
-      timeoutMsg: 'expected youtube after 5s',
+  beforeAll(async () => {
+    testIdentifier = await pageSetup();
+  });
+  // If that passes, everything else will work the same as passing in an ID
+  describe('YouTube Tracker with Existing Player', () => {
+    it('should track any event', async () => {
+      await browser.url('/youtube/tracking-player.html');
+      await waitUntil(browser, () => $('#youtube').isExisting(), {
+        timeout: 5000,
+        timeoutMsg: 'expected youtube after 5s',
+      });
+
+      const player = await $('#youtube');
+
+      await player.click();
+      await browser.pause(1000);
+
+      await player.click();
+      await browser.pause(5000);
+
+      const log = await browser.call(async () => await fetchResults());
+      const testResults = log.filter((l: any) => l.event?.app_id === 'yt-player-' + testIdentifier);
+
+      // Any non-zero amount of events received means the
+      // plugin is successfully sending events from the player
+      expect(testResults.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('YouTube Tracker', () => {
+    if (shouldSkipBrowser(browser)) {
+      fit('Skip browser', () => true);
+      return;
+    }
+
+    const getFirstEventOfEventType = (eventType: string): any => {
+      let results = log.filter(
+        (l: any) =>
+          l.event?.unstruct_event?.data.data.type === eventType && l.event?.app_id === 'yt-tracking-' + testIdentifier
+      );
+      return results[results.length - 1];
+    };
+
+    beforeAll(async () => {
+      await browser.url('/youtube/tracking.html');
+      await waitUntil(browser, () => $('#player').isExisting(), {
+        timeout: 5000,
+        timeoutMsg: 'expected youtube after 5s',
+      });
+
+      await browser.pause(1000);
+
+      await $('#player').click();
+      await browser.pause(1000);
+
+      /* `player` is set at /youtube/tracking.html and is a YT JS API object https://developers.google.com/youtube/iframe_api_reference */
+
+      await browser.setTimeout({ script: 30000 });
+      await browser.executeAsync((done) => {
+        var initialTimeMS = 0;
+
+        setTimeout(() => {
+          var duration = player.getDuration();
+          player.seekTo(duration / 5, true);
+        }, (initialTimeMS += 500));
+
+        setTimeout(() => {
+          player.setPlaybackRate(1.25);
+        }, (initialTimeMS += 500));
+
+        setTimeout(() => {
+          player.setVolume(player.getVolume() - 10);
+        }, (initialTimeMS += 4000));
+
+        setTimeout(() => {
+          player.setVolume(player.getVolume() - 10);
+        }, (initialTimeMS += 1000));
+
+        setTimeout(() => {
+          player.pauseVideo();
+        }, (initialTimeMS += 1000));
+
+        setTimeout(() => {
+          var duration = player.getDuration();
+          player.seekTo(duration - 1, true);
+          player.playVideo();
+        }, (initialTimeMS += 1000));
+
+        setTimeout(done, (initialTimeMS += 3000));
+      });
+
+      log = await browser.call(async () => await fetchResults());
     });
 
-    const player = await $('#youtube');
+    const expected = {
+      ready: { youtube: { cued: true } },
+      percentprogress: {},
+      playbackqualitychange: {},
+      play: {},
+      playbackratechange: {},
+      seek: { mediaPlayer: { paused: jasmine.any(Boolean) } },
+      volumechange: { mediaPlayer: { paused: jasmine.any(Boolean) } },
+      pause: { mediaPlayer: { paused: true } },
+      ended: { mediaPlayer: { ended: true } },
+    };
 
-    await player.click();
-    await browser.pause(5000);
-
-    await player.click();
-    await browser.pause(5000);
-
-    await browser.waitUntil(
-      async () => {
-        log = await browser.call(async () => await fetchResults(docker.url));
-        return log.length > 0;
-      },
-      {
-        timeout: 20000,
-        timeoutMsg: 'expected events after 20s',
+    Object.entries(expected).forEach(([name, properties]) => {
+      if (browser.capabilities.browserName === 'internet explorer' && name === 'playbackratechange') {
+        return;
+        // The hotkey for playback rate change doesn't work in IE
+        // Trying to create a key sequence to change the option in the UI has proved to be
+        // very unreliable, so this test is skipped
       }
-    );
-  });
-
-  afterAll(async () => {
-    await browser.call(async () => await clearCache(docker.url));
-  });
-
-  it('should track any event', async () => {
-    // Any non-zero amount of events received means the
-    // plugin is successfully sending events from the player
-    expect(log.length).toBeGreaterThan(0);
-  });
-});
-
-describe('YouTube Tracker', () => {
-  const getFirstEventOfEventType = (eventType: string): any => {
-    let results = log.filter((l: any) => l.event.unstruct_event.data.data.type === eventType);
-    return results[results.length - 1];
-  };
-
-  if (shouldSkipBrowser(browser)) {
-    fit('Skip browser', () => true);
-    return;
-  }
-
-  beforeAll(async () => {
-    await browser.call(async () => (docker = await start()));
-
-    await browser.url('/index.html');
-    await browser.setCookies({ name: 'container', value: docker.url });
-    await browser.url('/youtube/tracking.html');
-    await waitUntil(browser, () => $('#youtube').isExisting(), {
-      timeout: 5000,
-      timeoutMsg: 'expected youtube after 5s',
+      if (browser.capabilities.browserName === 'safari' && name == 'percentprogress') {
+        return;
+        // percentprogress events seem not be tracked reliably in Safari, should investigate why
+      }
+      it('tracks ' + name, () => {
+        const expected = makeExpectedEvent(name, properties, 'player');
+        const received = getFirstEventOfEventType(name);
+        compare(expected, received);
+      });
     });
-
-    const player = $('#youtube');
-    await player.click(); // emits 'playbackqualitychange' and 'play';
-    await browser.keys(Array(2).fill('ArrowRight')); // Skips to the point just before 'percentprogress' fires
-    await browser.pause(15000); // Wait to track percentprogress events
-
-    const events = [
-      async () => await browser.keys(['Shift', '.', 'Shift']), // Increase playback rate
-      async () => await browser.keys(['ArrowRight']), // Seek
-      async () => await browser.keys(['ArrowDown']), // Volume down
-      async () => await browser.keys(['k']), // Pause
-      async () => await browser.keys(['9']), // Skip as close as we can to the end
-    ];
-
-    for (const e of events) {
-      await e();
-      await browser.pause(200);
-    }
-
-    // We've got ~216 seconds left to skip
-    for (let i = 0; i < 60; i++) {
-      // Ended
-      await browser.keys(['ArrowRight']);
-      await browser.pause(50);
-    }
-    await browser.pause(1000);
-
-    log = await browser.call(async () => await fetchResults(docker.url));
-
-    // YouTube saves the volume level in localstorage, meaning loading a new page will have the same
-    // volume level as the end of this test, so we need to increase it again to return to the 'default' state
-    await browser.keys(['ArrowUp']);
   });
 
-  const expected = {
-    ready: { youtube: { cued: true } },
-    percentprogress: {},
-    playbackqualitychange: {},
-    play: {},
-    playbackratechange: {},
-    seek: { mediaPlayer: { paused: jasmine.any(Boolean) } },
-    volumechange: { mediaPlayer: { paused: jasmine.any(Boolean) } },
-    pause: { mediaPlayer: { paused: true } },
-    ended: { mediaPlayer: { ended: true } },
-  };
-
-  Object.entries(expected).forEach(([name, properties]) => {
-    if (browser.capabilities.browserName === 'internet explorer' && name === 'playbackratechange') {
+  describe('YouTube Tracker (2 videos, 1 tracker)', () => {
+    if (shouldSkipBrowser(browser)) {
+      fit('Skip browser', () => true);
       return;
-      // The hotkey for playback rate change doesn't work in IE
-      // Trying to create a key sequence to change the option in the UI has proved to be
-      // very unreliable, so this test is skipped
     }
-    if (browser.capabilities.browserName === 'safari' && name == 'percentprogress') {
-      return;
-      // percentprogress events seem not be tracked reliably in Safari, should investigate why
-    }
-    it('tracks ' + name, () => {
-      const expected = makeExpectedEvent(name, properties);
-      const received = getFirstEventOfEventType(name);
-      compare(expected, received);
-    });
-  });
 
-  afterAll(async () => {
-    await waitUntil(browser, async () => {
-      return await browser.call(async () => await clearCache(docker.url));
-    });
-  });
-});
+    const getFirstEventOfEventTypeWithId = (eventType: string, id: string) => {
+      const results = log.filter(
+        (l: any) =>
+          l.event?.unstruct_event?.data.data.type === eventType &&
+          l.event.contexts.data[0].data.playerId === id &&
+          l.event?.app_id === 'yt-2-videos-' + testIdentifier
+      );
+      return results[results.length - 1];
+    };
 
-describe('YouTube Tracker (2 videos, 1 tracker)', () => {
-  if (shouldSkipBrowser(browser)) {
-    fit('Skip browser', () => true);
-    return;
-  }
+    it('Tracks 2 YouTube players with a single tracker', async () => {
+      await browser.url('/youtube/tracking-2-videos.html');
+      await waitUntil(browser, () => $('#youtube').isExisting(), {
+        timeout: 5000,
+        timeoutMsg: 'expected youtube after 5s',
+      });
 
-  const getFirstEventOfEventTypeWithId = (eventType: string, id: string) => {
-    const results = log.filter(
-      (l: any) => l.event.unstruct_event.data.data.type === eventType && l.event.contexts.data[0].data.playerId === id
-    );
-    return results[results.length - 1];
-  };
+      const player1 = $('#youtube');
+      const player2 = $('#youtube-2');
 
-  beforeAll(async () => {
-    await browser.url('/index.html');
-    await browser.setCookies({ name: 'container', value: docker.url });
-    await browser.url('/youtube/tracking-2-videos.html');
-    await waitUntil(browser, () => $('#youtube').isExisting(), {
-      timeout: 5000,
-      timeoutMsg: 'expected youtube after 5s',
-    });
-
-    const player1 = $('#youtube');
-    const player2 = $('#youtube-2');
-
-    const actions = [
-      async () => await player1.click(), // emits 'playbackqualitychange' and 'play';
-      async () => await browser.keys(['k']), // Pause
-      async () => await player2.click(), // emits 'playbackqualitychange' and 'play';
-      async () => await browser.keys(['k']), // Pause
-    ];
-
-    for (const a of actions) {
-      await a();
+      await player1.click();
       await browser.pause(500);
+
+      await player2.click();
+      await browser.pause(3000);
+
+      log = await browser.call(async () => await fetchResults());
+      const expectedOne = makeExpectedEvent('playbackqualitychange');
+      const receivedOne = getFirstEventOfEventTypeWithId('playbackqualitychange', 'youtube');
+      compare(expectedOne, receivedOne);
+
+      const expectedTwo = makeExpectedEvent('playbackqualitychange', {}, 'youtube-2');
+      const receivedTwo = getFirstEventOfEventTypeWithId('playbackqualitychange', 'youtube-2');
+      compare(expectedTwo, receivedTwo);
+    });
+  });
+
+  describe('YouTube Tracker (1 video, 2 trackers)', () => {
+    if (shouldSkipBrowser(browser)) {
+      fit('Skip browser', () => true);
+      return;
     }
-    await browser.pause(1000);
 
-    log = await browser.call(async () => await fetchResults(docker.url));
-  });
+    const getTwoEventsOfEventType = (eventType: string): Array<any> => {
+      const results = log.filter(
+        (l: any) =>
+          l.event?.unstruct_event?.data.data.type === eventType && l.event?.app_id === 'yt-2-trackers-' + testIdentifier
+      );
+      return results.slice(results.length - 2);
+    };
 
-  afterAll(async () => {
-    await waitUntil(browser, async () => {
-      return await browser.call(async () => await clearCache(docker.url));
+    it('Tracks 1 YouTube player with two trackers', async () => {
+      await browser.url('/youtube/tracking-2-trackers.html');
+      await waitUntil(browser, () => $('#youtube').isExisting(), {
+        timeout: 5000,
+        timeoutMsg: 'expected youtube after 5s',
+      });
+
+      const player = $('#youtube');
+      await player.click(); // emits 'playbackqualitychange' and 'play';
+      await browser.pause(2000);
+
+      log = await browser.call(async () => await fetchResults());
+
+      const expected = makeExpectedEvent('playbackqualitychange', {
+        mediaPlayer: { paused: jasmine.any(Boolean) },
+      });
+      const result = getTwoEventsOfEventType('playbackqualitychange');
+      compare(expected, result[0]);
+      compare(expected, result[1]);
+      const tracker_names = result.map((r: any) => r.event.name_tracker);
+      expect(tracker_names).toContain('sp1');
+      expect(tracker_names).toContain('sp2');
     });
-  });
-
-  it('Tracks 2 YouTube players with a single tracker', () => {
-    const expectedOne = makeExpectedEvent('playbackqualitychange');
-    const recievedOne = getFirstEventOfEventTypeWithId('playbackqualitychange', 'youtube');
-    compare(expectedOne, recievedOne);
-
-    const expectedTwo = makeExpectedEvent('playbackqualitychange', {}, 'youtube-2');
-    const recievedTwo = getFirstEventOfEventTypeWithId('playbackqualitychange', 'youtube-2');
-    compare(expectedTwo, recievedTwo);
-  });
-});
-
-describe('YouTube Tracker (1 video, 2 trackers)', () => {
-  if (shouldSkipBrowser(browser)) {
-    fit('Skip browser', () => true);
-    return;
-  }
-
-  beforeAll(async () => {
-    await browser.url('/index.html');
-    await browser.setCookies({ name: 'container', value: docker.url });
-    await browser.url('/youtube/tracking-2-trackers.html');
-    await waitUntil(browser, () => $('#youtube').isExisting(), {
-      timeout: 5000,
-      timeoutMsg: 'expected youtube after 5s',
-    });
-
-    const player = $('#youtube');
-    await player.click(); // emits 'playbackqualitychange' and 'play';
-    await browser.pause(1000);
-    await browser.keys(['k']); // Pause
-    await browser.pause(1000);
-
-    log = await browser.call(async () => await fetchResults(docker.url));
-  });
-
-  afterAll(async () => {
-    await browser.call(async () => await stop(docker.container));
-  });
-
-  const getTwoEventsOfEventType = (eventType: string): Array<any> => {
-    const results = log.filter((l: any) => l.event.unstruct_event.data.data.type === eventType);
-    return results.slice(results.length - 2);
-  };
-
-  it('Tracks 2 YouTube players with a single tracker', () => {
-    const expected = makeExpectedEvent('playbackqualitychange', {
-      mediaPlayer: { paused: jasmine.any(Boolean) },
-    });
-    const result = getTwoEventsOfEventType('playbackqualitychange');
-    compare(expected, result[0]);
-    compare(expected, result[1]);
-    const tracker_names = result.map((r: any) => r.event.name_tracker);
-    expect(tracker_names).toContain('sp1');
-    expect(tracker_names).toContain('sp2');
   });
 });

--- a/trackers/javascript-tracker/test/pages/cookieless.html
+++ b/trackers/javascript-tracker/test/pages/cookieless.html
@@ -9,6 +9,7 @@
 
     <script>
       var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
 
@@ -46,7 +47,7 @@
       var ieTest = parseQuery().ieTest;
 
       window.snowplow('newTracker', 'sp', collector_endpoint, {
-        appId: ieTest ? 'ie' : 'anon',
+        appId: (ieTest ? 'cookieless-ie-' : 'cookieless-anon-') + testIdentifier,
         eventMethod: 'post',
         contexts: {
           webPage: true,

--- a/trackers/javascript-tracker/test/pages/form-tracking.html
+++ b/trackers/javascript-tracker/test/pages/form-tracking.html
@@ -66,6 +66,7 @@
 
     <script>
       var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
 
       var formHtml = '<form><input type="text" name="fname" id="fname"></form>';
@@ -96,7 +97,7 @@
       document.write(collector_endpoint);
 
       snowplow('newTracker', 'sp', collector_endpoint, {
-        appId: 'autotracking',
+        appId: 'autotracking-form-' + testIdentifier,
       });
       snowplow(function () {
         document.getElementById('init').innerText = 'true';

--- a/trackers/javascript-tracker/test/pages/integration.html
+++ b/trackers/javascript-tracker/test/pages/integration.html
@@ -9,10 +9,11 @@
 
     <div id="init"></div>
     <div id="secondInit"></div>
-    <div id="bottomRight" style="position: absolute; bottom: 0; right: 0">Bottom right</div>
+    <button id="bottomRight">Bottom right button</button>
 
     <script>
       var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
 
@@ -66,7 +67,7 @@
       var eventMethod = parseQuery().eventMethod;
 
       window.snowplow('newTracker', 'sp', collector_endpoint, {
-        appId: 'sp-' + eventMethod,
+        appId: 'sp-' + eventMethod + '-' + testIdentifier,
         platform: 'mob',
         eventMethod: eventMethod,
         contexts: {
@@ -78,7 +79,7 @@
       });
 
       window.secondSnowplow('newTracker', 'b64off', collector_endpoint, {
-        appId: 'no-b64-' + eventMethod,
+        appId: 'no-b64-' + eventMethod + '-' + testIdentifier,
         platform: 'web',
         eventMethod: eventMethod,
         encodeBase64: false,

--- a/trackers/javascript-tracker/test/pages/link-tracking.html
+++ b/trackers/javascript-tracker/test/pages/link-tracking.html
@@ -25,6 +25,7 @@
 
     <script>
       var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
 
@@ -48,7 +49,7 @@
       document.write(collector_endpoint);
 
       snowplow('newTracker', 'sp', collector_endpoint, {
-        appId: 'autotracking',
+        appId: 'autotracking-link-' + testIdentifier,
       });
       snowplow(function () {
         document.getElementById('init').innerText = 'true';

--- a/trackers/javascript-tracker/test/pages/media/tracking-2-players.html
+++ b/trackers/javascript-tracker/test/pages/media/tracking-2-players.html
@@ -3,7 +3,8 @@
   <head>
     <title>Page for HTML5 media tracking testing with Snowplow Micro</title>
     <script>
-      const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
   </head>
@@ -28,7 +29,7 @@
       document.write(collector_endpoint);
 
       window.snowplow('newTracker', 'sp2', collector_endpoint, {
-        appId: 'html5-track-test',
+        appId: 'media-2-players-1-tracker-' + testIdentifier,
       });
 
       window.snowplow('enableMediaTracking', {

--- a/trackers/javascript-tracker/test/pages/media/tracking-2-trackers.html
+++ b/trackers/javascript-tracker/test/pages/media/tracking-2-trackers.html
@@ -3,7 +3,8 @@
   <head>
     <title>Page for HTML5 media tracking testing with Snowplow Micro</title>
     <script>
-      const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
   </head>
@@ -28,10 +29,10 @@
       document.write(collector_endpoint);
 
       window.snowplow('newTracker', 'sp1', collector_endpoint, {
-        appId: 'html5-track-test',
+        appId: 'media-1-player-2-trackers-' + testIdentifier,
       });
       window.snowplow('newTracker', 'sp2', collector_endpoint, {
-        appId: 'html5-track-test',
+        appId: 'media-1-player-2-trackers-' + testIdentifier,
       });
 
       window.snowplow('enableMediaTracking', {

--- a/trackers/javascript-tracker/test/pages/media/tracking-all-events.html
+++ b/trackers/javascript-tracker/test/pages/media/tracking-all-events.html
@@ -3,7 +3,8 @@
   <head>
     <title>Page for HTML5 media tracking testing with Snowplow Micro</title>
     <script>
-      const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
   </head>
@@ -28,7 +29,7 @@
       document.write(collector_endpoint);
 
       window.snowplow('newTracker', 'sp2', collector_endpoint, {
-        appId: 'html5-track-test',
+        appId: 'media-all-events-' + testIdentifier,
       });
 
       window.snowplow('enableMediaTracking', {

--- a/trackers/javascript-tracker/test/pages/media/tracking.html
+++ b/trackers/javascript-tracker/test/pages/media/tracking.html
@@ -3,7 +3,8 @@
   <head>
     <title>Page for HTML5 media tracking testing with Snowplow Micro</title>
     <script>
-      const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
   </head>
@@ -28,7 +29,7 @@
       document.write(collector_endpoint);
 
       window.snowplow('newTracker', 'sp2', collector_endpoint, {
-        appId: 'html5-track-test',
+        appId: 'media-default-events-' + testIdentifier,
       });
 
       window.snowplow('enableMediaTracking', {

--- a/trackers/javascript-tracker/test/pages/session-integration.html
+++ b/trackers/javascript-tracker/test/pages/session-integration.html
@@ -8,6 +8,7 @@
 
     <script>
       var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
 
@@ -31,9 +32,11 @@
       document.write(collector_endpoint);
 
       window.snowplow('newTracker', 'cookieSessionTracker', collector_endpoint, {
+        appId: 'session-integration-' + testIdentifier,
         sessionCookieTimeout: 1,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        cookieName: testIdentifier,
         contexts: {
           session: true,
           webPage: false,
@@ -50,6 +53,8 @@
       }, 3000);
 
       window.snowplow('newTracker', 'localStorageSessionTracker', collector_endpoint, {
+        appId: 'session-integration-' + testIdentifier,
+        cookieName: testIdentifier,
         sessionCookieTimeout: 1,
         stateStorageStrategy: 'localStorage',
       });
@@ -64,6 +69,8 @@
       }, 3000);
 
       window.snowplow('newTracker', 'anonymousSessionTracker', collector_endpoint, {
+        appId: 'session-integration-' + testIdentifier,
+        cookieName: testIdentifier,
         sessionCookieTimeout: 1,
         stateStorageStrategy: 'localStorage',
         anonymousTracking: { withSessionTracking: true },

--- a/trackers/javascript-tracker/test/pages/session-update-callback.html
+++ b/trackers/javascript-tracker/test/pages/session-update-callback.html
@@ -10,6 +10,7 @@
 
     <script>
       var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
       document.body.className += ' loaded';
     </script>
 
@@ -33,9 +34,10 @@
       document.write(collector_endpoint);
 
       snowplow('newTracker', 'sp', collector_endpoint, {
-        appId: 'onSessionCallback',
+        appId: 'onSessionCallback' + testIdentifier,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        eventMethod: 'get',
         onSessionUpdateCallback: function (session) {
           snowplow('trackStructEvent:sp', {
             category: 'session_callback',

--- a/trackers/javascript-tracker/test/pages/youtube/tracking-2-trackers.html
+++ b/trackers/javascript-tracker/test/pages/youtube/tracking-2-trackers.html
@@ -2,7 +2,8 @@
 <head>
   <title>Page for YouTube tracking testing with Snowplow Micro</title>
   <script>
-    const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
     document.body.className += ' loaded';
   </script>
 </head>
@@ -27,14 +28,14 @@
     document.write(collector_endpoint);
 
     window.snowplow('newTracker', 'sp1', collector_endpoint, {
-      appId: 'youtube-track-test',
+      appId: 'yt-2-trackers-' + testIdentifier,
     });
 
     window.snowplow('newTracker', 'sp2', collector_endpoint, {
-      appId: 'youtube-track-test',
+      appId: 'yt-2-trackers-' + testIdentifier,
     });
 
-    let args = {
+    var args = {
       id: 'youtube',
       options: {
         label: 'test-label',
@@ -48,7 +49,7 @@
     id="youtube"
     width="560"
     height="315"
-    src="https://www.youtube.com/embed/zSM4ZyVe8xs"
+    src="https://www.youtube.com/embed/ublEqhffop0"
     title="YouTube video player"
     rel="0"
     frameborder="0"

--- a/trackers/javascript-tracker/test/pages/youtube/tracking-2-videos.html
+++ b/trackers/javascript-tracker/test/pages/youtube/tracking-2-videos.html
@@ -2,7 +2,8 @@
 <head>
   <title>Page for YouTube tracking testing with Snowplow Micro</title>
   <script>
-    const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
     document.body.className += ' loaded';
   </script>
 </head>
@@ -27,10 +28,10 @@
     document.write(collector_endpoint);
 
     window.snowplow('newTracker', 'sp2', collector_endpoint, {
-      appId: 'youtube-track-test',
+      appId: 'yt-2-videos-' + testIdentifier,
     });
 
-    let args = {
+    var args = {
       id: 'youtube',
       options: {
         label: 'test-label',
@@ -54,7 +55,7 @@
     id="youtube"
     width="560"
     height="315"
-    src="https://www.youtube.com/embed/zSM4ZyVe8xs"
+    src="https://www.youtube.com/embed/ublEqhffop0"
     title="YouTube video player"
     rel="0"
     frameborder="0"
@@ -65,7 +66,7 @@
     id="youtube-2"
     width="560"
     height="315"
-    src="https://www.youtube.com/embed/zSM4ZyVe8xs"
+    src="https://www.youtube.com/embed/ublEqhffop0"
     title="YouTube video player"
     rel="0"
     frameborder="0"

--- a/trackers/javascript-tracker/test/pages/youtube/tracking-player.html
+++ b/trackers/javascript-tracker/test/pages/youtube/tracking-player.html
@@ -2,7 +2,8 @@
 <head>
   <title>Page for YouTube tracking testing with Snowplow Micro</title>
   <script>
-    const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
     document.body.className += ' loaded';
   </script>
 </head>
@@ -27,7 +28,7 @@
     document.write(collector_endpoint);
 
     window.snowplow('newTracker', 'sp2', collector_endpoint, {
-      appId: 'youtube-track-test',
+      appId: 'yt-player-' + testIdentifier,
     });
   </script>
   <div id="youtube"></div>
@@ -41,7 +42,7 @@
     // `onYouTubeIframeAPIReady` will run once the API is loaded
     function onYouTubeIframeAPIReady() {
       new YT.Player('youtube', {
-        videoId: 'zSM4ZyVe8xs',
+        videoId: 'ublEqhffop0',
         events: {
           onReady: (e) =>
             window.snowplow('enableYouTubeTracking', {

--- a/trackers/javascript-tracker/test/pages/youtube/tracking.html
+++ b/trackers/javascript-tracker/test/pages/youtube/tracking.html
@@ -2,52 +2,63 @@
 <head>
   <title>Page for YouTube tracking testing with Snowplow Micro</title>
   <script>
-    const collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var collector_endpoint = document.cookie.split('container=')[1].split(';')[0].trim();
+    var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
     document.body.className += ' loaded';
   </script>
 </head>
 <body>
+  <div id="player"></div>
   <script>
-    (function (p, l, o, w, i, n, g) {
-      if (!p[i]) {
-        p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
-        p.GlobalSnowplowNamespace.push(i);
-        p[i] = function () {
-          (p[i].q = p[i].q || []).push(arguments);
-        };
-        p[i].q = p[i].q || [];
-        n = l.createElement(o);
-        g = l.getElementsByTagName(o)[0];
-        n.async = 1;
-        n.src = w;
-        g.parentNode.insertBefore(n, g);
-      }
-    })(window, document, 'script', '../snowplow.js', 'snowplow');
+    var tag = document.createElement('script');
+    tag.src = 'https://www.youtube.com/iframe_api';
+    var firstScriptTag = document.getElementsByTagName('script')[0];
+    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
-    document.write(collector_endpoint);
-
-    window.snowplow('newTracker', 'sp2', collector_endpoint, {
-      appId: 'youtube-track-test',
-    });
-
-    window.snowplow('enableYouTubeTracking', {
-      id: 'youtube',
-      options: {
-        label: 'test-label',
-        captureEvents: ['DefaultEvents'],
-        boundaries: [1],
-      },
-    });
+    var player;
+    function onYouTubeIframeAPIReady() {
+      player = new YT.Player('player', {
+        height: '315',
+        width: '560',
+        videoId: 'ublEqhffop0',
+        playerVars: {
+          playsinline: 1,
+        },
+        events: {
+          onReady: initTracking,
+        },
+      });
+    }
   </script>
-  <iframe
-    id="youtube"
-    width="560"
-    height="315"
-    src="https://www.youtube.com/embed/zSM4ZyVe8xs"
-    title="YouTube video player"
-    rel="0"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-  ></iframe>
+  <script>
+    function initTracking(event) {
+      (function (p, l, o, w, i, n, g) {
+        if (!p[i]) {
+          p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
+          p.GlobalSnowplowNamespace.push(i);
+          p[i] = function () {
+            (p[i].q = p[i].q || []).push(arguments);
+          };
+          p[i].q = p[i].q || [];
+          n = l.createElement(o);
+          g = l.getElementsByTagName(o)[0];
+          n.async = 1;
+          n.src = w;
+          g.parentNode.insertBefore(n, g);
+        }
+      })(window, document, 'script', '../snowplow.js', 'snowplow');
+
+      window.snowplow('newTracker', 'sp2', collector_endpoint, {
+        appId: 'yt-tracking-' + testIdentifier,
+      });
+
+      window.snowplow('enableYouTubeTracking', {
+        id: player,
+        options: {
+          label: 'test-label',
+          captureEvents: ['DefaultEvents'],
+        },
+      });
+    }
+  </script>
 </body>

--- a/trackers/javascript-tracker/test/tsconfig.json
+++ b/trackers/javascript-tracker/test/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "@wdio/types", "@wdio/globals/types", "@wdio/jasmine-framework", "jest"]
+    "types": [
+      "node",
+      "@wdio/types",
+      "@wdio/globals/types",
+      "@wdio/jasmine-framework",
+      "jest",
+      "@wdio/shared-store-service",
+      "youtube"
+    ]
   },
   "include": ["./**/*.test.ts"]
 }

--- a/trackers/javascript-tracker/test/wdio.default.conf.ts
+++ b/trackers/javascript-tracker/test/wdio.default.conf.ts
@@ -1,15 +1,21 @@
-function getFullPath(path: String): String {
+import { DockerWrapper, start, stop } from './micro';
+import { setValue } from '@wdio/shared-store-service';
+import type { Options } from '@wdio/types';
+
+function getFullPath(path: string): string {
   return process.cwd() + '/' + path;
 }
 
-export const config = {
-  specs: [getFullPath('test/functional/*.test.ts'), getFullPath('test/integration/*.test.ts')],
+type CustomTestRunnerConfig = Options.Testrunner & { dockerInstance?: DockerWrapper };
+
+export const config: Omit<Options.Testrunner, 'capabilities'> = {
+  specs: [[getFullPath('test/functional/*.test.ts'), getFullPath('test/integration/*.test.ts')]],
   logLevel: 'warn',
   baseUrl: 'http://snowplow-js-tracker.local:8080',
   waitforTimeout: 30000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
-  specFileRetries: 3,
+  specFileRetries: 1,
   specFileRetriesDelay: 60, // Delay in seconds between the spec file retry attempts
   specFileRetriesDeferred: true, // Defer retries to the end of the queue
   maxInstances: 5, // Maximum number of total parallel running workers
@@ -17,5 +23,14 @@ export const config = {
   reporters: ['spec'],
   jasmineOpts: {
     defaultTimeoutInterval: 120000,
+  },
+  async onPrepare(config: CustomTestRunnerConfig) {
+    const isSauce = config.services?.some((service) => Array.isArray(service) && service[0] === 'sauce');
+    config.dockerInstance = await start(isSauce);
+    await setValue('dockerInstanceUrl', config.dockerInstance.url);
+    return;
+  },
+  async onComplete(_, config: CustomTestRunnerConfig) {
+    await stop(config.dockerInstance!.container);
   },
 };

--- a/trackers/javascript-tracker/test/wdio.local.conf.ts
+++ b/trackers/javascript-tracker/test/wdio.local.conf.ts
@@ -1,9 +1,10 @@
+import { Options } from '@wdio/types';
 import { config as defaultConfig } from './wdio.default.conf';
 
-export const config = {
+export const config: Partial<Options.Testrunner> = {
   ...defaultConfig,
 
-  maxInstances: 1,
+  maxInstances: 2,
   capabilities: [
     {
       browserName: 'chrome',
@@ -11,12 +12,24 @@ export const config = {
         args: ['--auto-open-devtools-for-tabs'],
       },
     },
+    // {
+    //   browserName: 'safari',
+    // },
+    // {
+    //   browserName: 'MicrosoftEdge',
+    //   port: 9515,
+    //   'ms:edgeOptions': {
+    //     args: ['--auto-open-devtools-for-tabs'],
+    //   },
+    // }
   ],
   specFileRetries: 0,
-  logLevel: 'debug',
-  bail: 1,
+  logLevel: 'info',
+  bail: 4,
   services: [
-    ['chromedriver', {}],
+    'chromedriver',
+    // 'safaridriver',
+    // 'edgedriver',
     [
       'static-server',
       {
@@ -24,5 +37,6 @@ export const config = {
         port: 8080,
       },
     ],
+    'shared-store',
   ],
 };

--- a/trackers/javascript-tracker/test/wdio.sauce.conf.ts
+++ b/trackers/javascript-tracker/test/wdio.sauce.conf.ts
@@ -1,3 +1,4 @@
+import { Options } from '@wdio/types';
 import { config as defaultConfig } from './wdio.default.conf';
 
 let buildIdentifier = Math.floor(Math.random() * 1000000).toString();
@@ -7,7 +8,7 @@ if (process.env.GITHUB_WORKFLOW) {
 
 const buildName = `snowplow-js-tracker-${buildIdentifier}`;
 
-export const config = {
+export const config: Partial<Options.Testrunner> = {
   ...defaultConfig,
 
   user: process.env.SAUCE_USERNAME,
@@ -50,15 +51,7 @@ export const config = {
     {
       browserName: 'MicrosoftEdge',
       platformName: 'Windows 10',
-      browserVersion: '97',
-      'sauce:options': {
-        build: buildName,
-      },
-    },
-    {
-      browserName: 'internet explorer',
-      platformName: 'Windows 8.1',
-      browserVersion: '11',
+      browserVersion: 'latest',
       'sauce:options': {
         build: buildName,
       },
@@ -95,5 +88,6 @@ export const config = {
         port: 8080,
       },
     ],
+    'shared-store',
   ],
 };


### PR DESCRIPTION
- Removed IE for now.
- Micro is spinned up only once at the start of the suite.
- Switch micro from 1.4 to latest.
- Introduced the concept of a `testIdentifier` which allows tests to run in parallel in the same micro instance. This flows through the tracking scenarios as `appId`.
- Browser instances are spinned up only once rather than one per spec. Test results per test have different identifiers or in the case of cookie/localstorage tests different `cookieName`.
- Types are mostly fixed.
- Added brief Instructions for multi-browser local runs.