### PR TITLE
Update vendor and version of the player schema used in the media plugin (close #1222)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media/issue-1222-update_player_schema_2023-08-08-08-01.json
+++ b/common/changes/@snowplow/browser-plugin-media/issue-1222-update_player_schema_2023-08-08-08-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media",
+      "comment": "Update version of the player schema used in the media plugin to 2-0-0 (#1222)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media"
+}

--- a/plugins/browser-plugin-media/src/schemata.ts
+++ b/plugins/browser-plugin-media/src/schemata.ts
@@ -2,7 +2,7 @@ import { MediaEventType } from './types';
 
 const MEDIA_SCHEMA_PREFIX = 'iglu:com.snowplowanalytics.snowplow.media/';
 const MEDIA_SCHEMA_SUFFIX = '/jsonschema/1-0-0';
-export const MEDIA_PLAYER_SCHEMA = MEDIA_SCHEMA_PREFIX + 'player' + MEDIA_SCHEMA_SUFFIX;
+export const MEDIA_PLAYER_SCHEMA = 'iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0';
 export const MEDIA_SESSION_SCHEMA = MEDIA_SCHEMA_PREFIX + 'session' + MEDIA_SCHEMA_SUFFIX;
 export const MEDIA_AD_SCHEMA = MEDIA_SCHEMA_PREFIX + 'ad' + MEDIA_SCHEMA_SUFFIX;
 export const MEDIA_AD_BREAK_SCHEMA = MEDIA_SCHEMA_PREFIX + 'ad_break' + MEDIA_SCHEMA_SUFFIX;

--- a/plugins/browser-plugin-media/src/schemata.ts
+++ b/plugins/browser-plugin-media/src/schemata.ts
@@ -2,6 +2,7 @@ import { MediaEventType } from './types';
 
 const MEDIA_SCHEMA_PREFIX = 'iglu:com.snowplowanalytics.snowplow.media/';
 const MEDIA_SCHEMA_SUFFIX = '/jsonschema/1-0-0';
+// NOTE: The player schema has a different vendor than the other media schemas because it builds on an older version of the same schema. Versions 3.12 to 3.13.1 of the media plugin used a conflicting schema URI which has since been removed from Iglu Central.
 export const MEDIA_PLAYER_SCHEMA = 'iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0';
 export const MEDIA_SESSION_SCHEMA = MEDIA_SCHEMA_PREFIX + 'session' + MEDIA_SCHEMA_SUFFIX;
 export const MEDIA_AD_SCHEMA = MEDIA_SCHEMA_PREFIX + 'ad' + MEDIA_SCHEMA_SUFFIX;


### PR DESCRIPTION
Issue #1222 

This PR updates the schema for the player entity used in the media plugin.

The previous schema had a conflict with another one which could lead to problems when loading data to warehouses. To face this, we republished the schema under the URI `iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0`.