### PR TITLE
Add E2E testIdentifier randomness between test retries

### DIFF
--- a/common/changes/@snowplow/javascript-tracker/fix-proper-test-identifier-between-e2e-retries_2023-08-16-07-58.json
+++ b/common/changes/@snowplow/javascript-tracker/fix-proper-test-identifier-between-e2e-retries_2023-08-16-07-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/test/integration/helpers.ts
+++ b/trackers/javascript-tracker/test/integration/helpers.ts
@@ -48,7 +48,8 @@ export async function pageSetup() {
   if (!dockerUrl) {
     throw 'dockerInstanceUrl not available in `browser.sharedStore`';
   }
-  const testIdentifier = browser.capabilities.browserName + '_' + browser.capabilities.browserVersion;
+  const testIdentifier =
+    browser.capabilities.browserName + '_' + browser.capabilities.browserVersion + '_' + Math.random();
   await browser.url('/index.html');
   await browser.setCookies([
     { name: 'container', value: dockerUrl },


### PR DESCRIPTION
Small fix to allow e2e test identifiers to add some randomness between test retries in the identifiers.

Currently tests that go into further retries will fail as the `testIdentifier` _(translating this to appId in the events)_ will be the same.