### PR TITLE
Allow for web vitals and performance navigation timing plugin in javascript tracker configuration

### DIFF
--- a/common/changes/@snowplow/javascript-tracker/issue-add-cwv-plugin-on-js-tracker-build-config_2023-08-31-16-05.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-add-cwv-plugin-on-js-tracker-build-config_2023-08-31-16-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Allow for web vitals and performance navigation timing plugins in javascript tracker configuration",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -91,6 +91,10 @@
       "allowedCategories": [ "trackers" ]
     },
     {
+      "name": "@snowplow/browser-plugin-performance-navigation-timing",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
       "name": "@snowplow/browser-plugin-performance-timing",
       "allowedCategories": [ "trackers" ]
     },
@@ -112,6 +116,10 @@
     },
     {
       "name": "@snowplow/browser-plugin-vimeo-tracking",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
+      "name": "@snowplow/browser-plugin-web-vitals",
       "allowedCategories": [ "trackers" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1514,12 +1514,14 @@ importers:
       '@snowplow/browser-plugin-media-tracking': workspace:*
       '@snowplow/browser-plugin-optimizely': workspace:*
       '@snowplow/browser-plugin-optimizely-x': workspace:*
+      '@snowplow/browser-plugin-performance-navigation-timing': workspace:*
       '@snowplow/browser-plugin-performance-timing': workspace:*
       '@snowplow/browser-plugin-privacy-sandbox': workspace:*
       '@snowplow/browser-plugin-site-tracking': workspace:*
       '@snowplow/browser-plugin-snowplow-ecommerce': workspace:*
       '@snowplow/browser-plugin-timezone': workspace:*
       '@snowplow/browser-plugin-vimeo-tracking': workspace:*
+      '@snowplow/browser-plugin-web-vitals': workspace:*
       '@snowplow/browser-plugin-youtube-tracking': workspace:*
       '@snowplow/browser-tracker': workspace:*
       '@snowplow/browser-tracker-core': workspace:*
@@ -1583,12 +1585,14 @@ importers:
       '@snowplow/browser-plugin-media-tracking': link:../../plugins/browser-plugin-media-tracking
       '@snowplow/browser-plugin-optimizely': link:../../plugins/browser-plugin-optimizely
       '@snowplow/browser-plugin-optimizely-x': link:../../plugins/browser-plugin-optimizely-x
+      '@snowplow/browser-plugin-performance-navigation-timing': link:../../plugins/browser-plugin-performance-navigation-timing
       '@snowplow/browser-plugin-performance-timing': link:../../plugins/browser-plugin-performance-timing
       '@snowplow/browser-plugin-privacy-sandbox': link:../../plugins/browser-plugin-privacy-sandbox
       '@snowplow/browser-plugin-site-tracking': link:../../plugins/browser-plugin-site-tracking
       '@snowplow/browser-plugin-snowplow-ecommerce': link:../../plugins/browser-plugin-snowplow-ecommerce
       '@snowplow/browser-plugin-timezone': link:../../plugins/browser-plugin-timezone
       '@snowplow/browser-plugin-vimeo-tracking': link:../../plugins/browser-plugin-vimeo-tracking
+      '@snowplow/browser-plugin-web-vitals': link:../../plugins/browser-plugin-web-vitals
       '@snowplow/browser-plugin-youtube-tracking': link:../../plugins/browser-plugin-youtube-tracking
       '@snowplow/browser-tracker': link:../browser-tracker
       '@snowplow/browser-tracker-core': link:../../libraries/browser-tracker-core

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "a8b7bdefbe86b839e0c359de02cae9c4ccc90039",
+  "pnpmShrinkwrapHash": "89375cb589f49417e57130b57f00d052e90c723a",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -65,7 +65,9 @@
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
     "@snowplow/browser-plugin-enhanced-consent": "workspace:*",
-    "@snowplow/browser-plugin-privacy-sandbox": "workspace:*"
+    "@snowplow/browser-plugin-privacy-sandbox": "workspace:*",
+    "@snowplow/browser-plugin-web-vitals": "workspace:*",
+    "@snowplow/browser-plugin-performance-navigation-timing": "workspace:*"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",

--- a/trackers/javascript-tracker/src/features.ts
+++ b/trackers/javascript-tracker/src/features.ts
@@ -54,6 +54,8 @@ import * as EnhancedConsent from '@snowplow/browser-plugin-enhanced-consent';
 import * as SnowplowMedia from '@snowplow/browser-plugin-media';
 import * as VimeoTracking from '@snowplow/browser-plugin-vimeo-tracking';
 import * as PrivacySandbox from '@snowplow/browser-plugin-privacy-sandbox';
+import * as WebVitals from '@snowplow/browser-plugin-web-vitals';
+import * as PerformanceNavigationTiming from '@snowplow/browser-plugin-performance-navigation-timing';
 
 /**
  * Calculates the required plugins to intialise per tracker
@@ -208,10 +210,20 @@ export function Plugins(configuration: JavaScriptTrackerConfiguration) {
     const { VimeoTrackingPlugin, ...apiMethods } = VimeoTracking;
     activatedPlugins.push([VimeoTrackingPlugin(), apiMethods]);
   }
-  
+
   if (plugins.privacySandbox) {
     const { PrivacySandboxPlugin, ...apiMethods } = PrivacySandbox;
     activatedPlugins.push([PrivacySandboxPlugin(), apiMethods]);
+  }
+
+  if (plugins.webVitals) {
+    const { WebVitalsPlugin, ...apiMethods } = WebVitals;
+    activatedPlugins.push([WebVitalsPlugin(), apiMethods]);
+  }
+
+  if (plugins.performanceNavigationTiming) {
+    const { PerformanceNavigationTimingPlugin, ...apiMethods } = PerformanceNavigationTiming;
+    activatedPlugins.push([PerformanceNavigationTimingPlugin(), apiMethods]);
   }
 
   return activatedPlugins;

--- a/trackers/javascript-tracker/tracker.config.ts
+++ b/trackers/javascript-tracker/tracker.config.ts
@@ -51,3 +51,5 @@ export const enhancedConsent = false;
 export const snowplowMedia = false;
 export const vimeoTracking = false;
 export const privacySandbox = false;
+export const webVitals = false;
+export const performanceNavigationTiming = false;

--- a/trackers/javascript-tracker/tracker.lite.config.ts
+++ b/trackers/javascript-tracker/tracker.lite.config.ts
@@ -51,3 +51,5 @@ export const enhancedConsent = false;
 export const snowplowMedia = false;
 export const vimeoTracking = false;
 export const privacySandbox = false;
+export const webVitals = false;
+export const performanceNavigationTiming = false;

--- a/trackers/javascript-tracker/tracker.test.config.ts
+++ b/trackers/javascript-tracker/tracker.test.config.ts
@@ -51,3 +51,5 @@ export const enhancedConsent = false;
 export const snowplowMedia = true;
 export const vimeoTracking = true;
 export const privacySandbox = false;
+export const webVitals = false;
+export const performanceNavigationTiming = false;


### PR DESCRIPTION
Allow for adding the Web Vitals and Performance Navigation Timing plugin on the JavaScript tracker build process.