### PR TITLE
Fix newTracker optional configuration typing

### DIFF
--- a/common/changes/@snowplow/browser-tracker/fix-remove-newTracker-faulty-typing_2023-09-13-09-52.json
+++ b/common/changes/@snowplow/browser-tracker/fix-remove-newTracker-faulty-typing_2023-09-13-09-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Fix newTracker typing for better understanding of arguments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/trackers/browser-tracker/src/index.ts
+++ b/trackers/browser-tracker/src/index.ts
@@ -50,7 +50,7 @@ const state = typeof window !== 'undefined' ? createSharedState() : undefined;
  * @param endpoint - Collector endpoint in the form collector.mysite.com
  * @param configuration - The initialisation options of the tracker
  */
-export function newTracker(trackerId: string, endpoint: string, configuration: TrackerConfiguration = {}) {
+export function newTracker(trackerId: string, endpoint: string, configuration?: TrackerConfiguration) {
   if (state) {
     return addTracker(trackerId, trackerId, `js-${version}`, endpoint, state, configuration);
   } else {


### PR DESCRIPTION
Remove unneeded empty object on `newTracker` initialization. _There is no reason for this to be there as all the downstream APIs accept configuration as an optional param without an initializer._