### PR TITLE
Provide option not to retry on event send failure (close #1248)

### DIFF
--- a/common/changes/@snowplow/browser-tracker/issue-1248-send-failure-retry-option_2023-10-23-14-24.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1248-send-failure-retry-option_2023-10-23-14-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Update API docs with retryFailedRequests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-1248-send-failure-retry-option_2023-10-23-14-29.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1248-send-failure-retry-option_2023-10-23-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add retryFailedRequests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -303,7 +303,8 @@ export function Tracker(
         trackerConfiguration.withCredentials ?? true,
         trackerConfiguration.retryStatusCodes ?? [],
         (trackerConfiguration.dontRetryStatusCodes ?? []).concat([400, 401, 403, 410, 422]),
-        trackerConfiguration.idService
+        trackerConfiguration.idService,
+        trackerConfiguration.retryFailedRequests
       ),
       // Whether pageViewId should be regenerated after each trackPageView. Affect web_page context
       preservePageViewId = false,

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -249,6 +249,19 @@ export type TrackerConfiguration = {
    * The request respects the `anonymousTracking` option, including the SP-Anonymous header if needed, and any additional custom headers from the customHeaders option.
    */
   idService?: string;
+  /**
+   * Whether to retry failed requests to the collector.
+   *
+   * Failed requests are requests that failed due to
+   * [timeouts](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout_event),
+   * [network errors](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/error_event),
+   * and [abort events](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/abort_event).
+   *
+   * Takes precedent over `retryStatusCodes` and `dontRetryStatusCodes`.
+   *
+   * @defaultValue true
+   */
+  retryFailedRequests?: boolean;
 };
 
 /**

--- a/trackers/browser-tracker/docs/browser-tracker.api.md
+++ b/trackers/browser-tracker/docs/browser-tracker.api.md
@@ -369,6 +369,7 @@ export type TrackerConfiguration = {
     dontRetryStatusCodes?: number[];
     onSessionUpdateCallback?: (updatedSession: ClientSession) => void;
     idService?: string;
+    retryFailedRequests?: boolean;
 };
 
 // @public


### PR DESCRIPTION
This PR adds an option to the `newTracker` config, which allows the user to choose if they want to retry sending events in the case of a sending failure, e.g.:

```js
newTracker(..., {
    retryFailures: true,
});
```