### PR TITLE
Add support for callbacks on failed/successful event sending (close #…

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -17,7 +17,7 @@
     },
     {
       "path": "./trackers/javascript-tracker/dist/sp.lite.js",
-      "maxSize": "15kb",
+      "maxSize": "15.5kb",
       "maxPercentIncrease": 10
     },
     {

--- a/common/changes/@snowplow/browser-tracker-core/issue-1262-event-fail-success-callback_2023-11-16-12-57.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1262-event-fail-success-callback_2023-11-16-12-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add onRequestSuccess and onRequestFailure callbacks",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1262-event-fail-success-callback_2023-11-16-12-57.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1262-event-fail-success-callback_2023-11-16-12-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Add onRequestSuccess and onRequestFailure callbacks",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -1,38 +1,9 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 import { attemptWriteLocalStorage, isString } from '../helpers';
 import { SharedState } from '../state';
 import { localStorageAccessible } from '../detectors';
 import { LOG, Payload } from '@snowplow/tracker-core';
 import { PAYLOAD_DATA_SCHEMA } from './schemata';
+import { EventBatch, RequestFailure } from './types';
 
 export interface OutQueue {
   enqueueRequest: (request: Payload, url: string) => void;
@@ -65,6 +36,8 @@ export interface OutQueue {
  * @param dontRetryStatusCodes – Failure HTTP response status codes from Collector for which sending events should not be retried
  * @param idService - Id service full URL. This URL will be added to the queue and will be called using a GET method.
  * @param retryFailedRequests - Whether to retry failed requests - Takes precedent over `retryStatusCodes` and `dontRetryStatusCodes`
+ * @param onRequestSuccess - Function called when a request succeeds
+ * @param onRequestFailure - Function called when a request does not succeed
  * @returns object OutQueueManager instance
  */
 export function OutQueueManager(
@@ -85,7 +58,9 @@ export function OutQueueManager(
   retryStatusCodes: number[],
   dontRetryStatusCodes: number[],
   idService?: string,
-  retryFailedRequests: boolean = true
+  retryFailedRequests: boolean = true,
+  onRequestSuccess?: (data: EventBatch) => void,
+  onRequestFailure?: (data: RequestFailure) => void
 ): OutQueue {
   type PostEvent = {
     evt: Record<string, unknown>;
@@ -237,7 +212,75 @@ export function OutQueueManager(
    */
   function sendPostRequestWithoutQueueing(body: PostEvent, configCollectorUrl: string) {
     const xhr = initializeXMLHttpRequest(configCollectorUrl, true, false);
-    xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent([body.evt])));
+    const batch = attachStmToEvent([body.evt]);
+
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState === 4) {
+        if (isSuccessfulRequest(xhr.status)) {
+          onRequestSuccess?.(batch);
+        } else {
+          onRequestFailure?.({
+            status: xhr.status,
+            message: xhr.statusText,
+            events: batch,
+            willRetry: false,
+          });
+        }
+      }
+    };
+
+    xhr.send(encloseInPayloadDataEnvelope(batch));
+  }
+
+  function removeEventsFromQueue(numberToSend: number): void {
+    for (let deleteCount = 0; deleteCount < numberToSend; deleteCount++) {
+      outQueue.shift();
+    }
+    if (useLocalStorage) {
+      attemptWriteLocalStorage(queueName, JSON.stringify(outQueue.slice(0, maxLocalStorageQueueSize)));
+    }
+  }
+
+  function setXhrCallbacks(xhr: XMLHttpRequest, numberToSend: number, batch: EventBatch) {
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState === 4) {
+        clearTimeout(xhrTimeout);
+        if (isSuccessfulRequest(xhr.status)) {
+          removeEventsFromQueue(numberToSend);
+          onRequestSuccess?.(batch);
+          executeQueue();
+        } else {
+          const willRetry = shouldRetryForStatusCode(xhr.status);
+          if (!willRetry) {
+            LOG.error(`Status ${xhr.status}, will not retry.`);
+            removeEventsFromQueue(numberToSend);
+          }
+          onRequestFailure?.({
+            status: xhr.status,
+            message: xhr.statusText,
+            events: batch,
+            willRetry,
+          });
+
+          executingQueue = false;
+        }
+      }
+    };
+
+    // Time out POST requests after connectionTimeout
+    const xhrTimeout = setTimeout(function () {
+      xhr.abort();
+      if (!retryFailedRequests) {
+        removeEventsFromQueue(numberToSend);
+      }
+      onRequestFailure?.({
+        status: 0,
+        message: 'timeout',
+        events: batch,
+        willRetry: retryFailedRequests,
+      });
+      executingQueue = false;
+    }, connectionTimeout);
   }
 
   /*
@@ -350,49 +393,9 @@ export function OutQueueManager(
         numberToSend = 1;
       }
 
-      // Time out POST requests after connectionTimeout
-      const xhrTimeout = setTimeout(function () {
-        xhr.abort();
-
-        if (!retryFailedRequests) {
-          removeEventsFromQueue(numberToSend);
-        }
-        executingQueue = false;
-      }, connectionTimeout);
-
-      const removeEventsFromQueue = (numberToSend: number): void => {
-        for (let deleteCount = 0; deleteCount < numberToSend; deleteCount++) {
-          outQueue.shift();
-        }
-        if (useLocalStorage) {
-          attemptWriteLocalStorage(queueName, JSON.stringify(outQueue.slice(0, maxLocalStorageQueueSize)));
-        }
-      };
-
-      // The events (`numberToSend` of them), have been sent, so we remove them from the outQueue
-      // We also call executeQueue() again, to let executeQueue() check if we should keep running through the queue
-      const onPostSuccess = (numberToSend: number): void => {
-        removeEventsFromQueue(numberToSend);
-        executeQueue();
-      };
-
-      xhr.onreadystatechange = function () {
-        if (xhr.readyState === 4) {
-          clearTimeout(xhrTimeout);
-          if (xhr.status >= 200 && xhr.status < 300) {
-            onPostSuccess(numberToSend);
-          } else {
-            if (!shouldRetryForStatusCode(xhr.status)) {
-              LOG.error(`Status ${xhr.status}, will not retry.`);
-              removeEventsFromQueue(numberToSend);
-            }
-            executingQueue = false;
-          }
-        }
-      };
-
       if (!postable(outQueue)) {
         // If not postable then it's a GET so just send it
+        setXhrCallbacks(xhr, numberToSend, [url]);
         xhr.send();
       } else {
         let batch = outQueue.slice(0, numberToSend);
@@ -418,9 +421,13 @@ export function OutQueueManager(
           // When beaconStatus is true, we can't _guarantee_ that it was successful (beacon queues asynchronously)
           // but the browser has taken it out of our hands, so we want to flush the queue assuming it will do its job
           if (beaconStatus === true) {
-            onPostSuccess(numberToSend);
+            removeEventsFromQueue(numberToSend);
+            onRequestSuccess?.(batch);
+            executeQueue();
           } else {
-            xhr.send(encloseInPayloadDataEnvelope(attachStmToEvent(eventBatch)));
+            const batch = attachStmToEvent(eventBatch);
+            setXhrCallbacks(xhr, numberToSend, batch);
+            xhr.send(encloseInPayloadDataEnvelope(batch));
           }
         }
       }
@@ -458,9 +465,20 @@ export function OutQueueManager(
     }
   }
 
+  /**
+   * Determines whether a request was successful, based on its status code
+   * Anything in the 2xx range is considered successful
+   *
+   * @param statusCode The status code of the request
+   * @returns Whether the request was successful
+   */
+  function isSuccessfulRequest(statusCode: number): boolean {
+    return statusCode >= 200 && statusCode < 300;
+  }
+
   function shouldRetryForStatusCode(statusCode: number) {
     // success, don't retry
-    if (statusCode >= 200 && statusCode < 300) {
+    if (isSuccessfulRequest(statusCode)) {
       return false;
     }
 

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -1,33 +1,3 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 import { BrowserPlugin } from '../plugins';
 import {
   CommonEventProperties,
@@ -661,3 +631,35 @@ export interface ClientSession extends Record<string, unknown> {
    */
   firstEventTimestamp: string | null;
 }
+
+/**
+ * A collection of GET events which are sent to the collector.
+ * This will be a collection of query strings.
+ */
+export type GetBatch = string[];
+
+/**
+ * A collection of POST events which are sent to the collector.
+ * This will be a collection of JSON objects.
+ */
+export type PostBatch = Record<string, unknown>[];
+
+/**
+ * A collection of events which are sent to the collector.
+ * This can either be a collection of query strings or JSON objects.
+ */
+export type EventBatch = GetBatch | PostBatch;
+
+/**
+ * The data that will be available to the `onRequestFailure` callback
+ */
+export type RequestFailure = {
+  /** The batch of events that failed to send */
+  events: EventBatch;
+  /** The status code of the failed request */
+  status?: number;
+  /** The error message of the failed request */
+  message?: string;
+  /** Whether the tracker will retry the request */
+  willRetry: boolean;
+};

--- a/libraries/browser-tracker-core/test/out_queue.test.ts
+++ b/libraries/browser-tracker-core/test/out_queue.test.ts
@@ -30,12 +30,22 @@
 
 import { OutQueueManager, OutQueue } from '../src/tracker/out_queue';
 import { SharedState } from '../src/state';
+import { EventBatch, RequestFailure } from '../src/tracker/types';
 
 const readPostQueue = () => {
   return JSON.parse(
     window.localStorage.getItem('snowplowOutQueue_sp_post2') ?? fail('Unable to find local storage queue')
   );
 };
+
+const readGetQueue = () =>
+  JSON.parse(window.localStorage.getItem('snowplowOutQueue_sp_get') ?? fail('Unable to find local storage queue'));
+
+const getQuerystring = (p: object) =>
+  '?' +
+  Object.entries(p)
+    .map(([k, v]) => k + '=' + encodeURIComponent(v))
+    .join('&');
 
 describe('OutQueueManager', () => {
   const maxQueueSize = 2;
@@ -57,9 +67,10 @@ describe('OutQueueManager', () => {
     jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => xhrMock as XMLHttpRequest);
   });
 
-  const respondMockRequest = (status: number) => {
+  const respondMockRequest = (status: number, statusText: string = '') => {
     (xhrMock as any).status = status;
     (xhrMock as any).response = '';
+    (xhrMock as any).statusText = statusText;
     (xhrMock as any).readyState = 4;
     (xhrMock as any).onreadystatechange();
   };
@@ -169,11 +180,6 @@ describe('OutQueueManager', () => {
 
   describe('GET requests', () => {
     var getOutQueue: (maxGetBytes: number) => OutQueue;
-    const getQuerystring = (p: object) =>
-      '?' +
-      Object.entries(p)
-        .map(([k, v]) => k + '=' + encodeURIComponent(v))
-        .join('&');
 
     beforeEach(() => {
       getOutQueue = (maxGetBytes) =>
@@ -419,6 +425,269 @@ describe('OutQueueManager', () => {
         expect(retrievedQueue).toHaveLength(0);
         done();
       }, 20);
+    });
+  });
+
+  type createQueueArgs = {
+    method: string;
+    onSuccess?: (data: EventBatch) => void;
+    onFailure?: (data: RequestFailure) => void;
+    maxPostBytes?: number;
+    maxGetBytes?: number;
+  };
+
+  const createQueue = (args: createQueueArgs) =>
+    OutQueueManager(
+      'sp',
+      new SharedState(),
+      true,
+      args.method,
+      '/com.snowplowanalytics.snowplow/tp2',
+      1,
+      args.maxPostBytes ?? 40000,
+      args.maxGetBytes ?? 0,
+      true,
+      maxQueueSize,
+      5000,
+      false,
+      {},
+      true,
+      [],
+      [],
+      '',
+      false,
+      args.onSuccess,
+      args.onFailure
+    );
+
+  describe('onRequestSuccess', () => {
+    const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
+
+    describe('POST requests', () => {
+      const method = 'POST';
+
+      it('should fire on a successful request', () => {
+        const callbackStorage: EventBatch[] = [];
+        const onSuccess = (e: EventBatch) => {
+          callbackStorage.push(e);
+        };
+
+        const postQueue = createQueue({ method, onSuccess });
+        postQueue.enqueueRequest(request, 'http://example.com');
+
+        expect(readPostQueue()).toHaveLength(1);
+
+        respondMockRequest(200);
+
+        expect(readPostQueue()).toHaveLength(0);
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0][0] as Record<string, unknown>;
+        expect(dataFromCallback.e).toEqual(request.e);
+        expect(dataFromCallback.eid).toEqual(request.eid);
+        expect(dataFromCallback.stm).toMatch(/\d{13}/);
+      });
+
+      // Oversized events don't get placed in the queue, but the callback should still fire
+      it('should fire on a successful oversized request', () => {
+        const callbackStorage: EventBatch[] = [];
+        const onSuccess = (e: EventBatch) => {
+          callbackStorage.push(e);
+        };
+
+        const postQueue = createQueue({ method, onSuccess, maxPostBytes: 1 });
+        postQueue.enqueueRequest(request, 'http://example.com');
+
+        respondMockRequest(200);
+
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0][0] as Record<string, unknown>;
+        expect(dataFromCallback.e).toEqual(request.e);
+        expect(dataFromCallback.eid).toEqual(request.eid);
+        expect(dataFromCallback.stm).toMatch(/\d{13}/);
+      });
+    });
+
+    describe('GET requests', () => {
+      const method = 'GET';
+
+      it('should fire on a successful request', () => {
+        let callbackStorage: EventBatch[] = [];
+        const onSuccess = (e: EventBatch) => {
+          callbackStorage.push(e);
+        };
+
+        const getQueue = createQueue({ method, onSuccess });
+        getQueue.enqueueRequest(request, 'http://example.com');
+
+        expect(readGetQueue()).toHaveLength(1);
+
+        respondMockRequest(200);
+
+        expect(readGetQueue()).toHaveLength(0);
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0][0] as string;
+        expect(dataFromCallback).toMatch(/\?stm=\d{13}&e=pv&eid=65cb78de-470c-4764-8c10-02bd79477a3a/);
+      });
+
+      // A single oversized events means no queue, but the callback should still fire
+      it('should fire the onRequestSuccess on a successful oversized request', () => {
+        let callbackStorage: EventBatch[] = [];
+        const onSuccess = (e: EventBatch) => {
+          callbackStorage.push(e);
+        };
+
+        const getQueue = createQueue({ method, onSuccess });
+        getQueue.enqueueRequest(request, 'http://example.com');
+
+        respondMockRequest(200);
+
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0][0] as string;
+        expect(dataFromCallback).toMatch(/\?stm=\d{13}&e=pv&eid=65cb78de-470c-4764-8c10-02bd79477a3a/);
+      });
+    });
+  });
+
+  describe('onRequestFailure', () => {
+    const request = { e: 'pv', eid: '65cb78de-470c-4764-8c10-02bd79477a3a' };
+
+    const createQueue = (args: createQueueArgs) =>
+      OutQueueManager(
+        'sp',
+        new SharedState(),
+        true,
+        args.method,
+        '/com.snowplowanalytics.snowplow/tp2',
+        1,
+        40000,
+        0,
+        true,
+        maxQueueSize,
+        5000,
+        false,
+        {},
+        true,
+        [],
+        [500],
+        '',
+        false,
+        args.onSuccess,
+        args.onFailure
+      );
+
+    describe('POST requests', () => {
+      const method = 'POST';
+
+      it('should fire on a failed request', () => {
+        const callbackStorage: RequestFailure[] = [];
+        const onFailure = (e: RequestFailure) => {
+          callbackStorage.push(e);
+        };
+
+        const postQueue = createQueue({ method, onFailure });
+        postQueue.enqueueRequest(request, 'http://example.com');
+
+        expect(readPostQueue()).toHaveLength(1);
+
+        respondMockRequest(500, 'Internal Server Error');
+
+        expect(readPostQueue()).toHaveLength(0);
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0] as RequestFailure;
+
+        const event = dataFromCallback.events[0] as Record<string, unknown>;
+        expect(event.e).toEqual(request.e);
+        expect(event.eid).toEqual(request.eid);
+        expect(event.stm).toMatch(/\d{13}/);
+
+        expect(dataFromCallback.status).toEqual(500);
+        expect(dataFromCallback.message).toEqual('Internal Server Error');
+        expect(dataFromCallback.willRetry).toEqual(false);
+      });
+
+      // A single oversized events means no queue, but the callback should still fire
+      it('should fire on a failed oversized request', () => {
+        const callbackStorage: RequestFailure[] = [];
+        const onFailure = (e: RequestFailure) => {
+          callbackStorage.push(e);
+        };
+
+        const postQueue = createQueue({ method, onFailure, maxPostBytes: 1 });
+        postQueue.enqueueRequest(request, 'http://example.com');
+
+        respondMockRequest(0, 'Request failed');
+
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0].events[0] as Record<string, unknown>;
+        expect(dataFromCallback.e).toEqual(request.e);
+        expect(dataFromCallback.eid).toEqual(request.eid);
+
+        // The payload will have had `stm` added to it
+        expect(dataFromCallback.stm).toMatch(/\d{13}/);
+        expect(callbackStorage[0].status).toEqual(0);
+        expect(callbackStorage[0].message).toEqual('Request failed');
+      });
+    });
+
+    describe('GET requests', () => {
+      const method = 'GET';
+
+      it('should fire on a failed request', () => {
+        let callbackStorage: RequestFailure[] = [];
+        const onFailure = (e: RequestFailure) => {
+          callbackStorage.push(e);
+        };
+
+        const getQueue = createQueue({ method, onFailure });
+        getQueue.enqueueRequest(request, 'http://example.com');
+
+        expect(readGetQueue()).toHaveLength(1);
+
+        respondMockRequest(500, 'Internal Server Error');
+
+        expect(readGetQueue()).toHaveLength(0);
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0] as RequestFailure;
+
+        expect(dataFromCallback.events[0]).toMatch(/\?stm=\d{13}&e=pv&eid=65cb78de-470c-4764-8c10-02bd79477a3a/);
+
+        expect(dataFromCallback.status).toEqual(500);
+        expect(dataFromCallback.message).toEqual('Internal Server Error');
+        expect(dataFromCallback.willRetry).toEqual(false);
+      });
+
+      // A single oversized events means no queue, but the callback should still fire
+      it('should fire on a failed oversized request', () => {
+        let callbackStorage: RequestFailure[] = [];
+        const onFailure = (e: RequestFailure) => {
+          callbackStorage.push(e);
+        };
+
+        const getQueue = createQueue({ method, onFailure, maxPostBytes: 1 });
+        getQueue.enqueueRequest(request, 'http://example.com');
+
+        expect(readGetQueue()).toHaveLength(1);
+
+        respondMockRequest(500, 'Internal Server Error');
+
+        expect(readGetQueue()).toHaveLength(0);
+        expect(callbackStorage).toHaveLength(1);
+
+        let dataFromCallback = callbackStorage[0] as RequestFailure;
+
+        expect(dataFromCallback.events[0]).toMatch(/\?stm=\d{13}&e=pv&eid=65cb78de-470c-4764-8c10-02bd79477a3a/);
+
+        expect(dataFromCallback.status).toEqual(500);
+        expect(dataFromCallback.message).toEqual('Internal Server Error');
+        expect(dataFromCallback.willRetry).toEqual(false);
+      });
     });
   });
 });

--- a/trackers/javascript-tracker/test/integration/integration.test.ts
+++ b/trackers/javascript-tracker/test/integration/integration.test.ts
@@ -50,12 +50,15 @@ describe('Snowplow Micro integration', () => {
   beforeAll(async () => {
     testIdentifier = await pageSetup();
     await loadUrlAndWait('/integration.html?eventMethod=get');
+    await browser.pause(2000); // Time for pings
     await $('#bottomRight').click();
     await browser.pause(5000); // Time for requests to get written
     await loadUrlAndWait('/integration.html?eventMethod=post');
+    await browser.pause(2000); // Time for pings
     await $('#bottomRight').click();
     await browser.pause(6000); // Time for requests to get written
     await loadUrlAndWait('/integration.html?eventMethod=beacon');
+    await browser.pause(2000); // Time for pings
     await $('#bottomRight').click();
     await browser.pause(6000); // Time for requests to get written
     log = await browser.call(async () => await fetchResults());


### PR DESCRIPTION
This PR adds two optional callbacks to `newTracker`. These are `onRequestSuccess` and `onRequestFailure`. 
- `onRequestSuccess` fires when defined, and a response contains code 200-299 
-  `onRequestFailure` fires when defined, and a response contains any code that isn't retried, or on timeout

```ts
newTracker(..., {
    onRequestSuccess: (data: EventBatch) => foo(data),
    onRequestFailure: (data: RequestFailure) => bar(data),
});
```

Where `EventBatch` is:
```ts
export type PostBatch = Record<string, unknown>[];
export type GetBatch = string[];
export type EventBatch = GetBatch | PostBatch;
```

And `RequestFailure` is:
```ts
export type RequestFailure = {
  /** The batch of events that failed to send */
  events: EventBatch;
  /** The status code of the failed request */
  status?: number;
  /** The error message of the failed request */
  message?: string;
};
```
(`RequestFailure` could possibly be given a better name, any suggestions welcome)








