### PR TITLE
Add OTB Button Click Tracking (close #1267)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-button-click-tracking/issue-1267-otb-button-click-tracking_2023-11-22-13-22.json
+++ b/common/changes/@snowplow/browser-plugin-button-click-tracking/issue-1267-otb-button-click-tracking_2023-11-22-13-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-button-click-tracking",
+      "comment": "Add Button Click tracking plugin (close #1267)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-button-click-tracking"
+}

--- a/common/changes/@snowplow/tracker-core/issue-1267-otb-button-click-tracking_2023-11-22-13-22.json
+++ b/common/changes/@snowplow/tracker-core/issue-1267-otb-button-click-tracking_2023-11-22-13-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Export 'removeEmptyProperties'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -35,6 +35,10 @@
       "allowedCategories": [ "trackers" ]
     },
     {
+      "name": "@snowplow/browser-plugin-button-click-tracking",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
       "name": "@snowplow/browser-plugin-client-hints",
       "allowedCategories": [ "trackers" ]
     },
@@ -56,6 +60,10 @@
     },
     {
       "name": "@snowplow/browser-plugin-error-tracking",
+      "allowedCategories": [ "trackers" ]
+    },
+    {
+      "name": "@snowplow/browser-plugin-focalmeter",
       "allowedCategories": [ "trackers" ]
     },
     {
@@ -116,10 +124,6 @@
     },
     {
       "name": "@snowplow/browser-plugin-youtube-tracking",
-      "allowedCategories": [ "trackers" ]
-    },
-    {
-      "name": "@snowplow/browser-plugin-focalmeter",
       "allowedCategories": [ "trackers" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -207,6 +207,59 @@ importers:
       ts-jest: 27.1.3_60149d457e34ffba7d4e845dde6a1263
       typescript: 4.6.2
 
+  ../../plugins/browser-plugin-button-click-tracking:
+    specifiers:
+      '@ampproject/rollup-plugin-closure-compiler': ~0.27.0
+      '@rollup/plugin-commonjs': ~21.0.2
+      '@rollup/plugin-node-resolve': ~13.1.3
+      '@snowplow/browser-tracker-core': workspace:*
+      '@snowplow/tracker-core': workspace:*
+      '@types/jest': ~27.4.1
+      '@types/jsdom': ~16.2.14
+      '@types/lodash': ~4.14.180
+      '@typescript-eslint/eslint-plugin': ~5.15.0
+      '@typescript-eslint/parser': ~5.15.0
+      eslint: ~8.11.0
+      jest: ~27.5.1
+      jest-environment-jsdom: ~27.5.1
+      jest-environment-jsdom-global: ~3.0.0
+      jest-standard-reporter: ~2.0.0
+      lodash: ~4.17.21
+      rollup: ~2.70.1
+      rollup-plugin-cleanup: ~3.2.1
+      rollup-plugin-license: ~2.6.1
+      rollup-plugin-terser: ~7.0.2
+      rollup-plugin-ts: ~2.0.5
+      ts-jest: ~27.1.3
+      tslib: ^2.3.1
+      typescript: ~4.6.2
+    dependencies:
+      '@snowplow/browser-tracker-core': link:../../libraries/browser-tracker-core
+      '@snowplow/tracker-core': link:../../libraries/tracker-core
+      tslib: 2.3.1
+    devDependencies:
+      '@ampproject/rollup-plugin-closure-compiler': 0.27.0_rollup@2.70.1
+      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
+      '@types/jest': 27.4.1
+      '@types/jsdom': 16.2.14
+      '@types/lodash': 4.14.180
+      '@typescript-eslint/eslint-plugin': 5.15.0_f2c49ce7d0e93ebcfdb4b7d25b131b28
+      '@typescript-eslint/parser': 5.15.0_eslint@8.11.0+typescript@4.6.2
+      eslint: 8.11.0
+      jest: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-jsdom-global: 3.0.0_jest-environment-jsdom@27.5.1
+      jest-standard-reporter: 2.0.0
+      lodash: 4.17.21
+      rollup: 2.70.1
+      rollup-plugin-cleanup: 3.2.1_rollup@2.70.1
+      rollup-plugin-license: 2.6.1_rollup@2.70.1
+      rollup-plugin-terser: 7.0.2_rollup@2.70.1
+      rollup-plugin-ts: 2.0.5_rollup@2.70.1+typescript@4.6.2
+      ts-jest: 27.1.3_60149d457e34ffba7d4e845dde6a1263
+      typescript: 4.6.2
+
   ../../plugins/browser-plugin-client-hints:
     specifiers:
       '@ampproject/rollup-plugin-closure-compiler': ~0.27.0
@@ -1551,6 +1604,7 @@ importers:
       '@rollup/plugin-replace': ~4.0.0
       '@snowplow/browser-plugin-ad-tracking': workspace:*
       '@snowplow/browser-plugin-browser-features': workspace:*
+      '@snowplow/browser-plugin-button-click-tracking': workspace:*
       '@snowplow/browser-plugin-client-hints': workspace:*
       '@snowplow/browser-plugin-consent': workspace:*
       '@snowplow/browser-plugin-ecommerce': workspace:*
@@ -1620,6 +1674,7 @@ importers:
     dependencies:
       '@snowplow/browser-plugin-ad-tracking': link:../../plugins/browser-plugin-ad-tracking
       '@snowplow/browser-plugin-browser-features': link:../../plugins/browser-plugin-browser-features
+      '@snowplow/browser-plugin-button-click-tracking': link:../../plugins/browser-plugin-button-click-tracking
       '@snowplow/browser-plugin-client-hints': link:../../plugins/browser-plugin-client-hints
       '@snowplow/browser-plugin-consent': link:../../plugins/browser-plugin-consent
       '@snowplow/browser-plugin-ecommerce': link:../../plugins/browser-plugin-ecommerce
@@ -1669,7 +1724,7 @@ importers:
       '@wdio/static-server-service': 8.17.0
       '@wdio/types': 8.17.0
       chalk: 4.1.2
-      chromedriver: 114.0.2
+      chromedriver: 114.0.3
       dockerode: 3.3.1
       jest: 27.5.1_ts-node@10.9.1
       jest-environment-jsdom: 27.5.1
@@ -1689,7 +1744,7 @@ importers:
       ts-jest: 27.1.3_60149d457e34ffba7d4e845dde6a1263
       ts-node: 10.9.1_3a45c3db8dee5edcd277f201fb244988
       typescript: 4.6.2
-      wdio-chromedriver-service: 8.1.1_514dbdcecc2bde428ae175e957c6d0fe
+      wdio-chromedriver-service: 8.1.1_e56eb4ff7720135f2fea4d5c81e984e9
       wdio-edgedriver-service: 3.0.3_@wdio+types@8.17.0
       wdio-safaridriver-service: 2.1.1_4fb69569f1618470b3fa12973abeed28
       webdriverio: 8.18.2_typescript@4.6.2
@@ -1785,7 +1840,7 @@ packages:
     resolution: {integrity: sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.22.13
       '@babel/generator': 7.12.11
       '@babel/helper-module-transforms': 7.12.1
       '@babel/helpers': 7.12.5
@@ -1845,7 +1900,7 @@ packages:
       '@babel/helper-replace-supers': 7.12.11
       '@babel/helper-simple-access': 7.12.1
       '@babel/helper-split-export-declaration': 7.12.11
-      '@babel/helper-validator-identifier': 7.16.7
+      '@babel/helper-validator-identifier': 7.22.20
       '@babel/template': 7.12.7
       '@babel/traverse': 7.12.10
       '@babel/types': 7.16.8
@@ -2060,7 +2115,7 @@ packages:
   /@babel/template/7.12.7:
     resolution: {integrity: sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==}
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.22.13
       '@babel/parser': 7.16.12
       '@babel/types': 7.16.8
     dev: true
@@ -2068,7 +2123,7 @@ packages:
   /@babel/traverse/7.12.10:
     resolution: {integrity: sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==}
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.22.13
       '@babel/generator': 7.12.11
       '@babel/helper-function-name': 7.12.11
       '@babel/helper-split-export-declaration': 7.12.11
@@ -2085,7 +2140,7 @@ packages:
     resolution: {integrity: sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: true
 
@@ -2210,7 +2265,7 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/node': 14.6.4
-      ansi-escapes: 4.3.1
+      ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
@@ -2255,7 +2310,7 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/node': 14.6.4
-      ansi-escapes: 4.3.1
+      ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
@@ -2787,8 +2842,8 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
-  /@testim/chrome-version/1.1.3:
-    resolution: {integrity: sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==}
+  /@testim/chrome-version/1.1.4:
+    resolution: {integrity: sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==}
     dev: true
 
   /@tootallnate/once/1.1.2:
@@ -3604,13 +3659,6 @@ packages:
       string-width: 4.2.3
     dev: true
 
-  /ansi-escapes/4.3.1:
-    resolution: {integrity: sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==}
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: 0.11.0
-    dev: true
-
   /ansi-escapes/4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -3854,8 +3902,8 @@ packages:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: true
 
-  /axios/1.4.0:
-    resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
+  /axios/1.6.2:
+    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
     dependencies:
       follow-redirects: 1.15.2
       form-data: 4.0.0
@@ -4431,15 +4479,15 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /chromedriver/114.0.2:
-    resolution: {integrity: sha512-v0qrXRBknbxqmtklG7RWOe3TJ/dLaHhtB0jVxE7BAdYERxUjEaNRyqBwoGgVfQDibHCB0swzvzsj158nnfPgZw==}
+  /chromedriver/114.0.3:
+    resolution: {integrity: sha512-Qy5kqsAUrCDwpovM5pIWFkb3X3IgJLoorigwFEDgC1boL094svny3N7yw06marJHAuyX4CE/hhd25RarIcKvKg==}
     engines: {node: '>=16'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@testim/chrome-version': 1.1.3
-      axios: 1.4.0
-      compare-versions: 5.0.3
+      '@testim/chrome-version': 1.1.4
+      axios: 1.6.2
+      compare-versions: 6.1.0
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
       proxy-from-env: 1.1.0
@@ -4649,8 +4697,8 @@ packages:
     resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
     dev: true
 
-  /compare-versions/5.0.3:
-    resolution: {integrity: sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==}
+  /compare-versions/6.1.0:
+    resolution: {integrity: sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==}
     dev: true
 
   /compatfactory/0.0.12_typescript@4.6.2:
@@ -7813,7 +7861,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       '@types/node': 14.6.4
-      ansi-escapes: 4.3.1
+      ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
       string-length: 4.0.1
@@ -9223,7 +9271,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.22.13
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -10854,7 +10902,7 @@ packages:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
     dependencies:
-      ansi-escapes: 4.3.1
+      ansi-escapes: 4.3.2
       supports-hyperlinks: 2.1.0
     dev: true
 
@@ -10875,7 +10923,7 @@ packages:
     dependencies:
       '@istanbuljs/schema': 0.1.2
       glob: 7.2.0
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     dev: true
 
   /text-table/0.2.0:
@@ -11102,11 +11150,6 @@ packages:
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
-    dev: true
-
-  /type-fest/0.11.0:
-    resolution: {integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==}
-    engines: {node: '>=8'}
     dev: true
 
   /type-fest/0.13.1:
@@ -11378,7 +11421,7 @@ packages:
       defaults: 1.0.3
     dev: true
 
-  /wdio-chromedriver-service/8.1.1_514dbdcecc2bde428ae175e957c6d0fe:
+  /wdio-chromedriver-service/8.1.1_e56eb4ff7720135f2fea4d5c81e984e9:
     resolution: {integrity: sha512-pN3GiOkTIMnalfq4PJAHdX95pDp1orHnTY8W1fIbd6ok81ba97UjerTgS7lUDRUh1p0MAm35Ww0uc0/9wzB7SA==}
     engines: {node: ^16.13 || >=18}
     peerDependencies:
@@ -11393,7 +11436,7 @@ packages:
     dependencies:
       '@wdio/logger': 8.16.17
       '@wdio/types': 8.17.0
-      chromedriver: 114.0.2
+      chromedriver: 114.0.3
       fs-extra: 11.1.0
       split2: 4.2.0
       tcp-port-used: 1.0.2

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "57af2bb401d45bb58b802eb1a04a7ee62b3aa732",
+  "pnpmShrinkwrapHash": "f22225c05d2747a95a11b5d6c6ee8827084cf800",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/tracker-core/src/core.ts
+++ b/libraries/tracker-core/src/core.ts
@@ -1366,7 +1366,7 @@ export function buildConsentGranted(event: ConsentGrantedEvent) {
  * @param exemptFields - Set of fields which should not be removed even if empty
  * @returns A cleaned copy of eventJson
  */
-function removeEmptyProperties(
+export function removeEmptyProperties(
   event: Record<string, unknown>,
   exemptFields: Record<string, boolean> = {}
 ): Record<string, unknown> {

--- a/plugins/browser-plugin-button-click-tracking/LICENSE
+++ b/plugins/browser-plugin-button-click-tracking/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2023 Snowplow Analytics Ltd, 2010 Anthon Pang
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plugins/browser-plugin-button-click-tracking/README.md
+++ b/plugins/browser-plugin-button-click-tracking/README.md
@@ -1,0 +1,63 @@
+# Snowplow Button Click Tracking
+
+[![npm version][npm-image]][npm-url]
+[![License][license-image]](LICENSE)
+
+Browser Plugin to be used with `@snowplow/browser-tracker`.
+
+Adds button click tracking events to your Snowplow tracking.
+
+## Maintainer quick start
+
+Part of the Snowplow JavaScript Tracker monorepo.  
+Build with [Node.js](https://nodejs.org/en/) (14 or 16) and [Rush](https://rushjs.io/).
+
+### Setup repository
+
+```bash
+npm install -g @microsoft/rush 
+git clone https://github.com/snowplow/snowplow-javascript-tracker.git
+rush update
+```
+
+## Package Installation
+
+With npm:
+
+```bash
+npm install @snowplow/browser-plugin-button-click-tracking
+```
+
+## Usage
+
+Initialize your tracker with the ButtonClickTrackingPlugin:
+
+```js
+import { newTracker } from '@snowplow/browser-tracker';
+import { ButtonClickTrackingPlugin } from '@snowplow/browser-plugin-button-click-tracking';
+
+newTracker('sp1', '{{collector}}', { plugins: [ ButtonClickTrackingPlugin() ] }); // Also stores reference at module level
+```
+
+Then use the available functions from this package to track to all trackers which have been initialized with this plugin:
+
+```js
+import { enableButtonClickTracking } from '@snowplow/browser-plugin-button-click-tracking';
+
+enableButtonClickTracking({ filter: { .. }, context: { .. } });
+```
+
+For a full API reference, you can read the plugin [documentation page](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/plugins/button-click-tracking/).
+
+## Copyright and license
+
+Licensed and distributed under the [BSD 3-Clause License](LICENSE) ([An OSI Approved License][osi]).
+
+Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang.
+
+All rights reserved.
+
+[npm-url]: https://www.npmjs.com/package/@snowplow/browser-plugin-form-tracking
+[npm-image]: https://img.shields.io/npm/v/@snowplow/browser-plugin-form-tracking
+[osi]: https://opensource.org/licenses/BSD-3-Clause
+[license-image]: https://img.shields.io/npm/l/@snowplow/browser-plugin-form-tracking

--- a/plugins/browser-plugin-button-click-tracking/jest.config.js
+++ b/plugins/browser-plugin-button-click-tracking/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+  testEnvironment: 'jest-environment-jsdom-global',
+};

--- a/plugins/browser-plugin-button-click-tracking/package.json
+++ b/plugins/browser-plugin-button-click-tracking/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@snowplow/browser-plugin-button-click-tracking",
+  "version": "3.17.0",
+  "description": "Button Click tracking for Snowplow",
+  "homepage": "https://github.com/snowplow/snowplow-javascript-tracker",
+  "bugs": "https://github.com/snowplow/snowplow-javascript-tracker/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowplow/snowplow-javascript-tracker.git"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Snowplow Analytics Ltd (https://snowplow.io/)",
+  "sideEffects": false,
+  "main": "./dist/index.umd.js",
+  "module": "./dist/index.module.js",
+  "types": "./dist/index.module.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c --silent --failAfterWarnings",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@snowplow/browser-tracker-core": "workspace:*",
+    "@snowplow/tracker-core": "workspace:*",
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
+    "@rollup/plugin-commonjs": "~21.0.2",
+    "@rollup/plugin-node-resolve": "~13.1.3",
+    "@types/jest": "~27.4.1",
+    "@types/jsdom": "~16.2.14",
+    "@types/lodash": "~4.14.180",
+    "@typescript-eslint/eslint-plugin": "~5.15.0",
+    "@typescript-eslint/parser": "~5.15.0",
+    "eslint": "~8.11.0",
+    "jest": "~27.5.1",
+    "jest-environment-jsdom": "~27.5.1",
+    "jest-environment-jsdom-global": "~3.0.0",
+    "jest-standard-reporter": "~2.0.0",
+    "lodash": "~4.17.21",
+    "rollup": "~2.70.1",
+    "rollup-plugin-cleanup": "~3.2.1",
+    "rollup-plugin-license": "~2.6.1",
+    "rollup-plugin-terser": "~7.0.2",
+    "rollup-plugin-ts": "~2.0.5",
+    "ts-jest": "~27.1.3",
+    "typescript": "~4.6.2"
+  },
+  "peerDependencies": {
+    "@snowplow/browser-tracker": "~3.16.0"
+  }
+}

--- a/plugins/browser-plugin-button-click-tracking/rollup.config.js
+++ b/plugins/browser-plugin-button-click-tracking/rollup.config.js
@@ -1,0 +1,37 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
+import { banner } from '../../banner';
+import compiler from '@ampproject/rollup-plugin-closure-compiler';
+import { terser } from 'rollup-plugin-terser';
+import cleanup from 'rollup-plugin-cleanup';
+import pkg from './package.json';
+import { builtinModules } from 'module';
+
+const umdPlugins = [nodeResolve({ browser: true }), commonjs(), ts()];
+const umdName = 'snowplowButtonClickTracking';
+
+export default [
+  // CommonJS (for Node) and ES module (for bundlers) build.
+  {
+    input: './src/index.ts',
+    plugins: [...umdPlugins, banner()],
+    treeshake: { moduleSideEffects: ['sha1'] },
+    output: [{ file: pkg.main, format: 'umd', sourcemap: true, name: umdName }],
+  },
+  {
+    input: './src/index.ts',
+    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    treeshake: { moduleSideEffects: ['sha1'] },
+    output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
+  },
+  {
+    input: './src/index.ts',
+    external: [...builtinModules, ...Object.keys(pkg.dependencies), ...Object.keys(pkg.devDependencies)],
+    plugins: [
+      ts(), // so Rollup can convert TypeScript to JavaScript
+      banner(),
+    ],
+    output: [{ file: pkg.module, format: 'es', sourcemap: true }],
+  },
+];

--- a/plugins/browser-plugin-button-click-tracking/src/api.ts
+++ b/plugins/browser-plugin-button-click-tracking/src/api.ts
@@ -1,0 +1,108 @@
+import { BrowserPlugin, BrowserTracker, dispatchToTrackersInCollection } from '@snowplow/browser-tracker-core';
+import { DynamicContext, CommonEventProperties, resolveDynamicContext } from '@snowplow/tracker-core';
+
+import { createEventFromButton, filterFunctionFromFilter } from './util';
+import { buildButtonClick } from './core';
+import { ButtonClickEvent, ButtonClickTrackingConfiguration, FilterFunction } from './types';
+
+const _trackers: Record<string, BrowserTracker> = {};
+
+// The event listeners added to the document, for each tracker
+// This allows them to be removed with `removeEventListener` if button click tracking is disabled
+const _listeners: Record<string, (event: MouseEvent) => void> = {};
+
+/**
+ * Button click tracking
+ *
+ * Will automatically tracking button clicks once enabled with 'enableButtonClickTracking'
+ * or you can manually track button clicks with 'trackButtonClick'
+ */
+export function ButtonClickTrackingPlugin(): BrowserPlugin {
+  return {
+    activateBrowserPlugin: (tracker: BrowserTracker) => {
+      _trackers[tracker.id] = tracker;
+    },
+  };
+}
+
+/**
+ * Manually log a click
+ *
+ * @param event - The event information
+ * @param trackers - The tracker identifiers which the event will be sent to
+ */
+export function trackButtonClick(
+  event: ButtonClickEvent & CommonEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  dispatchToTrackersInCollection(trackers, _trackers, (t) => {
+    t.core.track(buildButtonClick(event), event.context, event.timestamp);
+  });
+}
+
+/**
+ * Enable automatic click tracking for all `<button>` and `<input type="button">` elements on the page
+ *
+ * @param configuration  - The configuration for automatic button click tracking
+ * @param trackers - The tracker identifiers which the event will be sent to
+ */
+export function enableButtonClickTracking(
+  configuration: ButtonClickTrackingConfiguration = {},
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  // Ensure that click tracking uses the latest configuration
+  // In the case of `enableButtonClickTracking` being called multiple times in a row
+  disableButtonClickTracking();
+
+  trackers.forEach((trackerId) => {
+    // Store the configuration for this tracker, if it doesn't already exist
+    // This allows us to enable click tracking for a tracker if it has been disabled
+    _listeners[trackerId] = (event: MouseEvent) => {
+      eventHandler(event, trackerId, filterFunctionFromFilter(configuration.filter), configuration.context);
+    };
+
+    const addClickListener = () => {
+      document.addEventListener('click', _listeners[trackerId]);
+    };
+
+    if (_trackers[trackerId]?.sharedState.hasLoaded) {
+      // the load event has already fired, add the click listeners now
+      addClickListener();
+    } else {
+      // defer until page has loaded
+      _trackers[trackerId]?.sharedState.registeredOnLoadHandlers.push(addClickListener);
+    }
+  });
+}
+
+/**
+ * Disable automatic click tracking for all `<button>` and `<input type="button">` elements on the page
+ *
+ * Can be re-enabled with {@link enableButtonClickTracking}
+ */
+export function disableButtonClickTracking() {
+  for (const trackerId in _trackers) {
+    if (_listeners[trackerId]) {
+      document.removeEventListener('click', _listeners[trackerId]);
+    }
+  }
+}
+
+/**
+ * Handle a click event
+ *
+ * @param event - The click event
+ * @param trackerId - The tracker identifier which the event will be sent to
+ * @param filter - The filter function to use for button click tracking
+ * @param context - The dynamic context which will be evaluated for each button click event
+ */
+function eventHandler(event: MouseEvent, trackerId: string, filter: FilterFunction, context?: DynamicContext) {
+  const elem = event.target as HTMLElement;
+  if (elem.tagName === 'BUTTON' || (elem.tagName === 'INPUT' && (elem as HTMLInputElement).type === 'button')) {
+    if (filter(elem)) {
+      const buttonClickEvent = createEventFromButton(elem as HTMLButtonElement | HTMLInputElement);
+      buttonClickEvent.context = resolveDynamicContext(context, buttonClickEvent);
+      trackButtonClick(buttonClickEvent, [trackerId]);
+    }
+  }
+}

--- a/plugins/browser-plugin-button-click-tracking/src/core.ts
+++ b/plugins/browser-plugin-button-click-tracking/src/core.ts
@@ -1,0 +1,19 @@
+import { PayloadBuilder, buildSelfDescribingEvent, removeEmptyProperties } from '@snowplow/tracker-core';
+import { ButtonClickEvent } from './types';
+
+/**
+ * Build a Button Click Event
+ * Used when a user clicks on a <button> tag on a webpage
+ *
+ * @param event - Contains the properties for the Button Click event
+ * @returns PayloadBuilder to be sent to {@link @snowplow/tracker-core#TrackerCore.track}
+ */
+export function buildButtonClick(event: ButtonClickEvent): PayloadBuilder {
+  const { label, id, classes, name } = event;
+  const eventJson = {
+    schema: 'iglu:com.snowplowanalytics.snowplow/button_click/jsonschema/1-0-0',
+    data: removeEmptyProperties({ label, id, classes, name }),
+  };
+
+  return buildSelfDescribingEvent({ event: eventJson });
+}

--- a/plugins/browser-plugin-button-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-button-click-tracking/src/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/plugins/browser-plugin-button-click-tracking/src/types.ts
+++ b/plugins/browser-plugin-button-click-tracking/src/types.ts
@@ -1,0 +1,47 @@
+import { DynamicContext } from '@snowplow/tracker-core';
+
+/** A list of CSS classes that will have their clicks tracked */
+export type AllowList = { allowlist: string[] };
+
+/** A list of CSS classes that will _not_ have their clicks tracked */
+export type DenyList = { denylist: string[] };
+
+/** A function which determines whether a button click should be tracked */
+export type FilterFunction = (element: HTMLElement) => boolean;
+
+/** A filter for button click tracking */
+export type Filter = AllowList | DenyList | FilterFunction;
+
+/** The configuration for automatic button click tracking */
+export interface ButtonClickTrackingConfiguration {
+  /** The filter options for the button click tracking */
+  filter?: Filter;
+  /** The dynamic context which will be evaluated for each button click event */
+  context?: DynamicContext;
+}
+
+/**
+ * A Button Click event
+ *
+ * Used when a user clicks on a <button> tag on a webpage
+ * <input type="submit"> tags are intentionally not tracked by this event,
+ * as this functionality is provided by the Form Tracking plugin
+ * see: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/plugins/form-tracking/
+ */
+export interface ButtonClickEvent {
+  /** The text on the button clicked
+   *
+   * This can be overridden by setting the `data-sp-button-label` attribute on the button:
+   *
+   * `<button data-sp-button-label="show-modal">Click Here!</button>`
+   *
+   * will result in `{ label: 'show-modal' }`
+   */
+  label: string;
+  /** The ID of the button clicked, if present */
+  id?: string;
+  /** An array of class names from the button clicked */
+  classes?: Array<string>;
+  /** The name of the button, if present */
+  name?: string;
+}

--- a/plugins/browser-plugin-button-click-tracking/src/util.ts
+++ b/plugins/browser-plugin-button-click-tracking/src/util.ts
@@ -1,0 +1,60 @@
+import { CommonEventProperties } from '@snowplow/tracker-core';
+import { ButtonClickEvent, Filter, FilterFunction } from './types';
+
+/**
+ * Convert any {@link Filter} or undefined into a {@link FilterFunction}
+ *
+ * @param filter - The filter to convert
+ * @returns The filter function
+ */
+export function filterFunctionFromFilter(filter?: Filter): FilterFunction {
+  // If a function is provided, return it as-is
+  if (typeof filter === 'function') {
+    return filter;
+  }
+
+  if (typeof filter === 'object') {
+    // If an allowlist is provided, return a function which matches the allowlist
+    if ('allowlist' in filter) {
+      return (element) => {
+        const classes = Array.from(element?.classList || []);
+        return classes.some((className) => filter.allowlist.includes(className));
+      };
+    }
+
+    // If a denylist is provided, return a function which matches the denylist
+    if ('denylist' in filter) {
+      return (element) => {
+        const classes = Array.from(element?.classList || []);
+        return !classes.some((className) => filter.denylist.includes(className));
+      };
+    }
+  }
+
+  // Return a function that will match all buttons if no filter is provided
+  return () => true;
+}
+
+/**
+ * Creates a {@link ButtonClickEvent} from a button element
+ *
+ * @param button - The button element to create the event from
+ * @returns The button click event
+ */
+export function createEventFromButton(
+  button: HTMLButtonElement | HTMLInputElement
+): ButtonClickEvent & CommonEventProperties {
+  let ret = {} as ButtonClickEvent & CommonEventProperties;
+
+  if (button.tagName === 'INPUT') {
+    ret.label = button.dataset.spButtonLabel || button.value;
+  } else {
+    ret.label = button.dataset.spButtonLabel || button.innerText;
+  }
+
+  button.id && (ret.id = button.id);
+  button.name && (ret.name = button.name);
+  button.classList.length && (ret.classes = Array.from(button.classList));
+
+  return ret;
+}

--- a/plugins/browser-plugin-button-click-tracking/test/test.test.ts
+++ b/plugins/browser-plugin-button-click-tracking/test/test.test.ts
@@ -1,0 +1,185 @@
+import { filterFunctionFromFilter, createEventFromButton } from '../src/util';
+
+describe('Button Click Tracking Plugin', () => {
+  describe('filterToFunction', () => {
+    const createDiv = (className: string): HTMLDivElement => {
+      const ret = document.createElement('div');
+      ret.className = className;
+      return ret;
+    };
+
+    it('should return a function that returns true if no filter is provided', () => {
+      const filter = filterFunctionFromFilter(undefined);
+      expect(filter(createDiv(''))).toBe(true);
+    });
+
+    it('should turn an allowlist into a filter function', () => {
+      const filter = filterFunctionFromFilter({ allowlist: ['foo'] });
+      expect(filter(createDiv('foo'))).toBe(true);
+      expect(filter(createDiv('bar'))).toBe(false);
+    });
+
+    it('should turn a denylist into a filter function', () => {
+      const filter = filterFunctionFromFilter({ denylist: ['foo'] });
+      expect(filter(createDiv('foo'))).toBe(false);
+      expect(filter(createDiv('bar'))).toBe(true);
+    });
+  });
+
+  describe('getFilterPassingButtons', () => {
+    type TestDocument = {
+      testDocument: Document;
+      include_btn: HTMLButtonElement | HTMLInputElement;
+      exclude_btn: HTMLButtonElement | HTMLInputElement;
+    };
+
+    describe('HTMLButtonElements', () => {
+      const getTestDocument = (): TestDocument => {
+        const testDocument = document.implementation.createHTMLDocument('test');
+        const include_btn = testDocument.createElement('button');
+        include_btn.className = 'include';
+        testDocument.body.appendChild(include_btn);
+        const exclude_btn = testDocument.createElement('button');
+        exclude_btn.className = 'exclude';
+        testDocument.body.appendChild(exclude_btn);
+
+        return {
+          testDocument,
+          include_btn,
+          exclude_btn,
+        };
+      };
+
+      const { testDocument, include_btn, exclude_btn } = getTestDocument();
+      const buttons = Array.from(testDocument.getElementsByTagName('button'));
+
+      it('should return all elements if no filter is provided', () => {
+        const buttonFilter = filterFunctionFromFilter(undefined);
+        const filteredButtons = buttons.filter(buttonFilter);
+        expect(filteredButtons).toEqual([include_btn, exclude_btn]);
+      });
+
+      it('should only return elements that match the `filter` function', () => {
+        const filter = filterFunctionFromFilter((element?: HTMLElement) => element?.className === 'include');
+        const filteredButtons = buttons.filter(filter);
+        expect(filteredButtons).toEqual([include_btn]);
+      });
+
+      it('should return all elements with the classes in `allowlist`', () => {
+        const filter = filterFunctionFromFilter({ allowlist: ['include'] });
+        const filteredButtons = buttons.filter(filter);
+        expect(filteredButtons).toEqual([include_btn]);
+      });
+
+      it('should not return any elements with the classes in `denylist`', () => {
+        const filter = filterFunctionFromFilter({ denylist: ['exclude'] });
+        const filteredButtons = buttons.filter(filter);
+        expect(filteredButtons).toEqual([include_btn]);
+      });
+    });
+
+    describe('HTMLInputElement', () => {
+      const getTestDocument = (): TestDocument => {
+        const testDocument = document.implementation.createHTMLDocument('test');
+        const include_btn = testDocument.createElement('input');
+        include_btn.type = 'button';
+        include_btn.className = 'include';
+        testDocument.body.appendChild(include_btn);
+        const exclude_btn = testDocument.createElement('input');
+        exclude_btn.type = 'button';
+        exclude_btn.className = 'exclude';
+        testDocument.body.appendChild(exclude_btn);
+
+        return {
+          testDocument,
+          include_btn,
+          exclude_btn,
+        };
+      };
+
+      const { testDocument, include_btn, exclude_btn } = getTestDocument();
+      const buttons = Array.from(testDocument.getElementsByTagName('input')).filter((input) => input.type === 'button');
+
+      it('should return all elements if no filter is provided', () => {
+        const buttonFilter = filterFunctionFromFilter(undefined);
+        const filteredButtons = buttons.filter(buttonFilter);
+        expect(filteredButtons).toEqual([include_btn, exclude_btn]);
+      });
+
+      it('should only return elements that match the `filter` function', () => {
+        const filter = filterFunctionFromFilter((element?: HTMLElement) => element?.className === 'include');
+        const filteredButtons = buttons.filter(filter);
+        expect(filteredButtons).toEqual([include_btn]);
+      });
+
+      it('should return all elements with the classes in `allowlist`', () => {
+        const filter = filterFunctionFromFilter({ allowlist: ['include'] });
+        const filteredButtons = buttons.filter(filter);
+        expect(filteredButtons).toEqual([include_btn]);
+      });
+
+      it('should not return any elements with the classes in `denylist`', () => {
+        const filter = filterFunctionFromFilter({ denylist: ['exclude'] });
+        const filteredButtons = buttons.filter(filter);
+        expect(filteredButtons).toEqual([include_btn]);
+      });
+    });
+  });
+
+  describe('createEventFromButton', () => {
+    describe('HTMLButtonElement', () => {
+      it('should create an event from a button', () => {
+        const button = document.createElement('button');
+        button.innerText = 'testLabel';
+        button.id = 'testId';
+        button.className = 'testClass testClass2';
+        button.name = 'testName';
+
+        const event = {
+          label: 'testLabel',
+          id: 'testId',
+          classes: ['testClass', 'testClass2'],
+          name: 'testName',
+        };
+
+        expect(createEventFromButton(button)).toEqual(event);
+      });
+
+      it('should prefer the data-sp-button-label attribute over the innerText', () => {
+        const button = document.createElement('button');
+        button.innerText = 'testLabel';
+
+        button.setAttribute('data-sp-button-label', 'testLabelFromAttribute');
+        expect(createEventFromButton(button).label).toEqual('testLabelFromAttribute');
+      });
+    });
+    describe('HTMLInputElement', () => {
+      it('should create an event from an input', () => {
+        const input = document.createElement('input');
+        input.type = 'button';
+        input.value = 'testLabel';
+        input.id = 'testId';
+        input.className = 'testClass testClass2';
+        input.name = 'testName';
+
+        const event = {
+          label: 'testLabel',
+          id: 'testId',
+          classes: ['testClass', 'testClass2'],
+          name: 'testName',
+        };
+
+        expect(createEventFromButton(input)).toEqual(event);
+      });
+
+      it('should prefer the data-sp-button-label attribute over the value', () => {
+        const input = document.createElement('input');
+        input.type = 'button';
+        input.value = 'testLabel';
+
+        input.setAttribute('data-sp-button-label', 'testLabelFromAttribute');
+        expect(createEventFromButton(input).label).toEqual('testLabelFromAttribute');
+      });
+    });
+  });
+});

--- a/plugins/browser-plugin-button-click-tracking/tsconfig.json
+++ b/plugins/browser-plugin-button-click-tracking/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/rush.json
+++ b/rush.json
@@ -577,6 +577,12 @@
       "projectFolder": "plugins/browser-plugin-focalmeter",
       "reviewCategory": "plugins",
       "versionPolicyName": "tracker"
+    },
+    {
+      "projectFolder": "plugins/browser-plugin-button-click-tracking",
+      "packageName": "@snowplow/browser-plugin-button-click-tracking",
+      "reviewCategory": "plugins",
+      "versionPolicyName": "tracker"
     }
   ]
 }

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -65,7 +65,8 @@
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
     "@snowplow/browser-plugin-enhanced-consent": "workspace:*",
-    "@snowplow/browser-plugin-privacy-sandbox": "workspace:*"
+    "@snowplow/browser-plugin-privacy-sandbox": "workspace:*",
+    "@snowplow/browser-plugin-button-click-tracking": "workspace:*"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",

--- a/trackers/javascript-tracker/src/features.ts
+++ b/trackers/javascript-tracker/src/features.ts
@@ -54,6 +54,7 @@ import * as EnhancedConsent from '@snowplow/browser-plugin-enhanced-consent';
 import * as SnowplowMedia from '@snowplow/browser-plugin-media';
 import * as VimeoTracking from '@snowplow/browser-plugin-vimeo-tracking';
 import * as PrivacySandbox from '@snowplow/browser-plugin-privacy-sandbox';
+import * as ButtonClickTracking from '@snowplow/browser-plugin-button-click-tracking';
 
 /**
  * Calculates the required plugins to intialise per tracker
@@ -213,6 +214,11 @@ export function Plugins(configuration: JavaScriptTrackerConfiguration) {
   if (plugins.privacySandbox) {
     const { PrivacySandboxPlugin, ...apiMethods } = PrivacySandbox;
     activatedPlugins.push([PrivacySandboxPlugin(), apiMethods]);
+  }
+
+  if (plugins.buttonClickTracking) {
+    const { ButtonClickTrackingPlugin, ...apiMethods } = ButtonClickTracking;
+    activatedPlugins.push([ButtonClickTrackingPlugin(), apiMethods]);
   }
 
   return activatedPlugins;

--- a/trackers/javascript-tracker/test/integration/buttonClick.test.ts
+++ b/trackers/javascript-tracker/test/integration/buttonClick.test.ts
@@ -1,0 +1,149 @@
+import F from 'lodash/fp';
+import { fetchResults } from '../micro';
+import { pageSetup } from './helpers';
+
+const loadUrlAndWait = async (url: string) => {
+  await browser.url(url);
+  await browser.waitUntil(async () => (await $('#init').getText()) === 'true', {
+    timeout: 5000,
+    timeoutMsg: 'expected init after 5s',
+  });
+};
+
+describe('Snowplow Micro integration', () => {
+  if (browser.capabilities.browserName === 'internet explorer') {
+    fit('Skip IE', () => true);
+    return;
+  }
+
+  let eventMethods = ['get', 'post', 'beacon'];
+  let log: Array<any> = [];
+  let testIdentifier = '';
+
+  const logContains = (ev: unknown) => F.some(F.isMatch(ev as object), log);
+
+  type Button = {
+    label: string;
+    id?: string;
+    classes?: Array<string>;
+    name?: string;
+  };
+
+  const makeEvent = (button: Button, method: string) => {
+    return {
+      event: {
+        event: 'unstruct',
+        app_id: 'button-click-tracking-' + testIdentifier,
+        page_url: `http://snowplow-js-tracker.local:8080/button-click-tracking.html?eventMethod=${method}`,
+        unstruct_event: {
+          data: {
+            schema: 'iglu:com.snowplowanalytics.snowplow/button_click/jsonschema/1-0-0',
+            data: button,
+          },
+        },
+      },
+    };
+  };
+
+  const logContainsButtonClick = (event: any) => {
+    expect(logContains(event)).toBe(true);
+  };
+
+  const nButtons = 7;
+  beforeAll(async () => {
+    testIdentifier = await pageSetup();
+
+    const runClicks = async (method: string) => {
+      await loadUrlAndWait('/button-click-tracking.html?eventMethod=' + method);
+      for (let i = 1; i < nButtons; i++) {
+        await (await $(`#button${i}`)).click();
+        await browser.pause(50);
+      }
+      // Dynamic button
+      await (await $('#addDynamic')).click();
+      await browser.pause(500);
+      await (await $('#button7')).click();
+      await browser.pause(500);
+
+      // Disable/enable
+
+      await (await $('#disable')).click();
+      await browser.pause(500);
+      await (await $('#disabled-click')).click();
+      await browser.pause(500);
+
+      await (await $('#enable')).click();
+      await browser.pause(500);
+      await (await $('#enabled-click')).click();
+      await browser.pause(500);
+
+      await (await $('#set-multiple-configs')).click();
+      await browser.pause(500);
+
+      await (await $('#final-config')).click();
+      await browser.pause(500);
+    };
+
+    for (let method of eventMethods) {
+      await runClicks(method);
+      await browser.pause(6000);
+    }
+
+    log = await browser.call(async () => await fetchResults());
+  });
+
+  eventMethods.forEach((method) => {
+    it('should get button1', () => {
+      const ev = makeEvent({ id: 'button1', label: 'TestButton' }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should get button2', () => {
+      const ev = makeEvent({ id: 'button2', label: 'TestButtonWithClass', classes: ['test-class'] }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should get button3', () => {
+      const ev = makeEvent(
+        { id: 'button3', label: 'TestButtonWithClasses', classes: ['test-class', 'test-class2'] },
+        method
+      );
+      logContainsButtonClick(ev);
+    });
+
+    it('should get button4', () => {
+      const ev = makeEvent({ id: 'button4', label: 'TestWithName', name: 'testName' }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should get button5', () => {
+      const ev = makeEvent({ id: 'button5', label: 'DataLabel' }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should get button6', () => {
+      const ev = makeEvent({ id: 'button6', label: 'TestInputButton' }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should get button7 after it is added dynamically', async () => {
+      const ev = makeEvent({ id: 'button7', label: 'TestDynamicButton-' + method }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should not get disabled-click', () => {
+      const ev = makeEvent({ id: 'disabled-click', label: 'DisabledClick' }, method);
+      expect(logContains(ev)).toBe(false);
+    });
+
+    it('should get enabled-click', () => {
+      const ev = makeEvent({ id: 'enabled-click', label: 'EnabledClick' }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should get `final-config` as it is the last config set', () => {
+      const ev = makeEvent({ id: 'final-config', classes: ['final-config'], label: 'Final Config' }, method);
+      logContainsButtonClick(ev);
+    });
+  });
+});

--- a/trackers/javascript-tracker/test/pages/button-click-tracking.html
+++ b/trackers/javascript-tracker/test/pages/button-click-tracking.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page for Link Click testing with Snowplow Micro</title>
+
+    <script>
+      function parseQuery() {
+        var query = {};
+        var pairs = window.location.search.substring(1).split('&');
+        for (var i = 0; i < pairs.length; i++) {
+          var pair = pairs[i].split('=');
+          query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
+        }
+        return query;
+      }
+    </script>
+  </head>
+  <body>
+    <p id="title">Page for Button Click testing with Snowplow Micro</p>
+    <div id="init"></div>
+    <button>TestMinimalButton</button>
+    <button id="button1">TestButton</button>
+    <button id="button2" class="test-class">TestButtonWithClass</button>
+    <button id="button3" class="test-class test-class2">TestButtonWithClasses</button>
+    <button id="button4" name="testName">TestWithName</button>
+
+    <!-- Test to ensure the `data-sp-button-label` attribute takes precedence -->
+    <button id="button5" data-sp-button-label="DataLabel">ButtonLabel</button>
+
+    <!-- Test to ensure input buttons work -->
+    <input id="button6" type="button" value="TestInputButton" />
+
+    <!-- A button that adds a new button dynamically -->
+    <button id="addDynamic" onclick="addDynamicButton()">AddButton</button>
+
+    <!-- Enable/disable testing -->
+    <button id="disable" onclick="snowplow('disableButtonClickTracking')">Disable</button>
+    <button id="disabled-click">DisabledClick</button>
+
+    <button id="enable" onclick="snowplow('enableButtonClickTracking')">Enable</button>
+    <button id="enabled-click">EnabledClick</button>
+
+    <!-- Ensuring the final config is used after multiple calls to `enableButtonClickTracking` -->
+    <button id="set-multiple-configs" onClick="setMultipleConfigs">Set Multiple Configs</button>
+    <button id="final-config" class="final-config">Final Config</button>
+
+    <script>
+      function setMultipleConfigs() {
+        enableButtonClickTracking({ denylist: ['final-config'] });
+        enableButtonClickTracking();
+      }
+    </script>
+
+    <script>
+      var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
+      document.body.className += ' loaded';
+    </script>
+
+    <script>
+      function addDynamicButton() {
+        // Add a new dynamic button
+        const newButton = document.createElement('button');
+        newButton.id = 'button7';
+        newButton.innerText = 'TestDynamicButton-' + parseQuery().eventMethod;
+        document.body.appendChild(newButton);
+      }
+    </script>
+
+    <script>
+      (function (p, l, o, w, i, n, g) {
+        if (!p[i]) {
+          p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
+          p.GlobalSnowplowNamespace.push(i);
+          p[i] = function () {
+            (p[i].q = p[i].q || []).push(arguments);
+          };
+          p[i].q = p[i].q || [];
+          n = l.createElement(o);
+          g = l.getElementsByTagName(o)[0];
+          n.async = 1;
+          n.src = w;
+          g.parentNode.insertBefore(n, g);
+        }
+      })(window, document, 'script', './snowplow.js', 'snowplow');
+
+      document.write(collector_endpoint);
+
+      snowplow('newTracker', 'sp', collector_endpoint, {
+        appId: 'button-click-tracking-' + testIdentifier,
+        method: parseQuery().eventMethod,
+      });
+      snowplow(function () {
+        document.getElementById('init').innerText = 'true';
+      });
+
+      snowplow('enableButtonClickTracking');
+    </script>
+  </body>
+</html>

--- a/trackers/javascript-tracker/tracker.config.ts
+++ b/trackers/javascript-tracker/tracker.config.ts
@@ -51,3 +51,4 @@ export const enhancedConsent = false;
 export const snowplowMedia = false;
 export const vimeoTracking = false;
 export const privacySandbox = false;
+export const buttonClickTracking = false;

--- a/trackers/javascript-tracker/tracker.lite.config.ts
+++ b/trackers/javascript-tracker/tracker.lite.config.ts
@@ -51,3 +51,4 @@ export const enhancedConsent = false;
 export const snowplowMedia = false;
 export const vimeoTracking = false;
 export const privacySandbox = false;
+export const buttonClickTracking = false;

--- a/trackers/javascript-tracker/tracker.test.config.ts
+++ b/trackers/javascript-tracker/tracker.test.config.ts
@@ -51,3 +51,4 @@ export const enhancedConsent = false;
 export const snowplowMedia = true;
 export const vimeoTracking = true;
 export const privacySandbox = false;
+export const buttonClickTracking = true;


### PR DESCRIPTION
This PR adds a plugin for automatic button click tracking, similar to the existing link click tracking.

It provides a single method, `enableButtonClickTracking`. Which accepts a couple of options:

### `enableButtonClickTracking.filter`

This allows the user to provide either an allowlist, denylist, or a custom callback, that will only track a click if the element that has been clicked on passes the filter, for example of a function filter that will accept the following button:

```html
<button id="my-cool-button">Click Here</button>
```

```TS
filter: (elem: HtmlElement) => elem.id === "my-cool-button")
```

### `enableButtonClickTracking.context`

Allows attaching a [dynamic entity](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/custom-tracking-using-schemas/global-context/#dynamic-entities) to the button click events.


note: The integration tests won't pass on CI, as the button click schema isn't on Iglu Central yet (see https://github.com/snowplow/iglu-central/compare/master...release/r150)
