### PR TITLE
Track mailto links in link click tracking (close #1270)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/issue-mailto_links_2023-12-01-10-15.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/issue-mailto_links_2023-12-01-10-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-link-click-tracking",
+      "comment": "Track mailto links in link click tracking (#1270)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking"
+}

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -177,7 +177,7 @@ function processClick(tracker: BrowserTracker, sourceElement: Element, context?:
     var originalSourceHostName = anchorElement.hostname || getHostName(anchorElement.href),
       sourceHostName = originalSourceHostName.toLowerCase(),
       sourceHref = anchorElement.href.replace(originalSourceHostName, sourceHostName),
-      scriptProtocol = new RegExp('^(javascript|vbscript|jscript|mocha|livescript|ecmascript|mailto):', 'i');
+      scriptProtocol = new RegExp('^(javascript|vbscript|jscript|mocha|livescript|ecmascript):', 'i');
 
     // Ignore script pseudo-protocol links
     if (!scriptProtocol.test(sourceHref)) {


### PR DESCRIPTION
This amazing piece of work addresses issue #1270 and adds support for tracking `mailto:` links in the link click tracking plugin.