### PR TITLE
Do not set the previous session ID reference in cookies if anonymous tracking is enabled (close #1268)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-1268-previous_session_id_anonymous_tracking_2023-12-12-13-35.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1268-previous_session_id_anonymous_tracking_2023-12-12-13-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Do not set the previous session ID reference in cookies if anonymous tracking is enabled (#1268)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/tracker/id_cookie.ts
+++ b/libraries/browser-tracker-core/src/tracker/id_cookie.ts
@@ -256,9 +256,17 @@ export function incrementEventIndexInIdCookie(idCookie: ParsedIdCookie) {
  * @param idCookie Parsed cookie
  * @returns String cookie value
  */
-export function serializeIdCookie(idCookie: ParsedIdCookie) {
-  idCookie.shift();
-  return idCookie.join('.');
+export function serializeIdCookie(idCookie: ParsedIdCookie, configAnonymousTracking: boolean) {
+  const propertiesToAnonymize = [domainUserIdIndex, previousSessionIdIndex];
+  const anonymizedIdCookie = idCookie.map((value, index) => {
+    if (configAnonymousTracking && propertiesToAnonymize.includes(index)) {
+      return '';
+    } else {
+      return value;
+    }
+  });
+  anonymizedIdCookie.shift();
+  return anonymizedIdCookie.join('.');
 }
 
 /**

--- a/libraries/browser-tracker-core/src/tracker/id_cookie.ts
+++ b/libraries/browser-tracker-core/src/tracker/id_cookie.ts
@@ -257,14 +257,11 @@ export function incrementEventIndexInIdCookie(idCookie: ParsedIdCookie) {
  * @returns String cookie value
  */
 export function serializeIdCookie(idCookie: ParsedIdCookie, configAnonymousTracking: boolean) {
-  const propertiesToAnonymize = [domainUserIdIndex, previousSessionIdIndex];
-  const anonymizedIdCookie = idCookie.map((value, index) => {
-    if (configAnonymousTracking && propertiesToAnonymize.includes(index)) {
-      return '';
-    } else {
-      return value;
-    }
-  });
+  const anonymizedIdCookie: (string | number | undefined)[] = [...idCookie];
+  if (configAnonymousTracking) {
+    anonymizedIdCookie[domainUserIdIndex] = '';
+    anonymizedIdCookie[previousSessionIdIndex] = '';
+  }
   anonymizedIdCookie.shift();
   return anonymizedIdCookie.join('.');
 }

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -586,7 +586,7 @@ export function Tracker(
      */
     function setDomainUserIdCookie(idCookie: ParsedIdCookie) {
       const cookieName = getSnowplowCookieName('id');
-      const cookieValue = serializeIdCookie(idCookie);
+      const cookieValue = serializeIdCookie(idCookie, configAnonymousTracking);
       return persistValue(cookieName, cookieValue, configVisitorCookieTimeout);
     }
 

--- a/libraries/browser-tracker-core/test/id_cookie.test.ts
+++ b/libraries/browser-tracker-core/test/id_cookie.test.ts
@@ -262,7 +262,12 @@ describe('incrementEventIndexInIdCookie', () => {
 describe('serializeIdCookie', () => {
   it("Doesn't change the original cookie", () => {
     let cookie = `def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9`;
-    expect(serializeIdCookie(parseIdCookie(cookie, '', '', 0))).toBe(cookie);
+    expect(serializeIdCookie(parseIdCookie(cookie, '', '', 0), false)).toBe(cookie);
+  });
+
+  it("Doesn't include domain user ID and previous session ID in case of anonymous tracking", () => {
+    let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9', '', '', 0);
+    expect(serializeIdCookie(idCookie, true)).toBe('.1653632272.10.1653632282.1653632262.ses..fid.1653632252.9');
   });
 });
 


### PR DESCRIPTION
Issue #1268 

Addresses the issue where the previous session ID reference was updated in the cookies even in case anonymous tracking (with session tracking was enabled).

This was a problem, because the cookie value is sent as an HTTP header along with requests. It allowed one to use a cookie enrichment to inspect the value and use the previous session ID reference to basically reconstruct the user identifier (join together their previous sessions).

To solve the issue, I updated the function that serializes the cookie value to accept a flag whether anonymous tracking is enabled. In case it is enabled, we skip serializing the domain user ID and the previous session ID.