### PR TITLE
Release/3.19.0

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -215,6 +215,9 @@ export interface EnableAnonymousTrackingConfiguration {
     stateStorageStrategy?: StateStorageStrategy;
 }
 
+// @public
+export type EventBatch = GetBatch | PostBatch;
+
 // @public (undocumented)
 export type EventMethod = "post" | "get" | "beacon";
 
@@ -235,6 +238,9 @@ export interface FlushBufferConfiguration {
 }
 
 // @public
+export type GetBatch = string[];
+
+// @public
 export function newSession(trackers?: Array<string>): void;
 
 // @public
@@ -253,10 +259,21 @@ export interface PageViewEvent {
 export type Platform = "web" | "mob" | "pc" | "srv" | "app" | "tv" | "cnsl" | "iot";
 
 // @public
+export type PostBatch = Record<string, unknown>[];
+
+// @public
 export function preservePageViewId(trackers?: Array<string>): void;
 
 // @public
 export function removeGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive>, trackers?: Array<string>): void;
+
+// @public
+export type RequestFailure = {
+    events: EventBatch;
+    status?: number;
+    message?: string;
+    willRetry: boolean;
+};
 
 // @public
 export interface RuleSet {
@@ -370,6 +387,8 @@ export type TrackerConfiguration = {
     onSessionUpdateCallback?: (updatedSession: ClientSession) => void;
     idService?: string;
     retryFailedRequests?: boolean;
+    onRequestSuccess?: (data: EventBatch) => void;
+    onRequestFailure?: (data: RequestFailure) => void;
 };
 
 // @public

--- a/common/changes/@snowplow/browser-plugin-web-vitals/wv-context_2023-12-12-00-59.json
+++ b/common/changes/@snowplow/browser-plugin-web-vitals/wv-context_2023-12-12-00-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-web-vitals",
+      "comment": "Add `context` support for the web_vitals event",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-web-vitals"
+}

--- a/common/changes/@snowplow/browser-tracker-core/issue-1268-previous_session_id_anonymous_tracking_2023-12-12-13-35.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1268-previous_session_id_anonymous_tracking_2023-12-12-13-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Do not set the previous session ID reference in cookies if anonymous tracking is enabled (#1268)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker-core/issue-1275-fix-config-for-callbacks_2023-12-13-13-14.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1275-fix-config-for-callbacks_2023-12-13-13-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Fix config for callbacks",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-1275-fix-config-for-callbacks_2023-12-13-14-30.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1275-fix-config-for-callbacks_2023-12-13-14-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Update API docs for callbacks",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/id_cookie.ts
+++ b/libraries/browser-tracker-core/src/tracker/id_cookie.ts
@@ -256,9 +256,14 @@ export function incrementEventIndexInIdCookie(idCookie: ParsedIdCookie) {
  * @param idCookie Parsed cookie
  * @returns String cookie value
  */
-export function serializeIdCookie(idCookie: ParsedIdCookie) {
-  idCookie.shift();
-  return idCookie.join('.');
+export function serializeIdCookie(idCookie: ParsedIdCookie, configAnonymousTracking: boolean) {
+  const anonymizedIdCookie: (string | number | undefined)[] = [...idCookie];
+  if (configAnonymousTracking) {
+    anonymizedIdCookie[domainUserIdIndex] = '';
+    anonymizedIdCookie[previousSessionIdIndex] = '';
+  }
+  anonymizedIdCookie.shift();
+  return anonymizedIdCookie.join('.');
 }
 
 /**

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -588,7 +588,7 @@ export function Tracker(
      */
     function setDomainUserIdCookie(idCookie: ParsedIdCookie) {
       const cookieName = getSnowplowCookieName('id');
-      const cookieValue = serializeIdCookie(idCookie);
+      const cookieValue = serializeIdCookie(idCookie, configAnonymousTracking);
       return persistValue(cookieName, cookieValue, configVisitorCookieTimeout);
     }
 

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -304,7 +304,9 @@ export function Tracker(
         trackerConfiguration.retryStatusCodes ?? [],
         (trackerConfiguration.dontRetryStatusCodes ?? []).concat([400, 401, 403, 410, 422]),
         trackerConfiguration.idService,
-        trackerConfiguration.retryFailedRequests
+        trackerConfiguration.retryFailedRequests,
+        trackerConfiguration.onRequestSuccess,
+        trackerConfiguration.onRequestFailure
       ),
       // Whether pageViewId should be regenerated after each trackPageView. Affect web_page context
       preservePageViewId = false,

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -232,6 +232,21 @@ export type TrackerConfiguration = {
    * @defaultValue true
    */
   retryFailedRequests?: boolean;
+  /**
+   * a callback function to be executed whenever a request is successfully sent to the collector.
+   * In practice this means any request which returns a 2xx status code will trigger this callback.
+   *
+   * @param data - The event batch that was successfully sent
+   */
+  onRequestSuccess?: (data: EventBatch) => void;
+
+  /**
+   * a callback function to be executed whenever a request fails to be sent to the collector.
+   * This is the inverse of the onRequestSuccess callback, so any non 2xx status code will trigger this callback.
+   *
+   * @param data - The data associated with the event(s) that failed to send
+   */
+  onRequestFailure?: (data: RequestFailure) => void;
 };
 
 /**

--- a/libraries/browser-tracker-core/test/id_cookie.test.ts
+++ b/libraries/browser-tracker-core/test/id_cookie.test.ts
@@ -262,7 +262,12 @@ describe('incrementEventIndexInIdCookie', () => {
 describe('serializeIdCookie', () => {
   it("Doesn't change the original cookie", () => {
     let cookie = `def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9`;
-    expect(serializeIdCookie(parseIdCookie(cookie, '', '', 0))).toBe(cookie);
+    expect(serializeIdCookie(parseIdCookie(cookie, '', '', 0), false)).toBe(cookie);
+  });
+
+  it("Doesn't include domain user ID and previous session ID in case of anonymous tracking", () => {
+    let idCookie = parseIdCookie('def.1653632272.10.1653632282.1653632262.ses.previous.fid.1653632252.9', '', '', 0);
+    expect(serializeIdCookie(idCookie, true)).toBe('.1653632272.10.1653632282.1653632262.ses..fid.1653632252.9');
   });
 });
 

--- a/plugins/browser-plugin-web-vitals/README.md
+++ b/plugins/browser-plugin-web-vitals/README.md
@@ -43,7 +43,8 @@ newTracker('sp1', '{{collector}}', { plugins: [ WebVitalsPlugin(/* pluginOptions
  * {
  *  loadWebVitalsScript: Should the plugin immediately load the Core Web Vitals measurement script from UNPKG CDN.
  *  webVitalsSource: The URL endpoint the Web Vitals script should be loaded from. Defaults to the UNPKG CDN.
- * } 
+ *  context: Array of entity objects or entity-generating functions (the web_vitals payload is passed as a parameter) to attach to the web_vitals event.
+ * }
  */
 ```
 

--- a/plugins/browser-plugin-web-vitals/src/index.ts
+++ b/plugins/browser-plugin-web-vitals/src/index.ts
@@ -1,5 +1,5 @@
 import { BrowserPlugin, BrowserTracker, dispatchToTrackersInCollection } from '@snowplow/browser-tracker-core';
-import { buildSelfDescribingEvent } from '@snowplow/tracker-core';
+import { DynamicContext, buildSelfDescribingEvent, resolveDynamicContext } from '@snowplow/tracker-core';
 import { WEB_VITALS_SCHEMA } from './schemata';
 import { attachWebVitalsPageListeners, createWebVitalsScript, webVitalsListener } from './utils';
 
@@ -10,11 +10,13 @@ let listenersAttached = false;
 interface WebVitalsPluginOptions {
   loadWebVitalsScript?: boolean;
   webVitalsSource?: string;
+  context?: DynamicContext;
 }
 
 const defaultPluginOptions = {
   loadWebVitalsScript: true,
   webVitalsSource: WEB_VITALS_SOURCE,
+  context: [],
 };
 
 /**
@@ -45,7 +47,8 @@ export function WebVitalsPlugin(pluginOptions: WebVitalsPluginOptions = defaultP
                 schema: WEB_VITALS_SCHEMA,
                 data: webVitalsObject,
               },
-            })
+            }),
+            resolveDynamicContext(options.context ?? [], webVitalsObject)
           );
         });
       }

--- a/plugins/browser-plugin-web-vitals/test/__snapshots__/web-vitals.test.ts.snap
+++ b/plugins/browser-plugin-web-vitals/test/__snapshots__/web-vitals.test.ts.snap
@@ -14,3 +14,19 @@ Object {
   "schema": "iglu:com.snowplowanalytics.snowplow/web_vitals/jsonschema/1-0-0",
 }
 `;
+
+exports[`Web Vitals plugin Returns values for Web Vitals properties: context 1`] = `
+Array [
+  Object {
+    "data": Array [
+      Object {
+        "data": Object {
+          "ok": true,
+        },
+        "schema": "iglu:com.example/test/jsonschema/1-0-0",
+      },
+    ],
+    "schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0",
+  },
+]
+`;

--- a/plugins/browser-plugin-web-vitals/test/web-vitals.test.ts
+++ b/plugins/browser-plugin-web-vitals/test/web-vitals.test.ts
@@ -40,13 +40,17 @@ describe('Web Vitals plugin', () => {
     const core = trackerCore({
       corePlugins: [],
       callback: (payloadBuilder) => {
-        const { data } = payloadBuilder.getJson()[0].json;
-        expect(data).toMatchSnapshot();
+        const [data, ...context] = payloadBuilder.getJson();
+        expect(data.json.data).toMatchSnapshot();
+        expect(context.map(({ json }) => json)).toMatchSnapshot('context');
         done();
       },
     });
 
-    WebVitalsPlugin({ loadWebVitalsScript: false }).activateBrowserPlugin?.({ core } as BrowserTracker);
+    WebVitalsPlugin({
+      loadWebVitalsScript: false,
+      context: [{ schema: 'iglu:com.example/test/jsonschema/1-0-0', data: { ok: true } }],
+    }).activateBrowserPlugin?.({ core } as BrowserTracker);
     const pagehideEvent = new PageTransitionEvent('pagehide');
     jsdom.window.dispatchEvent(pagehideEvent);
   });

--- a/trackers/browser-tracker/src/index.ts
+++ b/trackers/browser-tracker/src/index.ts
@@ -38,6 +38,10 @@ import {
   EventMethod,
   StateStorageStrategy,
   ClientSession,
+  RequestFailure,
+  EventBatch,
+  GetBatch,
+  PostBatch,
 } from '@snowplow/browser-tracker-core';
 import { version } from '@snowplow/tracker-core';
 
@@ -81,6 +85,10 @@ export {
   EventMethod,
   StateStorageStrategy,
   ClientSession,
+  RequestFailure,
+  EventBatch,
+  GetBatch,
+  PostBatch,
 };
 export { version };
 export * from './api';


### PR DESCRIPTION
This release adds the option to set custom entities to the event tracked by the Web vitals plugin. It also fixes configuration for the request success and failure callbacks and prevents the previous session ID reference to be stored in cookies when anonymous tracking with session tracking is enabled.

**New features**

* #1273 

**Bug fixes**

* #1275 
* #1268