### PR TITLE
BrowserTracker: fix method type definitions

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -75,7 +75,6 @@ export interface BrowserTracker {
     getCookieName: (basename: string) => string;
     getDomainSessionIndex: () => number;
     getDomainUserId: () => string;
-    // Warning: (ae-forgotten-export) The symbol "ParsedIdCookie" needs to be exported by the entry point index.module.d.ts
     getDomainUserInfo: () => ParsedIdCookie;
     getPageViewId: () => string;
     getTabId: () => string | null;
@@ -267,6 +266,21 @@ export interface PageViewEvent {
     contextCallback?: (() => Array<SelfDescribingJson>) | null;
     title?: string | null;
 }
+
+// @public
+export type ParsedIdCookie = [
+cookieDisabled: string,
+domainUserId: string,
+cookieCreateTs: number,
+visitCount: number,
+nowTs: number,
+lastVisitTs: number | undefined,
+sessionId: string,
+previousSessionId: string,
+firstEventId: string,
+firstEventTs: number | undefined,
+eventIndex: number
+];
 
 // @public (undocumented)
 export type Platform = "web" | "mob" | "pc" | "srv" | "app" | "tv" | "cnsl" | "iot";

--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -72,13 +72,14 @@ export interface BrowserTracker {
     enableActivityTrackingCallback: (configuration: ActivityTrackingConfiguration & ActivityTrackingConfigurationCallback) => void;
     enableAnonymousTracking: (configuration?: EnableAnonymousTrackingConfiguration) => void;
     flushBuffer: (configuration?: FlushBufferConfiguration) => void;
-    getCookieName: (basename: string) => void;
-    getDomainSessionIndex: () => void;
-    getDomainUserId: () => void;
-    getDomainUserInfo: () => void;
+    getCookieName: (basename: string) => string;
+    getDomainSessionIndex: () => number;
+    getDomainUserId: () => string;
+    // Warning: (ae-forgotten-export) The symbol "ParsedIdCookie" needs to be exported by the entry point index.module.d.ts
+    getDomainUserInfo: () => ParsedIdCookie;
     getPageViewId: () => string;
     getTabId: () => string | null;
-    getUserId: () => void;
+    getUserId: () => string | null | undefined;
     id: string;
     namespace: string;
     newSession: () => void;

--- a/common/changes/@snowplow/browser-tracker-core/bt-typedefs_2024-01-25-02-58.json
+++ b/common/changes/@snowplow/browser-tracker-core/bt-typedefs_2024-01-25-02-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Update method signatures for BrowserTracker",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker-core/bt-typedefs_2024-01-30-01-31.json
+++ b/common/changes/@snowplow/browser-tracker-core/bt-typedefs_2024-01-30-01-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/bt-typedefs_2024-01-30-01-31.json
+++ b/common/changes/@snowplow/browser-tracker/bt-typedefs_2024-01-30-01-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/id_cookie.ts
+++ b/libraries/browser-tracker-core/src/tracker/id_cookie.ts
@@ -30,7 +30,7 @@
 
 import { PayloadBuilder } from '@snowplow/tracker-core';
 import { v4 as uuid } from 'uuid';
-import { ClientSession } from './types';
+import { ClientSession, ParsedIdCookie } from './types';
 
 /**
  * Indices of cookie values
@@ -46,20 +46,6 @@ const cookieDisabledIndex = 0,
   firstEventIdIndex = 8,
   firstEventTsInMsIndex = 9,
   eventIndexIndex = 10;
-
-export type ParsedIdCookie = [
-  string, // cookieDisabled
-  string, // domainUserId
-  number, // cookieCreateTs
-  number, // visitCount
-  number, // nowTs
-  number | undefined, // lastVisitTs
-  string, // sessionId
-  string, // previousSessionId
-  string, // firstEventId
-  number | undefined, // firstEventTs
-  number // eventIndex
-];
 
 export function emptyIdCookie() {
   const idCookie: ParsedIdCookie = ['1', '', 0, 0, 0, undefined, '', '', '', undefined, 0];

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -47,6 +47,7 @@ import {
   ClearUserDataConfiguration,
   ClientSession,
   ExtendedCrossDomainLinkerOptions,
+  ParsedIdCookie,
 } from './types';
 import {
   parseIdCookie,
@@ -59,7 +60,6 @@ import {
   updateFirstEventInIdCookie,
   visitCountFromIdCookie,
   cookiesEnabledInIdCookie,
-  ParsedIdCookie,
   clientSessionFromIdCookie,
   incrementEventIndexInIdCookie,
   emptyIdCookie,

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -1,4 +1,3 @@
-import { ParsedIdCookie } from './id_cookie';
 import { BrowserPlugin } from '../plugins';
 import {
   CommonEventProperties,
@@ -365,6 +364,23 @@ export interface BrowserPluginConfiguration extends CorePluginConfiguration {
   /* The plugin to add */
   plugin: BrowserPlugin;
 }
+
+/**
+ * The format of state elements stored in the `id` cookie.
+ */
+export type ParsedIdCookie = [
+  cookieDisabled: string,
+  domainUserId: string,
+  cookieCreateTs: number,
+  visitCount: number,
+  nowTs: number,
+  lastVisitTs: number | undefined,
+  sessionId: string,
+  previousSessionId: string,
+  firstEventId: string,
+  firstEventTs: number | undefined,
+  eventIndex: number
+];
 
 /**
  * The Browser Tracker

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -1,3 +1,4 @@
+import { ParsedIdCookie } from './id_cookie';
 import { BrowserPlugin } from '../plugins';
 import {
   CommonEventProperties,
@@ -383,7 +384,7 @@ export interface BrowserTracker {
    *
    * @returns Domain session index
    */
-  getDomainSessionIndex: () => void;
+  getDomainSessionIndex: () => number;
 
   /**
    * Get the current page view ID
@@ -404,28 +405,28 @@ export interface BrowserTracker {
    *
    * @returns Cookie name
    */
-  getCookieName: (basename: string) => void;
+  getCookieName: (basename: string) => string;
 
   /**
    * Get the current user ID (as set previously with setUserId()).
    *
    * @returns Business-defined user ID
    */
-  getUserId: () => void;
+  getUserId: () => string | null | undefined;
 
   /**
    * Get visitor ID (from first party cookie)
    *
    * @returns Visitor ID (or null, if not yet known)
    */
-  getDomainUserId: () => void;
+  getDomainUserId: () => string;
 
   /**
    * Get the visitor information (from first party cookie)
    *
    * @returns The domain user information array
    */
-  getDomainUserInfo: () => void;
+  getDomainUserInfo: () => ParsedIdCookie;
 
   /**
    * Override referrer

--- a/trackers/browser-tracker/src/index.ts
+++ b/trackers/browser-tracker/src/index.ts
@@ -42,6 +42,7 @@ import {
   EventBatch,
   GetBatch,
   PostBatch,
+  ParsedIdCookie,
 } from '@snowplow/browser-tracker-core';
 import { version } from '@snowplow/tracker-core';
 
@@ -89,6 +90,7 @@ export {
   EventBatch,
   GetBatch,
   PostBatch,
+  ParsedIdCookie,
 };
 export { version };
 export * from './api';


### PR DESCRIPTION
Per the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/2/functions.html#return-type-void), functions that return values are type-compatible with functions declared as having void return type; however if you're consuming these type definitions this becomes annoying as you are required to cast `as unknown as string` at the call sites to get the correct types actually returned from these methods. Because the types are compatible tsc never reported any issue with these methods.