### PR TITLE
Always access `navigator` via `window`

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/navigator-access_2024-01-25-03-04.json
+++ b/common/changes/@snowplow/browser-tracker-core/navigator-access_2024-01-25-03-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Consistently access navigator via window.navigator",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/helpers/browser_props.ts
+++ b/libraries/browser-tracker-core/src/helpers/browser_props.ts
@@ -10,7 +10,7 @@ export function getBrowserProperties() {
     devicePixelRatio: window.devicePixelRatio,
     cookiesEnabled: window.navigator.cookieEnabled,
     online: window.navigator.onLine,
-    browserLanguage: navigator.language || (navigator as any).userLanguage,
+    browserLanguage: window.navigator.language || (window.navigator as any).userLanguage,
     documentLanguage: document.documentElement.lang,
     webdriver: window.navigator.webdriver,
     deviceMemory: (window.navigator as any).deviceMemory,

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -228,7 +228,7 @@ export function Tracker(
       // First-party cookie secure attribute
       configCookieSecure = trackerConfiguration.cookieSecure ?? true,
       // Do Not Track browser feature
-      dnt = navigator.doNotTrack || navigator.msDoNotTrack || window.doNotTrack,
+      dnt = window.navigator.doNotTrack || window.navigator.msDoNotTrack || window.doNotTrack,
       // Do Not Track
       configDoNotTrack =
         typeof trackerConfiguration.respectDoNotTrack !== 'undefined'

--- a/libraries/browser-tracker-core/src/tracker/out_queue.ts
+++ b/libraries/browser-tracker-core/src/tracker/out_queue.ts
@@ -81,7 +81,7 @@ export function OutQueueManager(
     isBeaconAvailable = Boolean(
       isBeaconRequested &&
         window.navigator &&
-        window.navigator.sendBeacon &&
+        typeof window.navigator.sendBeacon === 'function' &&
         !hasWebKitBeaconBug(window.navigator.userAgent)
     ),
     useBeacon = isBeaconAvailable && isBeaconRequested,
@@ -412,7 +412,7 @@ export function OutQueueManager(
               type: 'application/json',
             });
             try {
-              beaconStatus = navigator.sendBeacon(url, blob);
+              beaconStatus = window.navigator.sendBeacon(url, blob);
             } catch (error) {
               beaconStatus = false;
             }


### PR DESCRIPTION
This one is pretty niche, sorry. :sweat_smile:  I'm implementing the browser-tracker in a Shopify web-pixel's [strict sandbox](https://shopify.dev/docs/apps/marketing/pixels#strict-sandbox-web-pixel-app-extension).

In this environment, the typical globals (`window`, `document`, `navigator`, `screen`, etc.) are not defined, but copies of their more essential data are passed through to the sandboxed environment in the non-global "context" they provide via their APIs. Using this data is enough to manually recreate the globals before asynchronously importing the browser-tracker module and start sending events - with the exception of `navigator`. For some reason in the sandbox Shopify essentially do:

```javascript
Object.defineProperty(globalThis, "navigator", {value: undefined, configurable: false, writable: false});
```
Which means I can't define `navigator` in the global scope (I _can_ define `window`, and `window.navigator`, though).
Because the tracker tries to access properties of the global `navigator` on creation it instantly triggers a script error and does not function. By making the tracker consistently access `window.navigator` instead, I can avoid this error and use the tracker as intended, since I can ensure `window.navigator` has the expected values the tracker is looking for.

This change just makes the tracker consistently access `window.navigator` (as was already the case in some places) instead of `navigator` directly.
Alternatively, we could make sure `navigator` is defined before accessing it, but in this case that would result in not collecting that data, which is less preferable.

This also fixes a typescript nag about `window.navigator.sendBeacon` always being truthy.