### PR TITLE
Add an anonymization method to Node.js emitter and API (close #1286)

### DIFF
--- a/api-docs/docs/node-tracker/node-tracker.api.md
+++ b/api-docs/docs/node-tracker/node-tracker.api.md
@@ -213,6 +213,7 @@ export interface Emitter {
     flush: () => void;
     // (undocumented)
     input: (payload: Payload) => void;
+    setAnonymization?: (shouldAnonymize: boolean) => void;
 }
 
 // @public
@@ -235,7 +236,7 @@ export interface FormSubmissionEvent {
 }
 
 // @public
-export function gotEmitter(endpoint: string, protocol?: HttpProtocol, port?: number, method?: HttpMethod, bufferSize?: number, retry?: number | Partial<RequiredRetryOptions>, cookieJar?: PromiseCookieJar | ToughCookieJar, callback?: (error?: RequestError, response?: Response<string>) => void, agents?: Agents): Emitter;
+export function gotEmitter(endpoint: string, protocol?: HttpProtocol, port?: number, method?: HttpMethod, bufferSize?: number, retry?: number | Partial<RequiredRetryOptions>, cookieJar?: PromiseCookieJar | ToughCookieJar, callback?: (error?: RequestError, response?: Response<string>) => void, agents?: Agents, serverAnonymization?: boolean): Emitter;
 
 // @public (undocumented)
 export enum HttpMethod {

--- a/common/changes/@snowplow/node-tracker/feature-add-nodejs-server-anonymization_2024-01-25-21-37.json
+++ b/common/changes/@snowplow/node-tracker/feature-add-nodejs-server-anonymization_2024-01-25-21-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Add an anonymization method to Node.js emitter and API (close #1286)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/trackers/node-tracker/src/emitter.ts
+++ b/trackers/node-tracker/src/emitter.ts
@@ -1,38 +1,10 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 import { Payload } from '@snowplow/tracker-core';
 
 export interface Emitter {
   flush: () => void;
   input: (payload: Payload) => void;
+  /** Set if the requests from the emitter should be anonymized. Read more about anonymization used at https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/going-deeper/http-headers/. */
+  setAnonymization?: (shouldAnonymize: boolean) => void;
 }
 
 export enum HttpProtocol {

--- a/trackers/node-tracker/test/got_emitter.ts
+++ b/trackers/node-tracker/test/got_emitter.ts
@@ -1,33 +1,3 @@
-/*
- * Copyright (c) 2022 Snowplow Analytics Ltd
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 import test from 'ava';
 import sinon from 'sinon';
 import nock from 'nock';
@@ -35,25 +5,61 @@ import { HttpMethod, HttpProtocol, gotEmitter } from '../src/index';
 
 const endpoint = 'd3rkrsqld9gmqf.cloudfront.net';
 
-nock(new RegExp('https*://' + endpoint))
-  .persist()
-  .filteringPath(() => '/')
-  .get('/')
-  .reply(200, (uri) => uri);
-
-nock(new RegExp('https*://' + endpoint))
-  .matchHeader('content-type', 'application/json; charset=utf-8')
-  .persist()
-  .filteringRequestBody(() => '*')
-  .post('/com.snowplowanalytics.snowplow/tp2', '*')
-  .reply(200, (_uri, body: Record<string, unknown>) => (body['data'] as Array<unknown>)[0]);
-
 test.before(() => {
   nock.disableNetConnect();
 });
 
-test.after(() => {
+test.beforeEach(() => {
+  nock(new RegExp('https*://' + endpoint))
+    .filteringPath(() => '/')
+    .get('/')
+    .reply(200, (uri) => uri);
+
+  nock(new RegExp('https*://' + endpoint))
+    .matchHeader('content-type', 'application/json; charset=utf-8')
+    .filteringRequestBody(() => '*')
+    .post('/com.snowplowanalytics.snowplow/tp2', '*')
+    .reply(200, (_uri: string, body: Record<string, unknown>) => (body['data'] as Array<unknown>)[0]);
+});
+
+test.afterEach(() => {
   nock.cleanAll();
+});
+
+test.serial('gotEmitter should allow anonymization headers', async (t) => {
+  nock.cleanAll();
+
+  nock(new RegExp('https*://' + endpoint), {
+    reqheaders: {
+      'SP-Anonymous': '*',
+    },
+  })
+    .filteringPath(() => '/')
+    .get('/')
+    .once()
+    .reply(200, (uri) => uri);
+
+  await new Promise((resolve, reject) => {
+    const e = gotEmitter(
+      endpoint,
+      HttpProtocol.HTTPS,
+      80,
+      HttpMethod.GET,
+      undefined,
+      undefined,
+      undefined,
+      function (error, response) {
+        nock.cleanAll();
+        t.is(error, undefined);
+        t.pass();
+        if (error) reject(error);
+        else resolve(response);
+      },
+      undefined,
+      true
+    );
+    e.input({});
+  });
 });
 
 test('gotEmitter should send an HTTP GET request', async (t) => {


### PR DESCRIPTION
Allow for setting anonymous tracking on the emitter configuration plus on the emitter API using `setAnonymization` .

close #1286
