### PR TITLE
Expose snowplow-ecommerce browser plugin typings 

### DIFF
--- a/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/feature-1291-expose-snowplow-ecommerce-typings_2024-03-05-15-17.json
+++ b/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/feature-1291-expose-snowplow-ecommerce-typings_2024-03-05-15-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-snowplow-ecommerce",
+      "comment": "Expose types",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
+}

--- a/plugins/browser-plugin-snowplow-ecommerce/src/index.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/index.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './ua/api';
 export * from './ga4/api';
+export * from './types';

--- a/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
@@ -317,9 +317,9 @@ export interface User {
   email?: string;
 }
 
-export interface CommonEcommerceEventProperties extends CommonEventProperties {
+export interface CommonEcommerceEventProperties<T = Record<string, unknown>> extends CommonEventProperties<T> {
   /** Add context to an event by setting an Array of Self Describing JSON */
-  context?: Array<SelfDescribingJson>;
+  context?: Array<SelfDescribingJson<T>>;
 }
 
 export type ListViewEvent = { name: string; products: Product[] };


### PR DESCRIPTION
Allow for types to be passed down to contexts on `CommonEcommerceEventProperties` as we do with `CommonEventProperties`.

close #1291