### PR TITLE
Cache browser properties and use the ResizeObserver to update when changed (close #1295)

### DIFF
--- a/libraries/browser-tracker-core/src/helpers/browser_props.ts
+++ b/libraries/browser-tracker-core/src/helpers/browser_props.ts
@@ -1,8 +1,17 @@
+let cachedProperties: any = null;
+
 /* Separator used for dimension values e.g. widthxheight */
 const DIMENSION_SEPARATOR = 'x';
 
 export function getBrowserProperties() {
-  return {
+  if (!cachedProperties) {
+    updateBrowserProperties();
+  }
+  return cachedProperties;
+}
+
+function updateBrowserProperties() {
+  cachedProperties = {
     viewport: floorDimensionFields(detectViewport()),
     documentSize: floorDimensionFields(detectDocumentSize()),
     resolution: floorDimensionFields(detectScreenResolution()),
@@ -17,6 +26,20 @@ export function getBrowserProperties() {
     hardwareConcurrency: (window.navigator as any).hardwareConcurrency,
   };
 }
+
+// Initialize the ResizeObserver
+const resizeObserver = new ResizeObserver((entries) => {
+  for (let entry of entries) {
+    // Check if the observed entry is for document's body or root element
+    if (entry.target === document.body || entry.target === document.documentElement) {
+      updateBrowserProperties(); // Update the cache if there's a change
+    }
+  }
+});
+
+// Start observing the document's body and root element for size changes
+resizeObserver.observe(document.body);
+resizeObserver.observe(document.documentElement);
 
 /**
  * Gets the current viewport.


### PR DESCRIPTION
Hey everyone!

I've been diving into how we can make our track() function smoother and faster, and I've found something interesting. When I checked out how it's affecting our website's performance, especially with the new [INP metrics](https://web.dev/articles/inp) that Google is rolling out, I noticed that track() calls were taking up a whopping 30% of the time during some interactions. This slows down the experience for our users, which is something we definitely want to avoid.

The problem is caused by `getBrowserProperties` where expensive browser calls are involved like e.g. "document.body.clientWidth". Synchronously grab these values in every `beforeTrack()` is a performance impact we do not want. 

The viewport or device resolution is unlikely to change between every single track call. I think this could be greatly improved by involving a `ResizeObserver`. The observer would listen for changes, when we actually have to grab/update these browser properties - and the `getBrowserProperties()` function itself would only use the last cached values.

Let me shortly show my analysis about the call stack. 

First, we look at a flame-graph as it is today:
![before](https://github.com/snowplow/snowplow-javascript-tracker/assets/1505976/b9757bd7-8e0f-4243-983f-ddd39ad6aa75)
-> Here we see, the `track()` call eats up to 30% of the entire input handler with a CPU throttling of 6x (on my M1 Max 64GB)

And the same again with the new `ResizeObserver` approach:
![after](https://github.com/snowplow/snowplow-javascript-tracker/assets/1505976/041e091b-f5f8-4701-b66d-61465b701bad)
-> The execution time of the `track()` call comes down to ~6% of the entire input handler, still with 6x CPU throttling. 

My tests show that i still get the exact same data for the properties `viewport`, `documentSize` and `resolution`.

Would love to get your feedback, we really want to improve the library itself and not just create a patch for the package here at Digitec Galaxus AG.

Todos:

- [x] Only return cached browser properties in `getBrowserProperties()` - to make it a cheap and fast call
- [x] Detect if browser can use `ResizeObserver`, fallback to old approach if not available
- [x] If ResizeObserver is available, add an instance to update cached browser properties on observed changes
- [ ] Write tests (🚨 Doesn't make sense right now as this would involve an entire e2e stack)
- [x] Cleanup method to destroy ResizeObserver instance again (🚨 as there is no `destroy` method in `Tracker` class, we cannot implement this)
- [ ] Consider a debounce for updating the cache as it can happen very often in short time (🚨 I don't want to defer the update of the properties even further - by doing this, we increase the chance to be "out-of-sync" with the browser properties at the moment of `track()` function)

Fixes #1295