### PR TITLE
Fix snowplow ecommerce typename conflicts

### DIFF
--- a/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/fix-correct-ecommerce-typenames-conflict_2024-03-12-09-22.json
+++ b/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/fix-correct-ecommerce-typenames-conflict_2024-03-12-09-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-snowplow-ecommerce",
+      "comment": "Fix snowplow ecommerce type conflicts",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
+}

--- a/plugins/browser-plugin-snowplow-ecommerce/src/api.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/api.ts
@@ -20,9 +20,9 @@ import {
   ListViewEvent,
   Page as PageContext,
   Product,
-  Promotion,
+  SPPromotion,
   Refund,
-  Transaction,
+  SPTransaction,
   TransactionError,
   User as UserContext,
 } from './types';
@@ -109,7 +109,7 @@ export function trackProductListClick(
  * @param trackers - The tracker identifiers which the event will be sent to
  */
 export function trackPromotionView(
-  promotionView: Promotion & CommonEcommerceEventProperties,
+  promotionView: SPPromotion & CommonEcommerceEventProperties,
   trackers: Array<string> = Object.keys(_trackers)
 ) {
   const { context = [], timestamp, ...promotion } = promotionView;
@@ -127,7 +127,7 @@ export function trackPromotionView(
  * @param trackers - The tracker identifiers which the event will be sent to
  */
 export function trackPromotionClick(
-  promotionClick: Promotion & CommonEcommerceEventProperties,
+  promotionClick: SPPromotion & CommonEcommerceEventProperties,
   trackers: Array<string> = Object.keys(_trackers)
 ) {
   const { context = [], timestamp, ...promotion } = promotionClick;
@@ -201,7 +201,7 @@ export function trackRemoveFromCart(
  * @param trackers - The tracker identifiers which the event will be sent to
  */
 export function trackTransaction(
-  transaction: Transaction & CommonEcommerceEventProperties,
+  transaction: SPTransaction & CommonEcommerceEventProperties,
   trackers: Array<string> = Object.keys(_trackers)
 ) {
   let totalQuantity = 0;

--- a/plugins/browser-plugin-snowplow-ecommerce/src/ga4/utils.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/ga4/utils.ts
@@ -1,4 +1,4 @@
-import { Product, Promotion } from '../types';
+import { Product, SPPromotion } from '../types';
 import { Item, Promotion as GA4Promotion, GA4EcommerceObject } from './types';
 
 interface GA4ItemTransformation {
@@ -32,7 +32,7 @@ export function transformG4ItemsToSPProducts(
   });
 }
 
-export function transformGA4PromotionToSPPromotion(promotion: GA4EcommerceObject & GA4Promotion): Promotion {
+export function transformGA4PromotionToSPPromotion(promotion: GA4EcommerceObject & GA4Promotion): SPPromotion {
   const productIds = promotion.items.map((item) => item.item_id);
 
   return {

--- a/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
@@ -159,7 +159,7 @@ export type Product = {
 /**
  * Type/Schema for a promotion entity in Ecommerce
  */
-export interface Promotion {
+export interface SPPromotion {
   /**
    * The ID of the promotion.
    */
@@ -193,7 +193,7 @@ export interface Promotion {
 /**
  * Type/Schema for a transaction entity in Ecommerce
  */
-export interface Transaction {
+export interface SPTransaction {
   /**
    * The ID of the transaction
    */
@@ -296,7 +296,7 @@ export interface TransactionError {
   /**
    * The transaction object representing the transaction that ended up in an error.
    */
-  transaction: Transaction;
+  transaction: SPTransaction;
 }
 
 /**

--- a/plugins/browser-plugin-snowplow-ecommerce/src/ua/utils.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/ua/utils.ts
@@ -1,4 +1,4 @@
-import { Product, Promotion } from '../types';
+import { Product, SPPromotion } from '../types';
 import { EEProduct, EEPromo } from './types';
 
 export function transformUAProductsToSPProducts(products: EEProduct[], currency: string): Product[] {
@@ -18,7 +18,7 @@ export function transformUAProductsToSPProducts(products: EEProduct[], currency:
   });
 }
 
-export function transformUAPromotionsToSPPromotions(promotions: EEPromo[]): Promotion[] {
+export function transformUAPromotionsToSPPromotions(promotions: EEPromo[]): SPPromotion[] {
   return promotions.map((promotion) => ({
     name: promotion.name,
     slot: promotion.position,

--- a/plugins/browser-plugin-snowplow-ecommerce/test/events.test.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/test/events.test.ts
@@ -53,7 +53,7 @@ import {
   TRANSACTION_SCHEMA,
   TRANSACTION_ERROR_SCHEMA,
 } from '../src/schemata';
-import { CheckoutStep, Product, Promotion, Refund, Transaction, TransactionError } from '../src/types';
+import { CheckoutStep, Product, SPPromotion, Refund, SPTransaction, TransactionError } from '../src/types';
 
 const extractStateProperties = ({
   outQueues: [
@@ -168,7 +168,7 @@ describe('SnowplowEcommercePlugin events', () => {
   });
 
   it('trackPromotionView adds the expected "promotion view" event to the queue', () => {
-    const promoX: Promotion = {
+    const promoX: SPPromotion = {
       id: '1234',
       name: 'promo_winter',
       product_ids: ['P1234'],
@@ -193,7 +193,7 @@ describe('SnowplowEcommercePlugin events', () => {
   });
 
   it('trackPromotionClick adds the expected "promotion click" event to the queue', () => {
-    const promoX: Promotion = {
+    const promoX: SPPromotion = {
       id: '1234',
       name: 'promo_winter',
       product_ids: ['P1234'],
@@ -292,7 +292,12 @@ describe('SnowplowEcommercePlugin events', () => {
   it('trackTransaction adds the expected "transaction" event to the queue', () => {
     const productX: Product = { id: '1234', price: 12, currency: 'EUR', quantity: 4 };
     const productY: Product = { id: '12345', price: 25, currency: 'EUR', quantity: 1 };
-    const transaction: Transaction = { revenue: 45, currency: 'EUR', transaction_id: '12345', payment_method: 'card' };
+    const transaction: SPTransaction = {
+      revenue: 45,
+      currency: 'EUR',
+      transaction_id: '12345',
+      payment_method: 'card',
+    };
     trackTransaction({
       ...transaction,
       products: [productX, productY],
@@ -365,7 +370,12 @@ describe('SnowplowEcommercePlugin events', () => {
       error_shortcode: 'CARD_DECLINE',
       error_type: 'hard',
     };
-    const transaction: Transaction = { revenue: 45, currency: 'EUR', transaction_id: '12345', payment_method: 'card' };
+    const transaction: SPTransaction = {
+      revenue: 45,
+      currency: 'EUR',
+      transaction_id: '12345',
+      payment_method: 'card',
+    };
     trackTransactionError({
       ...transactionError,
       transaction,


### PR DESCRIPTION
Mistakenly it was not detected that the Snowplow ecommerce plugin exposes already two types `Promotion` and `Transaction` from the universal analytics ecommerce wrapper functionality. This overrides the definitions from other types exposed at 3.22.0.

To mitigate this we can rename the types `Promotion` and `Transaction` from the Snowplow Ecommerce package to `SPPromotion` and `SPTransaction`.


This would be bumped on a patch version.