### PR TITLE
Cache browser properties and use the ResizeObserver to update when changed (close #1295)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-cached_browser_properties_2024-03-27-10-36.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-cached_browser_properties_2024-03-27-10-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Cache browser properties and use the ResizeObserver to update when changed (#1295) thanks to @rvetere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}


### PR DESCRIPTION
Follow up on PR #1294 to fix integration tests failures and update changelog.