### PR TITLE
Add an option to generate the page view ID according to changes in the page URL to account for events tracked before page views in SPAs (close #1307 and #1125)

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -7,7 +7,7 @@
     },
     {
       "path": "./trackers/browser-tracker/dist/index.umd.min.js",
-      "maxSize": "15.5kb",
+      "maxSize": "16kb",
       "maxPercentIncrease": 10
     },
     {
@@ -22,7 +22,7 @@
     },
     {
       "path": "./libraries/browser-tracker-core/dist/index.module.js",
-      "maxSize": "27kb",
+      "maxSize": "28kb",
       "maxPercentIncrease": 10
     },
     {

--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -83,6 +83,7 @@ export interface BrowserTracker {
     namespace: string;
     newSession: () => void;
     preservePageViewId: () => void;
+    preservePageViewIdForUrl: (preserve: PreservePageViewIdForUrl) => void;
     setBufferSize: (newBufferSize: number) => void;
     setCollectorUrl: (collectorUrl: string) => void;
     setCookiePath: (path: string) => void;
@@ -291,6 +292,9 @@ export type PostBatch = Record<string, unknown>[];
 // @public
 export function preservePageViewId(trackers?: Array<string>): void;
 
+// @public (undocumented)
+export type PreservePageViewIdForUrl = boolean | "full" | "pathname" | "pathnameAndSearch";
+
 // @public
 export function removeGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive>, trackers?: Array<string>): void;
 
@@ -417,6 +421,7 @@ export type TrackerConfiguration = {
     retryFailedRequests?: boolean;
     onRequestSuccess?: (data: EventBatch) => void;
     onRequestFailure?: (data: RequestFailure) => void;
+    preservePageViewIdForUrl?: PreservePageViewIdForUrl;
 };
 
 // @public

--- a/common/changes/@snowplow/browser-tracker-core/issue-1307-page_view_id_2024-05-02-13-51.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1307-page_view_id_2024-05-02-13-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add an option to generate the page view ID according to changes in the page URL to account for events tracked before page views in SPAs (#1307 and #1125)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-1307-page_view_id_2024-05-02-14-18.json
+++ b/common/changes/@snowplow/browser-tracker/issue-1307-page_view_id_2024-05-02-14-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add an option to generate the page view ID according to changes in the page URL to account for events tracked before page views in SPAs (#1307 and #1125)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1307-page_view_id_2024-05-15-06-21.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1307-page_view_id_2024-05-15-06-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Fix running integration tests due to a problem with Micro",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/libraries/browser-tracker-core/src/state.ts
+++ b/libraries/browser-tracker-core/src/state.ts
@@ -52,6 +52,8 @@ export class SharedState {
   /* pageViewId, which can changed by other trackers on page;
    * initialized by tracker sent first event */
   pageViewId?: string;
+  /* URL of the page view which the `pageViewId` was generated for */
+  pageViewUrl?: string;
 }
 
 export function createSharedState(): SharedState {

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -734,6 +734,7 @@ export function Tracker(
       if (shouldGenerateNewPageViewId()) {
         state.pageViewId = uuid();
         state.pageViewUrl = configCustomUrl || locationHrefAlias;
+        pageViewSent = false;
       }
       return state.pageViewId!;
     }
@@ -979,7 +980,7 @@ export function Tracker(
 
     function logPageView({ title, context, timestamp, contextCallback }: PageViewEvent & CommonEventProperties) {
       refreshUrl();
-      if (pageViewSent && !preservePageViewIdForUrl) {
+      if (pageViewSent) {
         // Do not reset pageViewId if previous events were not page_view
         resetPageView();
       }

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -46,6 +46,9 @@ export type ExtendedCrossDomainLinkerAttributes = {
 
 export type ExtendedCrossDomainLinkerOptions = boolean | ExtendedCrossDomainLinkerAttributes;
 
+/* Setting for the `preservePageViewIdForUrl` configuration that decides how to preserve the pageViewId on URL changes. */
+export type PreservePageViewIdForUrl = boolean | 'full' | 'pathname' | 'pathnameAndSearch';
+
 /**
  * The configuration object for initialising the tracker
  * @example
@@ -266,6 +269,17 @@ export type TrackerConfiguration = {
    * @param data - The data associated with the event(s) that failed to send
    */
   onRequestFailure?: (data: RequestFailure) => void;
+
+  /**
+   * Decide how the `pageViewId` should be preserved based on the URL.
+   * If set to `false`, the `pageViewId` will be regenerated on the second and each following page view event (first page view doesn't change the page view ID since tracker initialization).
+   * If set to `true` or `'full'`, the `pageViewId` will be kept the same for all page views with that exact URL (even for events tracked before the page view event).
+   * If set to `'pathname'`, the `pageViewId` will be kept the same for all page views with the same pathname (search params or fragment may change).
+   * If set to `'pathnameAndSearch'`, the `pageViewId` will be kept the same for all page views with the same pathname and search params (fragment may change).
+   * If `preservePageViewId` is enabled, the `preservePageViewIdForUrl` setting is ignored.
+   * Defaults to `false`.
+   */
+  preservePageViewIdForUrl?: PreservePageViewIdForUrl;
 };
 
 /**
@@ -602,6 +616,17 @@ export interface BrowserTracker {
    * Stop regenerating `pageViewId` (available from `web_page` context)
    */
   preservePageViewId: () => void;
+
+  /**
+   * Decide how the `pageViewId` should be preserved based on the URL.
+   * If set to `false`, the `pageViewId` will be regenerated on the second and each following page view event (first page view doesn't change the page view ID since tracker initialization).
+   * If set to `true` or `'full'`, the `pageViewId` will be kept the same for all page views with that exact URL (even for events tracked before the page view event).
+   * If set to `'pathname'`, the `pageViewId` will be kept the same for all page views with the same pathname (search params or fragment may change).
+   * If set to `'pathnameAndSearch'`, the `pageViewId` will be kept the same for all page views with the same pathname and search params (fragment may change).
+   * If `preservePageViewId` is enabled, the `preservePageViewIdForUrl` setting is ignored.
+   * Defaults to `false`.
+   */
+  preservePageViewIdForUrl: (preserve: PreservePageViewIdForUrl) => void;
 
   /**
    * Log visit to this page

--- a/libraries/browser-tracker-core/test/helpers/index.ts
+++ b/libraries/browser-tracker-core/test/helpers/index.ts
@@ -75,7 +75,7 @@ export function createTestSessionIdCookie(params?: CreateTestSessionIdCookie) {
   return `_sp_ses.${domainHash}=*; Expires=; Path=/; SameSite=None; Secure;`;
 }
 
-export function createTracker(configuration?: TrackerConfiguration) {
+export function createTracker(configuration?: TrackerConfiguration, sharedState?: SharedState) {
   let id = 'sp-' + Math.random();
-  return addTracker(id, id, '', '', new SharedState(), configuration);
+  return addTracker(id, id, '', '', sharedState ?? new SharedState(), configuration);
 }

--- a/libraries/browser-tracker-core/test/tracker/page_view_id.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/page_view_id.test.ts
@@ -305,4 +305,55 @@ describe('Tracker API: page view IDs', () => {
       expect(pageView1).not.toEqual(pageView2);
     });
   });
+
+  describe('Multiple trackers with a shared state', () => {
+    it('Keeps the page view ID for each page view pairs', () => {
+      const tracker1 = createTracker();
+      const tracker2 = createTracker(undefined, tracker1?.sharedState);
+
+      tracker1?.setCustomUrl('http://example.com/1');
+      tracker1?.trackPageView();
+      const pageView1 = tracker1?.getPageViewId();
+
+      tracker2?.trackPageView();
+      const pageView2 = tracker2?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+
+      tracker1?.trackPageView();
+      const pageView3 = tracker1?.getPageViewId();
+
+      tracker2?.trackPageView();
+      const pageView4 = tracker2?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView3);
+      expect(pageView3).toEqual(pageView4);
+    });
+
+    it("Doesn't keep the page view ID for multiple calls to one tracker", () => {
+      const tracker1 = createTracker();
+      const tracker2 = createTracker(undefined, tracker1?.sharedState);
+
+      tracker1?.setCustomUrl('http://example.com/1');
+      tracker1?.trackPageView();
+      const pageView1 = tracker1?.getPageViewId();
+      tracker1?.trackPageView();
+      const pageView2 = tracker1?.getPageViewId();
+
+      tracker2?.trackPageView();
+      const pageView3 = tracker2?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+      expect(pageView2).toEqual(pageView3);
+
+      tracker1?.trackPageView();
+      const pageView4 = tracker1?.getPageViewId();
+
+      tracker2?.trackPageView();
+      const pageView5 = tracker2?.getPageViewId();
+
+      expect(pageView3).not.toEqual(pageView4);
+      expect(pageView4).toEqual(pageView5);
+    });
+  });
 });

--- a/libraries/browser-tracker-core/test/tracker/page_view_id.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/page_view_id.test.ts
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { createTracker } from '../helpers';
+
+describe('Tracker API: page view IDs', () => {
+  it('Keeps the page view ID when URL changes', () => {
+    const tracker = createTracker();
+    tracker?.setCustomUrl('http://example.com/1');
+    const pageView1 = tracker?.getPageViewId();
+    tracker?.setCustomUrl('http://example.com/2');
+    const pageView2 = tracker?.getPageViewId();
+
+    expect(pageView1).toEqual(pageView2);
+  });
+
+  describe('preservePageViewIdForUrl: false', () => {
+    it('Generates new page view ID on second page view', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl(false);
+
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView2 = tracker?.getPageViewId();
+      const pageView3 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView4 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+      expect(pageView2).toEqual(pageView3);
+      expect(pageView3).not.toEqual(pageView4);
+    });
+
+    it("Doesn't generate new page view ID when URL is changed", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl(false);
+
+      tracker?.setCustomUrl('http://example.com/1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+    });
+  });
+
+  describe('preservePageViewIdForUrl: full', () => {
+    it("Doesn't generate new page view ID on second page view", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('full');
+
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView2 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView3 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+      expect(pageView2).toEqual(pageView3);
+    });
+
+    it("Doesn't generate new page view ID for the same URL", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('full');
+
+      tracker?.setCustomUrl('http://example.com/1');
+      const pageView1 = tracker?.getPageViewId();
+
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+    });
+
+    it('Generates new page view ID when URL changes', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('full');
+
+      tracker?.setCustomUrl('http://example.com/1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+
+    it('Generates new page view ID when hash param changes', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('full');
+
+      tracker?.setCustomUrl('http://example.com/#1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/#2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+
+    it('Generates new page view ID when search param changes', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('full');
+
+      tracker?.setCustomUrl('http://example.com/?test=1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/?test=2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+
+    it('Works the same way if set to true', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl(true);
+
+      tracker?.setCustomUrl('http://example.com/#1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/#2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+
+    it('Works the same way if configured through createTracker', () => {
+      const tracker = createTracker({ preservePageViewIdForUrl: 'full' });
+
+      tracker?.setCustomUrl('http://example.com/?test=1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/?test=2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+  });
+
+  describe('preservePageViewIdForUrl: pathname', () => {
+    it("Doesn't generate new page view ID on second page view", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathname');
+
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView2 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView3 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+      expect(pageView2).toEqual(pageView3);
+    });
+
+    it("Doesn't generate new page view ID for the same URL", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathname');
+
+      tracker?.setCustomUrl('http://example.com/1');
+      const pageView1 = tracker?.getPageViewId();
+
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+    });
+
+    it("Doesn't generate new page view ID when hash param changes", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathname');
+
+      tracker?.setCustomUrl('http://example.com/#1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/#2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+    });
+
+    it("Doesn't generate new page view ID when search param changes", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathname');
+
+      tracker?.setCustomUrl('http://example.com/?test=1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/?test=2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+    });
+
+    it('Generates a new page view ID when the path changes', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathname');
+
+      tracker?.setCustomUrl('http://example.com/1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+  });
+
+  describe('preservePageViewIdForUrl: pathnameAndSearch', () => {
+    it("Doesn't generate new page view ID on second page view", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathnameAndSearch');
+
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView2 = tracker?.getPageViewId();
+
+      tracker?.trackPageView();
+      const pageView3 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+      expect(pageView2).toEqual(pageView3);
+    });
+
+    it("Doesn't generate new page view ID for the same URL", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathnameAndSearch');
+
+      tracker?.setCustomUrl('http://example.com/1');
+      const pageView1 = tracker?.getPageViewId();
+
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+    });
+
+    it("Doesn't generate new page view ID when hash param changes", () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathnameAndSearch');
+
+      tracker?.setCustomUrl('http://example.com/#1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/#2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).toEqual(pageView2);
+    });
+
+    it('Generates new page view ID when search param changes', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathnameAndSearch');
+
+      tracker?.setCustomUrl('http://example.com/?test=1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/?test=2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+
+    it('Generates a new page view ID when the path changes', () => {
+      const tracker = createTracker();
+      tracker?.preservePageViewIdForUrl('pathnameAndSearch');
+
+      tracker?.setCustomUrl('http://example.com/1');
+      const pageView1 = tracker?.getPageViewId();
+
+      tracker?.setCustomUrl('http://example.com/2');
+      const pageView2 = tracker?.getPageViewId();
+
+      expect(pageView1).not.toEqual(pageView2);
+    });
+  });
+});

--- a/libraries/browser-tracker-core/test/tracker/page_view_id.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/page_view_id.test.ts
@@ -75,7 +75,7 @@ describe('Tracker API: page view IDs', () => {
   });
 
   describe('preservePageViewIdForUrl: full', () => {
-    it("Doesn't generate new page view ID on second page view", () => {
+    it("Generates new page view ID on second page view on the same URL", () => {
       const tracker = createTracker();
       tracker?.preservePageViewIdForUrl('full');
 
@@ -88,7 +88,7 @@ describe('Tracker API: page view IDs', () => {
       const pageView3 = tracker?.getPageViewId();
 
       expect(pageView1).toEqual(pageView2);
-      expect(pageView2).toEqual(pageView3);
+      expect(pageView2).not.toEqual(pageView3);
     });
 
     it("Doesn't generate new page view ID for the same URL", () => {
@@ -169,7 +169,7 @@ describe('Tracker API: page view IDs', () => {
   });
 
   describe('preservePageViewIdForUrl: pathname', () => {
-    it("Doesn't generate new page view ID on second page view", () => {
+    it("Generates new page view ID on second page view on the same URL", () => {
       const tracker = createTracker();
       tracker?.preservePageViewIdForUrl('pathname');
 
@@ -182,7 +182,7 @@ describe('Tracker API: page view IDs', () => {
       const pageView3 = tracker?.getPageViewId();
 
       expect(pageView1).toEqual(pageView2);
-      expect(pageView2).toEqual(pageView3);
+      expect(pageView2).not.toEqual(pageView3);
     });
 
     it("Doesn't generate new page view ID for the same URL", () => {
@@ -238,7 +238,7 @@ describe('Tracker API: page view IDs', () => {
   });
 
   describe('preservePageViewIdForUrl: pathnameAndSearch', () => {
-    it("Doesn't generate new page view ID on second page view", () => {
+    it("Generates new page view ID on second page view on the same URL", () => {
       const tracker = createTracker();
       tracker?.preservePageViewIdForUrl('pathnameAndSearch');
 
@@ -251,7 +251,7 @@ describe('Tracker API: page view IDs', () => {
       const pageView3 = tracker?.getPageViewId();
 
       expect(pageView1).toEqual(pageView2);
-      expect(pageView2).toEqual(pageView3);
+      expect(pageView2).not.toEqual(pageView3);
     });
 
     it("Doesn't generate new page view ID for the same URL", () => {

--- a/trackers/browser-tracker/src/index.ts
+++ b/trackers/browser-tracker/src/index.ts
@@ -43,6 +43,7 @@ import {
   GetBatch,
   PostBatch,
   ParsedIdCookie,
+  PreservePageViewIdForUrl,
 } from '@snowplow/browser-tracker-core';
 import { version } from '@snowplow/tracker-core';
 
@@ -91,6 +92,7 @@ export {
   GetBatch,
   PostBatch,
   ParsedIdCookie,
+  PreservePageViewIdForUrl,
 };
 export { version };
 export * from './api';

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "docker:micro": "docker pull snowplow/snowplow-micro:latest",
+    "docker:micro": "docker pull snowplow/snowplow-micro:2.0.0",
     "test": "jest test/unit/*.test.ts --no-cache",
     "test:build": "rollup --config rollup.config.test.js --silent",
     "test:e2e:local": "npm-run-all --parallel test:build docker:micro --serial wdio:local",

--- a/trackers/javascript-tracker/test/micro.ts
+++ b/trackers/javascript-tracker/test/micro.ts
@@ -17,7 +17,7 @@ const docker = new Docker();
 export const start = (isRemote?: boolean) => {
   return docker
     .createContainer({
-      Image: 'snowplow/snowplow-micro:latest',
+      Image: 'snowplow/snowplow-micro:2.0.0',
       AttachStdin: false,
       AttachStdout: true,
       AttachStderr: true,


### PR DESCRIPTION
Issue #1307

## Problem

In SPAs, as the user is navigating through pages, it may happen that certain events belonging to a page are tracked before the page view event. For example, auto-tracked events relating to the experiment selection in A/B testing may be tracked before the actual page view.
We would want these events to share the same page view ID as the page view event that is tracked for the same page URL even though that is tracked later.

Currently the page view ID is generated at the time of the page view event, so all events tracked before it have a different page view ID (this is not the case for the very first page view event, but is for the second and subsequent events).

## Solution

This PR adds an option called `preservePageViewIdForUrl` to the tracker configuration which has the following settings:

* `false` (default) – keep the current behaviour (i.e., new page view ID is generated when new page view event is tracked)
*  `true` or `'full'` – the page view ID will be kept the same for all page views with that exact URL (even for events tracked before the page view event).
* `'pathname'` – the page view ID will be kept the same for all page views with the same pathname (search params or fragment may change).
* `'pathnameAndSearch'` – the page view ID will be kept the same for all page views with the same pathname and search params (fragment may change).

Thus, if this option is configured to something else than `false`, events that happen on the second page but precede the second page view will have the same page view ID as the second page view. To illustrate, it will work as follows:

1. User navigates to page `http://example.com/a`
2. Custom event A is tracked with page view ID 1
3. Page view event is tracked with page view ID 1
4. Custom event B is tracked with page view ID 1
5. User clicks on a link that takes them to `http://example.com/b`
6. Custom event C is tracked with page view ID 2 (this is what this PR enables, previously it would have page view ID 1)
7. Page view event is tracked with page view ID 2
8. Custom event D is tracked with page view ID 2

This PR also fixes issue #1125 which reported the problem that if two trackers are initialized on the same page, the second page view event will have different page view IDs for each of them (the first will have the same). If this new option is configured, the second page view event will have the same page view ID on both trackers.

cc @davidher-mann and @j7i – we discussed this problem on our call, would be great to get your feedback if this solution fixes the issue for you!