### PR TITLE
browser-plugin-media-tracking: adjust fileExtension extraction

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/PE-6330-file_ext_fix_2024-05-29-01-32.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/PE-6330-file_ext_fix_2024-05-29-01-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Adjust extraction of media_element.fileExtension from source URIs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/plugins/browser-plugin-media-tracking/src/buildMediaEvent.ts
+++ b/plugins/browser-plugin-media-tracking/src/buildMediaEvent.ts
@@ -1,6 +1,12 @@
 import { eventNames, NETWORK_STATE, READY_STATE } from './constants';
 import { MediaElement, MediaPlayer, MediaPlayerEvent, VideoElement } from './contexts';
-import { dataUrlHandler, isElementFullScreen, textTrackListToJson, timeRangesToObjectArray } from './helperFunctions';
+import {
+  dataUrlHandler,
+  getUriFileExtension,
+  isElementFullScreen,
+  textTrackListToJson,
+  timeRangesToObjectArray,
+} from './helperFunctions';
 import { EventDetail, MediaEntities, MediaEventData, TrackingOptions } from './types';
 
 export function buildMediaEvent(
@@ -60,7 +66,7 @@ function getHTMLMediaElementEntities(el: HTMLAudioElement | HTMLVideoElement, co
     seeking: el.seeking,
     src: dataUrlHandler(el.src || el.currentSrc),
     textTracks: textTrackListToJson(el.textTracks),
-    fileExtension: el.currentSrc.split('.').pop() as string,
+    fileExtension: getUriFileExtension(el.currentSrc),
     fullscreen: isElementFullScreen(el.id),
     pictureInPicture: document.pictureInPictureElement?.id === el.id,
   };

--- a/plugins/browser-plugin-media-tracking/src/contexts.ts
+++ b/plugins/browser-plugin-media-tracking/src/contexts.ts
@@ -112,7 +112,7 @@ export interface MediaElement {
   /**
    * The media file format
    **/
-  fileExtension: string;
+  fileExtension: string | null;
 
   /**
    * If the video element is fullscreen

--- a/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
+++ b/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
@@ -46,6 +46,21 @@ export function boundaryErrorHandling(boundaries: number[]): number[] {
   return boundaries;
 }
 
+export function getUriFileExtension(uri: string): string | null {
+  // greedily match until the final '.' is found with trailing characters, capture those as extension
+  // only capture until finding URI metacharacters
+  const pattern = /.+\.([^\.?&#]+)/;
+
+  let uriPath = uri;
+  try {
+    uriPath = new URL(uri).pathname;
+  } catch (e) {}
+
+  // try to match against the pathname only first, if unsuccessful try against the full URI
+  const match = pattern.exec(uriPath) || pattern.exec(uri);
+  return match && match[1];
+}
+
 export function trackingOptionsParser(id: string, trackingOptions?: MediaTrackingOptions): TrackingOptions {
   const defaults: TrackingOptions = {
     id: id,


### PR DESCRIPTION
The browser-plugin-media-tracking plugin builds its own payload for the [media_element](https://github.com/snowplow/iglu-central/tree/master/schemas/org.whatwg/media_element/jsonschema/1-0-0) entity, including the `fileExtension` property.

The current logic optimistically splits the current source URI on `.` and takes the last resulting substring.

In cases where the source URI contains query parameters or other trailing data after the file extension, the resulting value for `fileExtension` can be overly long, going over the `maxLength: 255` the schema defines.

This change adjusts the behaviour to only extract values following a dot that also excludes URI metacharacters like `?` that would denote query parameters. It also now prefers parsing the URI path value explicitly over the other parts like query parameters.