### PR TITLE
Make E2E tests compatible with micro v2 & v3

### DIFF
--- a/common/changes/@snowplow/javascript-tracker/saucefix_2024-05-30-05-37.json
+++ b/common/changes/@snowplow/javascript-tracker/saucefix_2024-05-30-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Add E2E test compatibility with Micro v3",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/test/micro.ts
+++ b/trackers/javascript-tracker/test/micro.ts
@@ -44,7 +44,7 @@ export const start = (isRemote?: boolean) => {
       return c.start().then(() => {
         const outs = new Writable({
           write(chunk, _, callback) {
-            let found = chunk.toString().includes('REST interface bound');
+            let found = /(REST interface bound|http4s.+started at)/.test(chunk.toString());
             if (found) this.end();
             callback();
           },


### PR DESCRIPTION
Stops the test timeouts e.g. https://github.com/snowplow/snowplow-javascript-tracker/actions/runs/9294297376/job/25579188474

The test script waits for particular output from micro's Docker container, but waits forever when it never gets printed because of the lib change in Collector v3 vs v2.

This updates the script to check for messages from both v2 and v3 so it works with each.

Similar to matus-tomlein's fix in #1308 but without pinning.