### PR TITLE
Release/3.24.1

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-1311-reszieobserver-invoked-before-document-body-ready_2024-06-27-05-58.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-1311-reszieobserver-invoked-before-document-body-ready_2024-06-27-05-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Fix ResizeObserver initialization if document.body does not exist yet (#1311)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -42,6 +42,6 @@
      *
      * Valid values are: "prerelease", "release", "minor", "patch", "major"
      */
-    "nextBump": "minor"
+    "nextBump": "patch"
   }
 ]

--- a/libraries/browser-tracker-core/src/helpers/browser_props.ts
+++ b/libraries/browser-tracker-core/src/helpers/browser_props.ts
@@ -22,6 +22,9 @@ function initializeResizeObserver() {
   if (resizeObserverInitialized) {
     return;
   }
+  if(!document || !document.body || !document.documentElement) {
+    return;
+  }
   resizeObserverInitialized = true;
 
   const resizeObserver = new ResizeObserver((entries) => {

--- a/libraries/browser-tracker-core/test/browser_props.test.ts
+++ b/libraries/browser-tracker-core/test/browser_props.test.ts
@@ -1,4 +1,4 @@
-import { floorDimensionFields } from '../src/helpers/browser_props';
+import { floorDimensionFields, getBrowserProperties } from '../src/helpers/browser_props';
 
 describe('Browser props', () => {
   it('floorDimensionFields correctly floors dimension type values', () => {
@@ -9,5 +9,19 @@ describe('Browser props', () => {
   it('floorDimensionFields correctly floors dimension type values with fractional numbers', () => {
     const testFractionalDimensions = '100.2x100.1';
     expect(floorDimensionFields(testFractionalDimensions)).toEqual('100x100');
+  });
+
+  describe('#getBrowserProperties', () => {
+    describe('with undefined document', () => {
+      beforeAll(() => {
+        // @ts-expect-error
+        document = undefined;
+      });
+  
+      it('does not invoke the resize observer if the document is null', () => {
+        const browserProperties = getBrowserProperties();
+        expect(browserProperties).not.toEqual(null);
+      });
+    });
   });
 });


### PR DESCRIPTION
This release fixes a bug in ResizeObserver by checking for the existence of document and document.body objects.

**Bug fixes**
* Fix ResizeObserver initialization if document.body does not exist yet (#1311) thanks to @AngusMorton