### PR TITLE
link-click-tracking: event delegation

### DIFF
--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/PE-4138-link-delegation_2024-07-05-06-32.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/PE-4138-link-delegation_2024-07-05-06-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-link-click-tracking",
+      "comment": "Update plugin to use global rather than per-element event listeners",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking"
+}

--- a/plugins/browser-plugin-link-click-tracking/README.md
+++ b/plugins/browser-plugin-link-click-tracking/README.md
@@ -42,11 +42,18 @@ newTracker('sp1', '{{collector}}', { plugins: [ LinkClickTrackingPlugin() ] }); 
 Then use the available functions from this package to track to all trackers which have been initialized with this plugin:
 
 ```js
-import { enableLinkClickTracking, refreshLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
+import { enableLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 
 enableLinkClickTracking({ options: { ... }, psuedoClicks: true });
+```
 
-refreshLinkClickTracking();
+You can also explicitly track a click without installing listeners:
+
+```js
+import { trackLinkClick } from '@snowplow/browser-plugin-link-click-tracking';
+
+trackLinkClick({ element: document.querySelector("a, area") });
+trackLinkClick({ targetUrl: "http://example.com/" });
 ```
 
 ## Copyright and license

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -166,17 +166,17 @@ export function refreshLinkClickTracking(_trackers: Array<string> = []) {
 /**
  * Manually log a click.
  *
- * @param event The event information
+ * @param event The event or element information
  * @param trackers The tracker identifiers which the event will be sent to
  */
 export function trackLinkClick(
-  event: (LinkClickEvent | { element: TrackableElement }) & CommonEventProperties,
+  event: (LinkClickEvent | { element: TrackableElement; trackContent?: boolean }) & CommonEventProperties,
   trackers: Array<string> = Object.keys(_trackers)
 ) {
   dispatchToTrackersInCollection(trackers, _trackers, (t) => {
     let payload: PayloadBuilder | undefined;
     if ('element' in event) {
-      const includeContent = _configuration[t.id]?.linkTrackingContent ?? false;
+      const includeContent = event.trackContent ?? _configuration[t.id]?.linkTrackingContent ?? false;
       payload = processClick(event.element, includeContent);
     } else {
       payload = buildLinkClick(event);

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -145,9 +145,9 @@ export function disableLinkClickTracking(trackers: Array<string> = Object.keys(_
   trackers.forEach((id) => {
     if (_trackers[id] && _listeners[id]) {
       // remove all possible cases where the handler may have been attached
-      window.removeEventListener('click', _listeners[id]);
-      window.removeEventListener('mouseup', _listeners[id]);
-      window.removeEventListener('mousedown', _listeners[id]);
+      window.removeEventListener('click', _listeners[id], true);
+      window.removeEventListener('mouseup', _listeners[id], true);
+      window.removeEventListener('mousedown', _listeners[id], true);
     }
   });
 }

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -198,20 +198,18 @@ function processClick(sourceElement: TrackableElement, includeContent: boolean =
   const anchorElement = sourceElement;
   // browsers, such as Safari, don't downcase hostname and href
   const originalSourceHostName = anchorElement.hostname || getHostName(anchorElement.href);
-  let sourceHref = anchorElement.href.replace(originalSourceHostName, (s) => s.toLowerCase());
+  const targetUrl = anchorElement.href.replace(originalSourceHostName, (s) => s.toLowerCase());
 
   // Ignore script pseudo-protocol links
-  if (!ELEMENT_PROTOCOL_FILTER.test(sourceHref)) {
+  if (!ELEMENT_PROTOCOL_FILTER.test(targetUrl)) {
     elementId = anchorElement.id;
     elementClasses = getCssClasses(anchorElement);
     elementTarget = anchorElement.target;
     elementContent = includeContent ? anchorElement.innerHTML : undefined;
 
     // decodeUrl %xx
-    // NOTE(jethron): Why do we do this?
-    sourceHref = unescape(sourceHref);
     return buildLinkClick({
-      targetUrl: sourceHref,
+      targetUrl,
       elementId,
       elementClasses,
       elementTarget,

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -29,48 +29,64 @@
  */
 
 import {
-  getHostName,
-  getCssClasses,
   addEventListener,
-  getFilterByClass,
-  FilterCriterion,
-  BrowserPlugin,
-  BrowserTracker,
   dispatchToTrackersInCollection,
+  getCssClasses,
+  getFilterByClass,
+  getHostName,
+  type BrowserPlugin,
+  type BrowserTracker,
+  type FilterCriterion,
 } from '@snowplow/browser-tracker-core';
+
 import {
-  resolveDynamicContext,
-  DynamicContext,
   buildLinkClick,
-  CommonEventProperties,
-  LinkClickEvent,
+  resolveDynamicContext,
+  type CommonEventProperties,
+  type DynamicContext,
+  type LinkClickEvent,
+  type Logger,
+  type PayloadBuilder,
 } from '@snowplow/tracker-core';
 
 interface LinkClickConfiguration {
   linkTrackingFilter?: (element: HTMLElement) => boolean;
   // Whether pseudo clicks are tracked
-  linkTrackingPseudoClicks?: boolean | null | undefined;
+  linkTrackingPseudoClicks?: boolean | null;
   // Whether to track the  innerHTML of clicked links
-  linkTrackingContent?: boolean | null | undefined;
+  linkTrackingContent?: boolean | null;
   // The context attached to link click events
-  linkTrackingContext?: DynamicContext | null | undefined;
-  lastButton?: number | null;
-  lastTarget?: EventTarget | null;
+  linkTrackingContext?: DynamicContext | null;
+  lastButton?: number;
+  lastTarget?: EventTarget;
 }
 
+type TrackableElement = HTMLAnchorElement | HTMLAreaElement;
+
+const TRACKABLE_ELEMENTS = ['a', 'area']; // should be kept in sync with TrackableElement type
+const TRACKABLE_ELEMENTS_SELECTOR = TRACKABLE_ELEMENTS.join(', ');
+const ELEMENT_PROTOCOL_FILTER = /^(javascript|vbscript|jscript|mocha|livescript|ecmascript):/i;
+
 const _trackers: Record<string, BrowserTracker> = {};
+const _listeners: Record<string, EventListener> = {};
 const _configuration: Record<string, LinkClickConfiguration> = {};
+let _logger: Logger | undefined = undefined;
 
 /**
- * Link click tracking
+ * Link click tracking.
  *
- * Will automatically tracking link clicks once enabled with 'enableLinkClickTracking'
- * or you can manually track link clicks with 'trackLinkClick'
+ * Will automatically track link clicks once enabled with `enableLinkClickTracking`
+ * or you can manually track link clicks with `trackLinkClick`.
+ *
+ * @returns Plugin instance
  */
 export function LinkClickTrackingPlugin(): BrowserPlugin {
   return {
     activateBrowserPlugin: (tracker: BrowserTracker) => {
       _trackers[tracker.id] = tracker;
+    },
+    logger: (logger: Logger) => {
+      _logger = logger;
     },
   };
 }
@@ -83,15 +99,15 @@ export interface LinkClickTrackingConfiguration {
    * Captures middle click events in browsers that don't generate standard click
    * events for middle click actions
    */
-  pseudoClicks?: boolean | null;
+  pseudoClicks?: boolean;
   /** Whether the content of the links should be tracked */
-  trackContent?: boolean | null;
-  /** The dyanmic context which will be evaluated for each link click event */
+  trackContent?: boolean;
+  /** The dynamic context which will be evaluated for each link click event */
   context?: DynamicContext | null;
 }
 
 /**
- * Enable link click tracking
+ * Enable link click tracking.
  *
  * @remarks
  * The default behaviour is to use actual click events. However, some browsers
@@ -99,162 +115,184 @@ export interface LinkClickTrackingConfiguration {
  *
  * To capture more "clicks", the pseudo click-handler uses mousedown + mouseup events.
  * This is not industry standard and is vulnerable to false positives (e.g., drag events).
+ *
+ * @param configuration The link tracking configuration to use for the new click handlers
+ * @param trackers List of tracker IDs that should track the click events
  */
 export function enableLinkClickTracking(
   configuration: LinkClickTrackingConfiguration = {},
   trackers: Array<string> = Object.keys(_trackers)
 ) {
+  // remove listeners in case pseudoclick support has been toggled, which may duplicate handlers
+  disableLinkClickTracking(trackers);
   trackers.forEach((id) => {
     if (_trackers[id]) {
-      if (_trackers[id].sharedState.hasLoaded) {
-        // the load event has already fired, add the click listeners now
-        configureLinkClickTracking(configuration, id);
-        addClickListeners(id);
-      } else {
-        // defer until page has loaded
-        _trackers[id].sharedState.registeredOnLoadHandlers.push(function () {
-          configureLinkClickTracking(configuration, id);
-          addClickListeners(id);
-        });
-      }
+      configureLinkClickTracking(configuration, id);
+      addClickListeners(id);
+    }
+  });
+}
+
+/**
+ * Disable link click tracking.
+ *
+ * Removes all document-level click event handlers installed by the plugin for
+ * provided tracker instances.
+ *
+ * @param trackers The tracker identifiers that will have their listeners removed
+ */
+export function disableLinkClickTracking(trackers: Array<string> = Object.keys(_trackers)) {
+  trackers.forEach((id) => {
+    if (_trackers[id] && _listeners[id]) {
+      // remove all possible cases where the handler may have been attached
+      window.removeEventListener('click', _listeners[id]);
+      window.removeEventListener('mouseup', _listeners[id]);
+      window.removeEventListener('mousedown', _listeners[id]);
     }
   });
 }
 
 /**
  * Add click event listeners to links which have been added to the page since the
- * last time enableLinkClickTracking or refreshLinkClickTracking was used
+ * last time `enableLinkClickTracking` or `refreshLinkClickTracking` was called.
  *
- * @param trackers - The tracker identifiers which the have their link click state refreshed
+ * @deprecated v4.0 moved to event delegation and this is no longer required
+ * @param trackers The tracker identifiers which the have their link click state refreshed
  */
-export function refreshLinkClickTracking(trackers: Array<string> = Object.keys(_trackers)) {
-  trackers.forEach((id) => {
-    if (_trackers[id]) {
-      if (_trackers[id].sharedState.hasLoaded) {
-        addClickListeners(id);
-      } else {
-        _trackers[id].sharedState.registeredOnLoadHandlers.push(function () {
-          addClickListeners(id);
-        });
-      }
+export function refreshLinkClickTracking(_trackers: Array<string> = []) {
+  _logger?.warn('refreshLinkClickTracking is deprecated in v4 and has no effect');
+}
+
+/**
+ * Manually log a click.
+ *
+ * @param event The event information
+ * @param trackers The tracker identifiers which the event will be sent to
+ */
+export function trackLinkClick(
+  event: (LinkClickEvent | { element: TrackableElement }) & CommonEventProperties,
+  trackers: Array<string> = Object.keys(_trackers)
+) {
+  dispatchToTrackersInCollection(trackers, _trackers, (t) => {
+    let payload: PayloadBuilder | undefined;
+    if ('element' in event) {
+      const includeContent = _configuration[t.id]?.linkTrackingContent ?? false;
+      payload = processClick(event.element, includeContent);
+    } else {
+      payload = buildLinkClick(event);
     }
+    if (payload) t.core.track(payload, event.context, event.timestamp);
   });
 }
 
 /**
- * Manually log a click
+ * Process a clicked element into a link_click event payload.
  *
- * @param event - The event information
- * @param trackers - The tracker identifiers which the event will be sent to
+ * @param sourceElement The trackable element to be used to build the payload
+ * @param includeContent Whether to include the element's contents in the payload
+ * @returns A link_click SDE payload for the given element, or nothing if the element shouldn't be tracked
  */
-export function trackLinkClick(
-  event: LinkClickEvent & CommonEventProperties,
-  trackers: Array<string> = Object.keys(_trackers)
-) {
-  dispatchToTrackersInCollection(trackers, _trackers, (t) => {
-    t.core.track(buildLinkClick(event), event.context, event.timestamp);
-  });
-}
+function processClick(sourceElement: TrackableElement, includeContent: boolean = false) {
+  let elementId, elementClasses, elementTarget, elementContent;
 
-/*
- * Process clicks
- */
-function processClick(tracker: BrowserTracker, sourceElement: Element, context?: DynamicContext | null) {
-  let parentElement, tag, elementId, elementClasses, elementTarget, elementContent;
+  const anchorElement = sourceElement;
+  // browsers, such as Safari, don't downcase hostname and href
+  const originalSourceHostName = anchorElement.hostname || getHostName(anchorElement.href);
+  let sourceHref = anchorElement.href.replace(originalSourceHostName, (s) => s.toLowerCase());
 
-  while (
-    (parentElement = sourceElement.parentElement) !== null &&
-    parentElement != null &&
-    (tag = sourceElement.tagName.toUpperCase()) !== 'A' &&
-    tag !== 'AREA'
-  ) {
-    sourceElement = parentElement;
+  // Ignore script pseudo-protocol links
+  if (!ELEMENT_PROTOCOL_FILTER.test(sourceHref)) {
+    elementId = anchorElement.id;
+    elementClasses = getCssClasses(anchorElement);
+    elementTarget = anchorElement.target;
+    elementContent = includeContent ? anchorElement.innerHTML : undefined;
+
+    // decodeUrl %xx
+    // NOTE(jethron): Why do we do this?
+    sourceHref = unescape(sourceHref);
+    return buildLinkClick({
+      targetUrl: sourceHref,
+      elementId,
+      elementClasses,
+      elementTarget,
+      elementContent,
+    });
   }
 
-  const anchorElement = <HTMLAnchorElement>sourceElement;
-  if (anchorElement.href != null) {
-    // browsers, such as Safari, don't downcase hostname and href
-    var originalSourceHostName = anchorElement.hostname || getHostName(anchorElement.href),
-      sourceHostName = originalSourceHostName.toLowerCase(),
-      sourceHref = anchorElement.href.replace(originalSourceHostName, sourceHostName),
-      scriptProtocol = new RegExp('^(javascript|vbscript|jscript|mocha|livescript|ecmascript):', 'i');
+  return;
+}
 
-    // Ignore script pseudo-protocol links
-    if (!scriptProtocol.test(sourceHref)) {
-      elementId = anchorElement.id;
-      elementClasses = getCssClasses(anchorElement);
-      elementTarget = anchorElement.target;
-      elementContent = _configuration[tracker.id].linkTrackingContent ? anchorElement.innerHTML : undefined;
+/**
+ * Find the nearest trackable element to the given element; this is Element.closest()
+ * with a polyfill if required.
+ *
+ * @param target
+ * @returns An element that may be used to track a link click event, or null if `target` has no eligible parent
+ */
+function findNearestEligibleElement(target: EventTarget | null): TrackableElement | null {
+  if (target instanceof Element) {
+    if (typeof target['closest'] === 'function') return target.closest(TRACKABLE_ELEMENTS_SELECTOR);
+    let sourceElement: Element | null = target;
 
-      // decodeUrl %xx
-      sourceHref = unescape(sourceHref);
-      tracker.core.track(
-        buildLinkClick({
-          targetUrl: sourceHref,
-          elementId,
-          elementClasses,
-          elementTarget,
-          elementContent,
-        }),
-        resolveDynamicContext(context, sourceElement)
-      );
+    while (sourceElement) {
+      const tagName = sourceElement.tagName.toLowerCase();
+      if (TRACKABLE_ELEMENTS.indexOf(tagName) !== -1) return sourceElement as TrackableElement;
+      sourceElement = sourceElement.parentElement;
     }
   }
+
+  return null;
 }
 
-/*
- * Return function to handle click event
+/**
+ * Handle a (pseudo)click event; decide if the click is for a valid, unfiltered,
+ * element and track the click.
+ *
+ * @param tracker Tracker ID to generate the event for
+ * @param evt The DOM click event itself
  */
-function getClickHandler(tracker: string, context?: DynamicContext | null): EventListenerOrEventListenerObject {
-  return function (evt: Event) {
-    var button, target;
+function clickHandler(tracker: string, evt: MouseEvent | undefined): void {
+  const context = _configuration[tracker].linkTrackingContext;
+  const filter = _configuration[tracker].linkTrackingFilter;
 
-    evt = evt || window.event;
-    button = (evt as MouseEvent).which || (evt as MouseEvent).button;
-    target = evt.target || evt.srcElement;
+  const event = evt || (window.event as MouseEvent);
 
-    // Using evt.type (added in IE4), we avoid defining separate handlers for mouseup and mousedown.
-    if (evt.type === 'click') {
-      if (target) {
-        processClick(_trackers[tracker], target as Element, context);
-      }
-    } else if (evt.type === 'mousedown') {
-      if ((button === 1 || button === 2) && target) {
-        _configuration[tracker].lastButton = button;
-        _configuration[tracker].lastTarget = target;
-      } else {
-        _configuration[tracker].lastButton = _configuration[tracker].lastTarget = null;
-      }
-    } else if (evt.type === 'mouseup') {
-      if (button === _configuration[tracker].lastButton && target === _configuration[tracker].lastTarget) {
-        processClick(_trackers[tracker], target as Element, context);
-      }
-      _configuration[tracker].lastButton = _configuration[tracker].lastTarget = null;
+  const button = event.which || event.button;
+  const target = findNearestEligibleElement(event.target || event.srcElement);
+
+  if (!target || target.href == null) return;
+  if (filter && !filter(target)) return;
+
+  // Using evt.type (added in IE4), we avoid defining separate handlers for mouseup and mousedown.
+  if (event.type === 'click') {
+    trackLinkClick({
+      element: target,
+      context: resolveDynamicContext(context, target),
+    });
+  } else if (event.type === 'mousedown') {
+    if (button === 1 || button === 2) {
+      _configuration[tracker].lastButton = button;
+      _configuration[tracker].lastTarget = target;
+    } else {
+      delete _configuration[tracker].lastButton;
     }
-  };
-}
-
-/*
- * Add click listener to a DOM element
- */
-function addClickListener(tracker: string, element: HTMLAnchorElement | HTMLAreaElement) {
-  if (_configuration[tracker].linkTrackingPseudoClicks) {
-    // for simplicity and performance, we ignore drag events
-    addEventListener(element, 'mouseup', getClickHandler(tracker, _configuration[tracker].linkTrackingContext), false);
-    addEventListener(
-      element,
-      'mousedown',
-      getClickHandler(tracker, _configuration[tracker].linkTrackingContext),
-      false
-    );
-  } else {
-    addEventListener(element, 'click', getClickHandler(tracker, _configuration[tracker].linkTrackingContext), false);
+  } else if (event.type === 'mouseup') {
+    if (button === _configuration[tracker].lastButton && target === _configuration[tracker].lastTarget) {
+      trackLinkClick({
+        element: target,
+        context: resolveDynamicContext(context, target),
+      });
+    }
+    delete _configuration[tracker].lastButton;
+    delete _configuration[tracker].lastTarget;
   }
 }
 
-/*
- * Configures link click tracking: how to filter which links will be tracked,
- * whether to use pseudo click tracking, and what context to attach to link_click events
+/**
+ * Update the link-tracking configuration for the given tracker ID.
+ *
+ * @param param0 The new link-tracking configuration
+ * @param tracker The tracker ID to update configuration for
  */
 function configureLinkClickTracking(
   { options, pseudoClicks, trackContent, context }: LinkClickTrackingConfiguration = {},
@@ -268,18 +306,20 @@ function configureLinkClickTracking(
   };
 }
 
-/*
- * Add click handlers to anchor and AREA elements, except those to be ignored
+/**
+ * Add (psuedo)click handlers to the window for the given tracker ID.
+ *
+ * @param trackerId Tracker ID to install a listener for
  */
 function addClickListeners(trackerId: string) {
-  var linkElements = document.links,
-    i;
+  // by re-using exact function references the browser will prevent dupes and allow removal
+  _listeners[trackerId] = _listeners[trackerId] || clickHandler.bind(null, trackerId);
 
-  for (i = 0; i < linkElements.length; i++) {
-    // Add a listener to link elements which pass the filter and aren't already tracked
-    if (_configuration[trackerId].linkTrackingFilter?.(linkElements[i]) && !(linkElements[i] as any)[trackerId]) {
-      addClickListener(trackerId, linkElements[i]);
-      (linkElements[i] as any)[trackerId] = true;
-    }
+  if (_configuration[trackerId].linkTrackingPseudoClicks) {
+    // for simplicity and performance, we ignore drag events
+    addEventListener(window, 'mouseup', _listeners[trackerId], true);
+    addEventListener(window, 'mousedown', _listeners[trackerId], true);
+  } else {
+    addEventListener(window, 'click', _listeners[trackerId], true);
   }
 }

--- a/plugins/browser-plugin-link-click-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-link-click-tracking/test/events.test.ts
@@ -58,6 +58,7 @@ describe('LinkClickTrackingPlugin', () => {
   afterEach(() => {
     // clear the outQueue(s) after each test
     state.outQueues.forEach((queue) => Array.isArray(queue) && (queue.length = 0));
+    jest.clearAllMocks();
   });
 
   describe('trackLinkClick', () => {
@@ -282,8 +283,8 @@ describe('LinkClickTrackingPlugin', () => {
       disableLinkClickTracking();
 
       const addCalls = $addEventListener.mock.calls;
-      console.log('addCalls', addCalls);
 
+      expect(addCalls).toHaveLength(1);
       expect($removeEventListener.mock.calls).toContainEqual(addCalls[0]);
     });
   });

--- a/plugins/browser-plugin-link-click-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-link-click-tracking/test/events.test.ts
@@ -30,7 +30,7 @@
 
 import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
 import F from 'lodash/fp';
-import { LinkClickTrackingPlugin, trackLinkClick } from '../src';
+import { LinkClickTrackingPlugin, disableLinkClickTracking, enableLinkClickTracking, trackLinkClick } from '../src';
 
 const getUEEvents = F.compose(F.filter(F.compose(F.eq('ue'), F.get('evt.e'))));
 const extractEventProperties = F.map(F.compose(F.get('data'), (cx: string) => JSON.parse(cx), F.get('evt.ue_pr')));
@@ -52,51 +52,239 @@ describe('LinkClickTrackingPlugin', () => {
     plugins: [LinkClickTrackingPlugin()],
   });
 
-  it('trackLinkClick adds the expected link click event to the queue', () => {
-    trackLinkClick({
-      targetUrl: 'https://www.example.com',
-      elementClasses: ['class-1', 'class-2'],
-      elementContent: 'content-1',
-      elementId: 'id-1234',
-      elementTarget: '_blank',
-    });
+  const $addEventListener = jest.spyOn(window, 'addEventListener');
+  const $removeEventListener = jest.spyOn(window, 'removeEventListener');
 
-    expect(
-      extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0])
-    ).toMatchObject({
-      schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
-      data: {
+  afterEach(() => {
+    // clear the outQueue(s) after each test
+    state.outQueues.forEach((queue) => Array.isArray(queue) && (queue.length = 0));
+  });
+
+  describe('trackLinkClick', () => {
+    it('adds the specified link click event to the queue', () => {
+      trackLinkClick({
         targetUrl: 'https://www.example.com',
         elementClasses: ['class-1', 'class-2'],
         elementContent: 'content-1',
         elementId: 'id-1234',
         elementTarget: '_blank',
-      },
+      });
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+        data: {
+          targetUrl: 'https://www.example.com',
+          elementClasses: ['class-1', 'class-2'],
+          elementContent: 'content-1',
+          elementId: 'id-1234',
+          elementTarget: '_blank',
+        },
+      });
+    });
+
+    it('generates a link click event from a given element and adds it to the queue', () => {
+      const a = Object.assign(document.createElement('a'), {
+        href: 'https://www.example.com/abc',
+        className: 'class-1 class-2',
+        textContent: 'content-1',
+        id: 'id-1234',
+        target: '_blank',
+      });
+
+      trackLinkClick({ element: a });
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+        data: {
+          targetUrl: 'https://www.example.com/abc',
+          elementClasses: ['class-1', 'class-2'],
+          //elementContent: missing because disabled in default configuration
+          elementId: 'id-1234',
+          elementTarget: '_blank',
+        },
+      });
+    });
+
+    it('does nothing for no trackers', () => {
+      trackLinkClick(
+        {
+          targetUrl: 'https://www.example.com',
+          elementClasses: ['class-1', 'class-2'],
+          elementContent: 'content-1',
+          elementId: 'id-1234',
+          elementTarget: '_blank',
+        },
+        []
+      );
+
+      expect(state.outQueues[0]).toHaveLength(0);
+    });
+
+    it('does nothing for fake trackers', () => {
+      trackLinkClick(
+        {
+          targetUrl: 'https://www.example.com',
+          elementClasses: ['class-1', 'class-2'],
+          elementContent: 'content-1',
+          elementId: 'id-1234',
+          elementTarget: '_blank',
+        },
+        ['doesNotExist']
+      );
+
+      expect(state.outQueues[0]).toHaveLength(0);
     });
   });
 
-  it('trackLinkClick with element adds the expected link click event to the queue', () => {
-    const a = Object.assign(document.createElement('a'), {
-      href: 'https://www.example.com/abc',
-      className: 'class-1 class-2',
-      textContent: 'content-1',
-      id: 'id-1234',
-      target: '_blank',
+  describe('enableLinkClickTracking', () => {
+    it('does nothing for no trackers', () => {
+      enableLinkClickTracking({}, []);
+      expect($addEventListener).not.toBeCalled();
     });
 
-    trackLinkClick({ element: a });
+    it('adds click listeners by default', () => {
+      enableLinkClickTracking();
 
-    expect(
-      extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0], 1)
-    ).toMatchObject({
-      schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
-      data: {
-        targetUrl: 'https://www.example.com/abc',
-        elementClasses: ['class-1', 'class-2'],
-        //elementContent: missing because disabled in default configuration
-        elementId: 'id-1234',
-        elementTarget: '_blank',
-      },
+      expect($addEventListener).lastCalledWith('click', expect.anything(), true);
+    });
+
+    it('adds pseudo-click listeners when requested', () => {
+      enableLinkClickTracking({ pseudoClicks: true });
+      expect($addEventListener).lastCalledWith('mousedown', expect.anything(), true);
+    });
+
+    it('tracks clicks on links that already exist', () => {
+      const target = document.createElement('a');
+      target.href = 'https://www.example.com/exists';
+      document.body.appendChild(target);
+
+      enableLinkClickTracking();
+
+      target.click();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+        data: {
+          targetUrl: 'https://www.example.com/exists',
+        },
+      });
+    });
+
+    it('tracks clicks on links added after enabling', () => {
+      enableLinkClickTracking();
+
+      const target = document.createElement('a');
+      target.href = 'https://www.example.com/dynamic';
+      document.body.appendChild(target);
+
+      target.click();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+        data: {
+          targetUrl: 'https://www.example.com/dynamic',
+        },
+      });
+    });
+
+    it('tracks clicks on child elements of links and contents', () => {
+      enableLinkClickTracking({ trackContent: true });
+
+      const parent = document.createElement('a');
+      parent.href = 'https://www.example.com/parent';
+
+      const target = document.createElement('span');
+      target.textContent = 'child';
+      parent.appendChild(target);
+
+      document.body.appendChild(parent);
+
+      target.click();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+        data: {
+          targetUrl: 'https://www.example.com/parent',
+          elementContent: '<span>child</span>',
+        },
+      });
+    });
+
+    it('doesnt double track clicks', () => {
+      enableLinkClickTracking({ pseudoClicks: true });
+      enableLinkClickTracking({ pseudoClicks: false });
+
+      const target = document.createElement('a');
+      target.href = 'https://www.example.com/multiple';
+      document.body.appendChild(target);
+
+      expect(state.outQueues[0]).toHaveLength(0);
+
+      target.click();
+
+      expect(state.outQueues[0]).toHaveLength(1);
+    });
+
+    it('ignores links that match denylist criteria', () => {
+      enableLinkClickTracking({ options: { denylist: ['exclude'] } });
+
+      const target = document.createElement('a');
+      target.href = 'https://www.example.com/exclude';
+      target.className = 'exclude';
+      document.body.appendChild(target);
+
+      expect(state.outQueues[0]).toHaveLength(0);
+
+      target.click();
+
+      expect(state.outQueues[0]).toHaveLength(0);
+
+      target.className = 'include';
+      target.click();
+
+      expect(state.outQueues[0]).toHaveLength(1);
+    });
+
+    it('ignores links that dont match allowlist criteria', () => {
+      enableLinkClickTracking({ options: { allowlist: ['include'] } });
+
+      const target = document.createElement('a');
+      target.href = 'https://www.example.com/include';
+      target.className = 'exclude';
+      document.body.appendChild(target);
+
+      expect(state.outQueues[0]).toHaveLength(0);
+
+      target.click();
+
+      expect(state.outQueues[0]).toHaveLength(0);
+
+      target.className = 'include';
+      target.click();
+
+      expect(state.outQueues[0]).toHaveLength(1);
+    });
+  });
+
+  describe('disableLinkClickTracking', () => {
+    it('removes any listeners added', () => {
+      enableLinkClickTracking();
+      disableLinkClickTracking();
+
+      const addCalls = $addEventListener.mock.calls;
+      console.log('addCalls', addCalls);
+
+      expect($removeEventListener.mock.calls).toContainEqual(addCalls[0]);
     });
   });
 });


### PR DESCRIPTION
There are several API changes included:

- Global event listeners are now used instead of per-element listeners
- `refreshLinkClickTracking` is now deprecated and does nothing as it should no longer be required (but still exists for API compatibility)
- There is now a `disableLinkClickTracking` method to balance `enableLinkClickTracking`
- `trackLinkClick` can now optionally be passed a link element directly, rather than requiring manual construction of the event payload

See PE-4138