### PR TITLE
Truncate stack when application_error stack trace exceeds 8kb (close #1327)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-error-tracking/issue-1327_truncate-stack-trace_2024-07-16-10-59.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/issue-1327_truncate-stack-trace_2024-07-16-10-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-error-tracking",
+      "comment": "Truncate error stack trace if it's size is greater than 8kb",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-error-tracking"
+}

--- a/plugins/browser-plugin-error-tracking/src/index.ts
+++ b/plugins/browser-plugin-error-tracking/src/index.ts
@@ -36,6 +36,7 @@ import {
   dispatchToTrackersInCollection,
 } from '@snowplow/browser-tracker-core';
 import { buildSelfDescribingEvent, CommonEventProperties, SelfDescribingJson } from '@snowplow/tracker-core';
+import { truncateStackTrace } from './util';
 
 let _trackers: Record<string, BrowserTracker> = {};
 
@@ -74,7 +75,7 @@ export function trackError(
   trackers: Array<string> = Object.keys(_trackers)
 ) {
   const { message, filename, lineno, colno, error, context, timestamp } = event,
-    stack = error && error.stack ? error.stack : null;
+    stack = error && truncateStackTrace(error.stack);
 
   dispatchToTrackersInCollection(trackers, _trackers, (t) => {
     t.core.track(

--- a/plugins/browser-plugin-error-tracking/src/index.ts
+++ b/plugins/browser-plugin-error-tracking/src/index.ts
@@ -36,7 +36,7 @@ import {
   dispatchToTrackersInCollection,
 } from '@snowplow/browser-tracker-core';
 import { buildSelfDescribingEvent, CommonEventProperties, SelfDescribingJson } from '@snowplow/tracker-core';
-import { truncateStackTrace } from './util';
+import { truncateString } from './util';
 
 let _trackers: Record<string, BrowserTracker> = {};
 
@@ -75,7 +75,8 @@ export function trackError(
   trackers: Array<string> = Object.keys(_trackers)
 ) {
   const { message, filename, lineno, colno, error, context, timestamp } = event,
-    stack = error && truncateStackTrace(error.stack);
+    stack = error && truncateString(error.stack, 8192),
+    truncatedMessage = message && truncateString(message, 2048);
 
   dispatchToTrackersInCollection(trackers, _trackers, (t) => {
     t.core.track(
@@ -84,7 +85,7 @@ export function trackError(
           schema: 'iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1',
           data: {
             programmingLanguage: 'JAVASCRIPT',
-            message: message ?? "JS Exception. Browser doesn't support ErrorEvent API",
+            message: truncatedMessage ?? "JS Exception. Browser doesn't support ErrorEvent API",
             stackTrace: stack,
             lineNumber: lineno,
             lineColumn: colno,

--- a/plugins/browser-plugin-error-tracking/src/util.ts
+++ b/plugins/browser-plugin-error-tracking/src/util.ts
@@ -1,0 +1,21 @@
+/**
+ * Truncate stack trace if it's size is greater than 8kb
+ *
+ * @param stackTrace - The stack trace to truncate
+ * @returns The trucated stack trace
+ */
+export function truncateStackTrace(stackTrace?: string): string | undefined {
+  const byteSize = (str: string) => new Blob([str]).size;
+
+  if (stackTrace && byteSize(stackTrace) > 8000) {
+    const encoder = new TextEncoder();
+    const encodedText = encoder.encode(stackTrace);
+    const truncatedEncodedText = encodedText.slice(0, 8000);
+    const decoder = new TextDecoder();
+    const truncatedStackTrace = decoder.decode(truncatedEncodedText);
+
+    return truncatedStackTrace;
+  }
+
+  return stackTrace;
+}

--- a/plugins/browser-plugin-error-tracking/src/util.ts
+++ b/plugins/browser-plugin-error-tracking/src/util.ts
@@ -1,21 +1,15 @@
 /**
- * Truncate stack trace if it's size is greater than 8kb
+ * Truncate string if it's longer than 8192 chars
  *
- * @param stackTrace - The stack trace to truncate
- * @returns The trucated stack trace
+ * @param string - The stack trace to truncate
+ * @param maxLength - The maximum length of the truncated string. Default = 8192
+ * @returns The truncated string
  */
-export function truncateStackTrace(stackTrace?: string): string | undefined {
-  const byteSize = (str: string) => new Blob([str]).size;
-
-  if (stackTrace && byteSize(stackTrace) > 8000) {
-    const encoder = new TextEncoder();
-    const encodedText = encoder.encode(stackTrace);
-    const truncatedEncodedText = encodedText.slice(0, 8000);
-    const decoder = new TextDecoder();
-    const truncatedStackTrace = decoder.decode(truncatedEncodedText);
-
-    return truncatedStackTrace;
+export function truncateString(string?: string, maxLength: number = 8192): string | undefined {
+  if (string && string.length > 8192) {
+    const truncatedString = string.substring(0, maxLength);
+    return truncatedString;
   }
 
-  return stackTrace;
+  return string;
 }

--- a/plugins/browser-plugin-error-tracking/src/util.ts
+++ b/plugins/browser-plugin-error-tracking/src/util.ts
@@ -6,7 +6,7 @@
  * @returns The truncated string
  */
 export function truncateString(string?: string, maxLength: number = 8192): string | undefined {
-  if (string && string.length > 8192) {
+  if (string && string.length > maxLength) {
     const truncatedString = string.substring(0, maxLength);
     return truncatedString;
   }


### PR DESCRIPTION
This PR fixes an issue where the stack trace exceeds 8k - causing a failed event on the error tracking. 

It uses the 'Blob' API to check the size of the stack trace, and if it exceeds 8kb truncates it using the `TextDecoder` API. 