### PR TITLE
Add event delegation for form tracking

### DIFF
--- a/common/changes/@snowplow/browser-plugin-form-tracking/PE-6528-formsv4_2024-07-17-01-15.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/PE-6528-formsv4_2024-07-17-01-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-form-tracking",
+      "comment": "Add event delegation for link click tracking",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/PE-6528-formsv4_2024-07-17-01-15.json
+++ b/common/changes/@snowplow/javascript-tracker/PE-6528-formsv4_2024-07-17-01-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/plugins/browser-plugin-form-tracking/jest.config.js
+++ b/plugins/browser-plugin-form-tracking/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  reporters: ['jest-standard-reporter'],
+  setupFilesAfterEnv: ['../../setupTestGlobals.ts'],
+  testEnvironment: 'jest-environment-jsdom-global',
+};

--- a/plugins/browser-plugin-form-tracking/package.json
+++ b/plugins/browser-plugin-form-tracking/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c --silent --failAfterWarnings",
-    "test": ""
+    "test": "jest"
   },
   "dependencies": {
     "@snowplow/browser-tracker-core": "workspace:*",

--- a/plugins/browser-plugin-form-tracking/src/index.ts
+++ b/plugins/browser-plugin-form-tracking/src/index.ts
@@ -1,12 +1,12 @@
-import { BrowserPlugin, BrowserTracker } from '@snowplow/browser-tracker-core';
-import { addFormListeners, FormTrackingConfiguration } from './helpers';
+import type { BrowserPlugin, BrowserTracker } from '@snowplow/browser-tracker-core';
+import { addFormListeners, removeFormListeners, type FormTrackingConfiguration } from './helpers';
 
-export { FormTrackingConfiguration } from './helpers';
+export { type FormTrackingConfiguration } from './helpers';
 
 const _trackers: Record<string, BrowserTracker> = {};
 
 /**
- * A plugin which enabled automatic form tracking
+ * A plugin which enables automatic form focus, change, and submit tracking
  */
 export function FormTrackingPlugin(): BrowserPlugin {
   return {
@@ -17,9 +17,10 @@ export function FormTrackingPlugin(): BrowserPlugin {
 }
 
 /**
- * Enables automatic form tracking
+ * Enables automatic form tracking.
+ *
  * An event will be fired when a form field is changed or a form submitted.
- * This can be called multiple times: only forms not already tracked will be tracked.
+ * This can be called multiple times: previous listeners will be removed and replaced with any updated configuration.
  *
  * @param configuration - The form tracking configuration
  * @param trackers - The tracker identifiers which the events will be sent to
@@ -30,13 +31,23 @@ export function enableFormTracking(
 ) {
   trackers.forEach((t) => {
     if (_trackers[t]) {
-      if (_trackers[t].sharedState.hasLoaded) {
-        addFormListeners(_trackers[t], configuration);
-      } else {
-        _trackers[t].sharedState.registeredOnLoadHandlers.push(function () {
-          addFormListeners(_trackers[t], configuration);
-        });
-      }
+      removeFormListeners(_trackers[t]);
+      addFormListeners(_trackers[t], configuration);
+    }
+  });
+}
+
+/**
+ * Disables automatic form tracking.
+ *
+ * All page-level listeners for the given trackers will be removed.
+ *
+ * @param trackers - The tracker identifiers which the events will be sent to
+ */
+export function disableFormTracking(trackers: Array<string> = Object.keys(_trackers)) {
+  trackers.forEach((t) => {
+    if (_trackers[t]) {
+      removeFormListeners(_trackers[t]);
     }
   });
 }

--- a/plugins/browser-plugin-form-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-form-tracking/test/events.test.ts
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { addTracker, SharedState } from '@snowplow/browser-tracker-core';
+import { enableFormTracking, disableFormTracking, FormTrackingPlugin } from '../src';
+
+const getUEEvents = (arr: any) => arr.filter(({ evt }: any) => evt.e === 'ue');
+const extractEventProperties = (arr: any) => arr.map(({ evt }: any) => JSON.parse(evt.ue_pr).data);
+const extractUeEvent = (schema: string) => ({
+  from: (arr: any, n: number = 0) =>
+    extractEventProperties(getUEEvents(arr))
+      .reduce((acc: any[], curr: any[]) => acc.concat([curr]), [])
+      .filter((evt: any) => evt.schema === schema)[n],
+});
+
+describe('FormTrackingPlugin', () => {
+  const state = new SharedState();
+  addTracker('sp1', 'sp1', 'js-3.0.0', '', state, {
+    stateStorageStrategy: 'cookie',
+    encodeBase64: false,
+    plugins: [FormTrackingPlugin()],
+  });
+
+  const $addEventListener = jest.spyOn(document, 'addEventListener');
+  const $removeEventListener = jest.spyOn(document, 'removeEventListener');
+
+  document.body.appendChild(Object.assign(document.createElement('form'), { id: 'test-form' }));
+
+  afterEach(() => {
+    // clear the outQueue(s) after each test
+    state.outQueues.forEach((queue) => Array.isArray(queue) && (queue.length = 0));
+    jest.clearAllMocks();
+    document.forms[0].replaceChildren();
+  });
+
+  describe('enableFormTracking', () => {
+    it('does nothing for no trackers', () => {
+      enableFormTracking({}, []);
+      expect($addEventListener).not.toBeCalled();
+    });
+
+    it('adds form listeners by default', () => {
+      enableFormTracking();
+
+      expect($addEventListener).toBeCalledWith('focus', expect.anything(), true);
+      expect($addEventListener).toBeCalledWith('change', expect.anything(), true);
+      expect($addEventListener).toBeCalledWith('submit', expect.anything(), true);
+    });
+
+    it('tracks focus on fields that already exist', () => {
+      const target = document.createElement('input');
+      document.forms[0].appendChild(target);
+
+      enableFormTracking();
+
+      target.focus();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+        data: {
+          formId: 'test-form',
+        },
+      });
+    });
+
+    it('tracks focus on fields added after enabling', () => {
+      enableFormTracking();
+
+      const target = document.createElement('input');
+      document.forms[0].appendChild(target);
+
+      target.focus();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+        data: {
+          formId: 'test-form',
+        },
+      });
+    });
+
+    it('tracks changes on field values', () => {
+      enableFormTracking();
+
+      const target = document.createElement('input');
+      document.forms[0].appendChild(target);
+
+      target.value = 'changed';
+      target.dispatchEvent(new Event('change'));
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0',
+        data: {
+          formId: 'test-form',
+          value: 'changed',
+        },
+      });
+    });
+
+    it('associates non-nested forms correctly', () => {
+      enableFormTracking();
+
+      const target = document.createElement('input');
+      target.setAttribute('form', 'test-form');
+      document.body.appendChild(target);
+
+      target.focus();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+        data: {
+          formId: 'test-form',
+        },
+      });
+
+      document.body.removeChild(target);
+    });
+
+    it('ignores password values', () => {
+      enableFormTracking();
+
+      const target = document.createElement('input');
+      target.type = 'password';
+      target.value = 'initial';
+      document.forms[0].appendChild(target);
+
+      target.focus();
+      target.value = 'zomg_private!1';
+      target.dispatchEvent(new Event('change'));
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+        data: {
+          formId: 'test-form',
+          nodeName: 'INPUT',
+          elementType: 'password',
+          value: null,
+        },
+      });
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0',
+        data: {
+          formId: 'test-form',
+          nodeName: 'INPUT',
+          type: 'password',
+          value: null,
+        },
+      });
+    });
+
+    it('does not listen for ignored event types', () => {
+      enableFormTracking({ options: { events: ['focus_form'] } });
+      expect($addEventListener).toBeCalledTimes(1);
+      expect($addEventListener).toBeCalledWith('focus', expect.anything(), true);
+    });
+
+    it('ignores form that are not explicitly specified', () => {
+      const extra = document.createElement('form');
+      extra.id = 'skipme';
+      document.body.appendChild(extra);
+
+      enableFormTracking({ options: { forms: [document.forms[0]] } });
+
+      let target = document.createElement('input');
+      extra.appendChild(target);
+      target.focus();
+
+      expect(state.outQueues[0]).toHaveLength(0);
+
+      target = document.createElement('input');
+      document.forms[0].appendChild(target);
+      target.focus();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+        data: {
+          formId: 'test-form',
+        },
+      });
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0').from(state.outQueues[0])
+      ).not.toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+        data: {
+          formId: 'skipme',
+        },
+      });
+
+      document.body.removeChild(extra);
+    });
+  });
+
+  describe('disableFormTracking', () => {
+    it('removes any listeners added', () => {
+      enableFormTracking();
+      disableFormTracking();
+
+      const addCalls = $addEventListener.mock.calls;
+
+      expect(addCalls).toHaveLength(3);
+
+      addCalls.forEach((call) => expect($removeEventListener.mock.calls).toContainEqual(call));
+    });
+  });
+});

--- a/trackers/javascript-tracker/test/pages/form-tracking.html
+++ b/trackers/javascript-tracker/test/pages/form-tracking.html
@@ -148,6 +148,7 @@
         case 'iframeForm':
           var forms = iframe.contentWindow.document.getElementsByTagName('form');
           snowplow('enableFormTracking', { options: { forms: forms } });
+          break;
         default:
           snowplow('enableFormTracking', {
             context: [


### PR DESCRIPTION
- Global event listeners are now used instead of per-element listeners
- Event listeners now use the capture phase instead of bubble
- Forms added after the initial `enableFormTracking` call should automatically be tracked without needing additional calls
- Field value transform functions can now return `null` for all events
- Add unit tests for form tracking
- The new `targets` parameter allows listening for forms in only a subset of the document tree, or across multiple same-origin documents (e.g. iframes)

PE-5793 PE-6528 #to-review