### PR TITLE
Fix SelfDescribingJson type to allow optional keys in type parameter (close #1203 and #1304)

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -143,7 +143,9 @@ export interface ClientSession extends Record<string, unknown> {
 }
 
 // @public
-export interface CommonEventProperties<T = Record<string, unknown>> {
+export interface CommonEventProperties<T extends {
+    [_: string]: unknown;
+} = Record<string, unknown>> {
     context?: Array<SelfDescribingJson<T>> | null;
     // Warning: (ae-forgotten-export) The symbol "Timestamp" needs to be exported by the entry point index.module.d.ts
     timestamp?: Timestamp | null;
@@ -330,7 +332,9 @@ export interface SelfDescribingEvent {
 }
 
 // @public
-export type SelfDescribingJson<T extends Record<keyof T, unknown> = Record<string, unknown>> = {
+export type SelfDescribingJson<T extends {
+    [_: string]: unknown;
+} = Record<string, unknown>> = {
     schema: string;
     data: T;
 };

--- a/api-docs/docs/node-tracker/node-tracker.api.md
+++ b/api-docs/docs/node-tracker/node-tracker.api.md
@@ -299,7 +299,9 @@ export interface SelfDescribingEvent {
 }
 
 // @public
-export type SelfDescribingJson<T extends Record<keyof T, unknown> = Record<string, unknown>> = {
+export type SelfDescribingJson<T extends {
+    [_: string]: unknown;
+} = Record<string, unknown>> = {
     schema: string;
     data: T;
 };

--- a/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/PE-4998-sdjtype_2024-07-17-01-28.json
+++ b/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/PE-4998-sdjtype_2024-07-17-01-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-snowplow-ecommerce",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
+}

--- a/common/changes/@snowplow/tracker-core/PE-4998-sdjtype_2024-07-17-01-28.json
+++ b/common/changes/@snowplow/tracker-core/PE-4998-sdjtype_2024-07-17-01-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Fix SelfDescribingJson type to allow optional keys in type parameter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/tracker-core/src/core.ts
+++ b/libraries/tracker-core/src/core.ts
@@ -45,7 +45,7 @@ import { LOG } from './logger';
  * Export interface for any Self-Describing JSON such as context or Self Describing events
  * @typeParam T - The type of the data object within a SelfDescribingJson
  */
-export type SelfDescribingJson<T extends Record<keyof T, unknown> = Record<string, unknown>> = {
+export type SelfDescribingJson<T extends { [_: string]: unknown } = Record<string, unknown>> = {
   /**
    * The schema string
    * @example 'iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0'
@@ -61,7 +61,7 @@ export type SelfDescribingJson<T extends Record<keyof T, unknown> = Record<strin
  * Export interface for any Self-Describing JSON which has the data attribute as an array
  * @typeParam T - The type of the data object within the SelfDescribingJson data array
  */
-export type SelfDescribingJsonArray<T extends Record<keyof T, unknown> = Record<string, unknown>> = {
+export type SelfDescribingJsonArray<T extends { [_: string]: unknown } = Record<string, unknown>> = {
   /**
    * The schema string
    * @example 'iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1'
@@ -70,7 +70,7 @@ export type SelfDescribingJsonArray<T extends Record<keyof T, unknown> = Record<
   /**
    * The data array which should conform to the supplied schema
    */
-  data: Array<T>;
+  data: (T extends SelfDescribingJson ? T : SelfDescribingJson<T>)[];
 };
 
 /**
@@ -119,7 +119,7 @@ function getTimestamp(timestamp?: Timestamp | null): TimestampPayload {
 }
 
 /** Additional data points to set when tracking an event */
-export interface CommonEventProperties<T = Record<string, unknown>> {
+export interface CommonEventProperties<T extends { [_: string]: unknown } = Record<string, unknown>> {
   /** Add context to an event by setting an Array of Self Describing JSON */
   context?: Array<SelfDescribingJson<T>> | null;
   /** Set the true timestamp or overwrite the device sent timestamp on an event */

--- a/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
+++ b/plugins/browser-plugin-snowplow-ecommerce/src/types.ts
@@ -317,7 +317,8 @@ export interface User {
   email?: string;
 }
 
-export interface CommonEcommerceEventProperties<T = Record<string, unknown>> extends CommonEventProperties<T> {
+export interface CommonEcommerceEventProperties<T extends { [_: string]: unknown } = Record<string, unknown>>
+  extends CommonEventProperties<T> {
   /** Add context to an event by setting an Array of Self Describing JSON */
   context?: Array<SelfDescribingJson<T>>;
 }


### PR DESCRIPTION
`Record<keyof T,` has the unfortunate side-effect of erasing the `optional` modifier for any properties in `T`, essentially mandating `Required<T>` instead of just `T`.

Explicitly using an index type removes this erasure while still being largely compatible with the rest of the interface expressed by `Record`.
An index type accepting only strings is preferable over plain `{}` because that allows arrays for `data`, which we don't support AFAIK outside of special cases like `payload_data` and `contexts`.

Should fix #1203 and #1304.