### PR TITLE
Add support for named global context

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -29,7 +29,7 @@ export interface ActivityTrackingConfigurationCallback {
 }
 
 // @public
-export function addGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive>, trackers?: Array<string>): void;
+export function addGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive> | Record<string, ConditionalContextProvider | ContextPrimitive>, trackers?: Array<string>): void;
 
 // @public
 export function addPlugin(configuration: BrowserPluginConfiguration, trackers?: Array<string>): void;
@@ -293,7 +293,7 @@ export function preservePageViewId(trackers?: Array<string>): void;
 export type PreservePageViewIdForUrl = boolean | "full" | "pathname" | "pathnameAndSearch";
 
 // @public
-export function removeGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive>, trackers?: Array<string>): void;
+export function removeGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive | string>, trackers?: Array<string>): void;
 
 // @public
 export type RequestFailure = {

--- a/common/changes/@snowplow/browser-tracker/PE-5311-namedctx_2024-07-17-02-36.json
+++ b/common/changes/@snowplow/browser-tracker/PE-5311-namedctx_2024-07-17-02-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add support for named global context",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/tracker-core/PE-5311-namedctx_2024-07-17-02-36.json
+++ b/common/changes/@snowplow/tracker-core/PE-5311-namedctx_2024-07-17-02-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Add support for named global context",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/tracker-core/src/core.ts
+++ b/libraries/tracker-core/src/core.ts
@@ -273,7 +273,11 @@ export interface TrackerCore {
    * Adds contexts globally, contexts added here will be attached to all applicable events
    * @param contexts - An array containing either contexts or a conditional contexts
    */
-  addGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive>): void;
+  addGlobalContexts(
+    contexts:
+      | Array<ConditionalContextProvider | ContextPrimitive>
+      | Record<string, ConditionalContextProvider | ContextPrimitive>
+  ): void;
 
   /**
    * Removes all global contexts
@@ -284,7 +288,7 @@ export interface TrackerCore {
    * Removes previously added global context, performs a deep comparison of the contexts or conditional contexts
    * @param contexts - An array containing either contexts or a conditional contexts
    */
-  removeGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive>): void;
+  removeGlobalContexts(contexts: Array<ConditionalContextProvider | ContextPrimitive | string>): void;
 
   /**
    * Add a plugin into the plugin collection after Core has already been initialised

--- a/trackers/browser-tracker/src/api.ts
+++ b/trackers/browser-tracker/src/api.ts
@@ -411,7 +411,9 @@ export function trackSelfDescribingEvent(event: SelfDescribingEvent & CommonEven
  * @param trackers - The tracker identifiers which the global contexts will be added to
  */
 export function addGlobalContexts(
-  contexts: Array<ConditionalContextProvider | ContextPrimitive>,
+  contexts:
+    | Array<ConditionalContextProvider | ContextPrimitive>
+    | Record<string, ConditionalContextProvider | ContextPrimitive>,
   trackers?: Array<string>
 ) {
   dispatchToTrackers(trackers, (t) => {
@@ -426,7 +428,7 @@ export function addGlobalContexts(
  * @param trackers - The tracker identifiers which the global contexts will be remove from
  */
 export function removeGlobalContexts(
-  contexts: Array<ConditionalContextProvider | ContextPrimitive>,
+  contexts: Array<ConditionalContextProvider | ContextPrimitive | string>,
   trackers?: Array<string>
 ) {
   dispatchToTrackers(trackers, (t) => {


### PR DESCRIPTION
This is a proposal for "named global context"; an update to the `addGlobalContexts`/`removeGlobalContexts` APIs to allow naming each primitive/generator.

Once named, you can remove them by referencing just the name, but you can also upsert the value by adding via the same name again. This allows avoiding gymnastics required by the current API, where to update a primitive you have to have the original value around in order to remove it in order to add it again without creating duplicates.