### PR TITLE
Add browser-tracker-core default for os_timezone

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/ostz_default_2024-08-30-04-14.json
+++ b/common/changes/@snowplow/browser-tracker-core/ostz_default_2024-08-30-04-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Add browser-tracker-core default for os_timezone",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/helpers/index.ts
+++ b/libraries/browser-tracker-core/src/helpers/index.ts
@@ -82,6 +82,18 @@ export function isFunction(func: unknown) {
 }
 
 /**
+ * Lightweight configured runtime timezone detection
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions#getting_the_users_time_zone_and_locale_preferences
+ * @returns IANA timezone name of current runtime preference
+ */
+export function getTimeZone(): string | void {
+  if (typeof Intl === 'object' && typeof Intl.DateTimeFormat === 'function') {
+    const systemPreferences = new Intl.DateTimeFormat().resolvedOptions();
+    return systemPreferences.timeZone;
+  }
+}
+
+/**
  * Cleans up the page title
  */
 export function fixupTitle(title: string | { text: string }) {

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -27,6 +27,7 @@ import {
   attemptGetSessionStorage,
   attemptWriteSessionStorage,
   createCrossDomainParameterValue,
+  getTimeZone,
 } from '../helpers';
 import { BrowserPlugin } from '../plugins';
 import { newOutQueue } from './out_queue';
@@ -306,6 +307,7 @@ export function Tracker(
     }
 
     const { browserLanguage, resolution, colorDepth, cookiesEnabled } = getBrowserProperties();
+    const timeZone = getTimeZone();
 
     // Set up unchanging name-value pairs
     core.setTrackerVersion(version);
@@ -317,6 +319,7 @@ export function Tracker(
     core.addPayloadPair('lang', browserLanguage);
     core.addPayloadPair('res', resolution);
     core.addPayloadPair('cd', colorDepth);
+    if (timeZone) core.addPayloadPair('tz', timeZone);
 
     /*
      * Initialize tracker


### PR DESCRIPTION
This adds a more lightweight way for the browser-tracker to get a value for the [`os_timezone`/`tz`](https://docs.snowplow.io/docs/understanding-your-pipeline/canonical-event/#date--time-fields) field that doesn't rely on the usual [Timezone](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracking-events/timezone-geolocation/) plugin.

The Timezone plugin is very data-heavy, and when minified is currently the 4th largest plugin we distribute, but populates only this single field:
```console
$ ls -nSh ./*/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004  48K Jul 24 19:00 ./browser-plugin-vimeo-tracking/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004  20K Jul 24 19:00 ./browser-plugin-media/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004  13K Jul 24 18:59 ./browser-plugin-snowplow-ecommerce/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004  13K Jul 24 18:59 ./browser-plugin-timezone/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004  11K Jul 24 18:59 ./browser-plugin-youtube-tracking/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004  11K Jul 24 19:00 ./browser-plugin-media-tracking/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004 9.3K Jul 24 19:01 ./browser-plugin-debugger/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004 6.3K Jul 24 19:00 ./browser-plugin-form-tracking/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004 5.9K Jul 24 19:00 ./browser-plugin-link-click-tracking/dist/index.umd.min.js
-rw-r--r-- 1 1000 1004 4.9K Jul 24 19:00 ./browser-plugin-enhanced-ecommerce/dist/index.umd.min.js
```

That plugin is no longer included by default in the `sp.js` build, and from my observations, rarely used when people use the `browser-tracker` directly, likely due to its size.

I think this value is valuable to have as a datapoint, because it enables using the `derived_tstamp` to actually measure the "time of day" a user is on a site without having to guess based on the region determined via GeoIP.
This adds a default to the tracker that should provide a good estimate for this value even without the use of the Timezone plugin, based on the configured timezone information available via the [Internationalization API](https://caniuse.com/mdn-javascript_builtins_intl_datetimeformat_resolvedoptions_computed_timezone).
If the Timezone plugin is in use, it will override the value with whatever it determines.
