### PR TITLE
Make cookie writes async by default to improve tracker performance

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -541,6 +541,7 @@ export type TrackerConfiguration = {
     plugins?: Array<BrowserPlugin>;
     onSessionUpdateCallback?: (updatedSession: ClientSession) => void;
     preservePageViewIdForUrl?: PreservePageViewIdForUrl;
+    synchronousCookieWrite?: boolean;
 } & EmitterConfigurationBase & LocalStorageEventStoreConfigurationBase;
 
 // @public

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.trackerconfiguration.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.trackerconfiguration.md
@@ -30,6 +30,7 @@ type TrackerConfiguration = {
     plugins?: Array<BrowserPlugin>;
     onSessionUpdateCallback?: (updatedSession: ClientSession) => void;
     preservePageViewIdForUrl?: PreservePageViewIdForUrl;
+    synchronousCookieWrite?: boolean;
 } & EmitterConfigurationBase & LocalStorageEventStoreConfigurationBase;
 ```
 

--- a/common/changes/@snowplow/browser-tracker-core/issue-cookie_optimization_2024-09-03-12-13.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-cookie_optimization_2024-09-03-12-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Make cookie writes async by default to improve tracker performance (#1340)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/issue-cookie_optimization_2024-09-03-12-13.json
+++ b/common/changes/@snowplow/browser-tracker/issue-cookie_optimization_2024-09-03-12-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Make cookie writes async by default to improve tracker performance (#1340)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-cookie_optimization_2024-09-03-12-13.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-cookie_optimization_2024-09-03-12-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Make cookie writes async by default to improve tracker performance (#1340)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/libraries/browser-tracker-core/src/helpers/index.ts
+++ b/libraries/browser-tracker-core/src/helpers/index.ts
@@ -254,10 +254,10 @@ export function findRootDomain(sameSite: string, secure: boolean) {
     cookie(cookieName, cookieValue, 0, '/', currentDomain, sameSite, secure);
     if (cookie(cookieName) === cookieValue) {
       // Clean up created cookie(s)
-      deleteCookie(cookieName, currentDomain, sameSite, secure);
+      deleteCookie(cookieName, '/', currentDomain, sameSite, secure);
       const cookieNames = getCookiesWithPrefix(cookiePrefix);
       for (let i = 0; i < cookieNames.length; i++) {
-        deleteCookie(cookieNames[i], currentDomain, sameSite, secure);
+        deleteCookie(cookieNames[i], '/', currentDomain, sameSite, secure);
       }
 
       return currentDomain;
@@ -290,8 +290,8 @@ export function isValueInArray<T>(val: T, array: T[]) {
  * @param cookieName - The name of the cookie to delete
  * @param domainName - The domain the cookie is in
  */
-export function deleteCookie(cookieName: string, domainName?: string, sameSite?: string, secure?: boolean) {
-  cookie(cookieName, '', -1, '/', domainName, sameSite, secure);
+export function deleteCookie(cookieName: string, path?: string, domainName?: string, sameSite?: string, secure?: boolean) {
+  cookie(cookieName, '', -1, path, domainName, sameSite, secure);
 }
 
 /**

--- a/libraries/browser-tracker-core/src/snowplow.ts
+++ b/libraries/browser-tracker-core/src/snowplow.ts
@@ -32,6 +32,7 @@ import { LOG } from '@snowplow/tracker-core';
 import { SharedState } from './state';
 import { Tracker } from './tracker';
 import { BrowserTracker, TrackerConfiguration } from './tracker/types';
+import { asyncCookieStorage } from './tracker/cookie_storage';
 
 const namedTrackers: Record<string, BrowserTracker> = {};
 
@@ -150,4 +151,13 @@ function getTrackersFromCollection(
     }
   }
   return trackers;
+}
+
+/**
+ * Write all pending cookies to the browser.
+ * Useful if you track events just before the page is unloaded.
+ * This call is not necessary if `synchronousCookieWrite` is set to `true`.
+ */
+export function flushPendingCookies() {
+  asyncCookieStorage.flush();
 }

--- a/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
+++ b/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
@@ -70,7 +70,8 @@ function newCookie(name: string): Cookie {
   let lastSetValueArgs: Parameters<typeof setValue> | undefined;
   let cacheExpireAt: Date | undefined;
   let flushed = true;
-  const flushTimeout = 10;
+  const flushTimeout = 10; // milliseconds
+  const maxCacheTtl = 0.1; // seconds
 
   function getValue(): string {
     // Note: we can't cache the cookie value as we don't know the expiration date
@@ -92,9 +93,7 @@ function newCookie(name: string): Cookie {
       }, flushTimeout);
     }
 
-    if (ttl !== undefined) {
-      cacheExpireAt = new Date(Date.now() + ttl * 1000);
-    }
+    cacheExpireAt = new Date(Date.now() + Math.min(maxCacheTtl, ttl ?? maxCacheTtl) * 1000);
     return true;
   }
 

--- a/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
+++ b/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
@@ -1,0 +1,174 @@
+import { cookie, deleteCookie } from '../helpers';
+
+
+/**
+ * Cookie storage interface for reading and writing cookies.
+ */
+export interface CookieStorage {
+  /**
+   * Get the value of a cookie
+   *
+   * @param name - The name of the cookie
+   * @returns The cookie value
+   */
+  getCookie(name: string): string;
+
+  /**
+   * Set a cookie
+   *
+   * @param name - The cookie name (required)
+   * @param value - The cookie value
+   * @param ttl - The cookie Time To Live (seconds)
+   * @param path - The cookies path
+   * @param domain - The cookies domain
+   * @param samesite - The cookies samesite attribute
+   * @param secure - Boolean to specify if cookie should be secure
+   * @returns string The cookies value
+   */
+  setCookie(
+    name: string,
+    value?: string,
+    ttl?: number,
+    path?: string,
+    domain?: string,
+    samesite?: string,
+    secure?: boolean
+  ): boolean;
+
+  /**
+   * Delete a cookie
+   *
+   * @param name - The cookie name
+   * @param domainName - The cookie domain name
+   * @param sameSite - The cookie same site attribute
+   * @param secure - Boolean to specify if cookie should be secure
+   */
+  deleteCookie(name: string, domainName?: string, sameSite?: string, secure?: boolean): void;
+
+  /**
+   * Clear the cookie storage cache (does not delete any cookies)
+   */
+  clearCache(): void;
+}
+
+interface Cookie {
+  getValue: () => string;
+  setValue: (value?: string, ttl?: number, path?: string, domain?: string, samesite?: string, secure?: boolean) => boolean;
+  deleteValue: (domainName?: string, sameSite?: string, secure?: boolean) => void;
+}
+
+function newCookie(name: string): Cookie {
+  let cachedValue: string | undefined;
+  let setCookieTimer: ReturnType<typeof setTimeout> | undefined;
+  const debounceTimeout = 10;
+
+  function scheduleClearCache(ttl: number) {
+    setCookieTimer = setTimeout(() => {
+      cachedValue = undefined;
+    }, ttl * 1000);
+  }
+
+  function getValue(): string {
+    // Note: we can't cache the cookie value as we don't know the expiration date
+    return cachedValue ?? cookie(name);
+  }
+
+  function setValue(value?: string, ttl?: number, path?: string, domain?: string, samesite?: string, secure?: boolean): boolean {
+    cachedValue = value;
+
+    // debounce setting the cookie
+    if (setCookieTimer !== undefined) {
+      clearTimeout(setCookieTimer);
+    }
+    setCookieTimer = setTimeout(() => {
+      setCookieTimer = undefined;
+      cookie(name, value, ttl, path, domain, samesite, secure);
+
+      if (ttl !== undefined) {
+        scheduleClearCache(ttl);
+      }
+    }, debounceTimeout);
+    return true;
+  }
+
+  function deleteValue(domainName?: string, sameSite?: string, secure?: boolean): void {
+    cachedValue = undefined;
+
+    // cancel setting the cookie
+    if (setCookieTimer !== undefined) {
+      clearTimeout(setCookieTimer);
+    }
+    deleteCookie(name, domainName, sameSite, secure);
+  }
+
+  return {
+    getValue,
+    setValue,
+    deleteValue
+  };
+}
+
+/**
+ * Create a new async cookie storage
+ *
+ * @returns A new cookie storage
+ */
+export function newCookieStorage(): CookieStorage {
+  let cache: Record<string, Cookie> = {};
+
+  function getOrInitCookie(name: string): Cookie {
+    if (!cache[name]) {
+      cache[name] = newCookie(name);
+    }
+    return cache[name];
+  }
+
+  function getCookie(name: string): string {
+    return getOrInitCookie(name).getValue();
+  }
+
+  function setCookie(
+    name: string,
+    value?: string,
+    ttl?: number,
+    path?: string,
+    domain?: string,
+    samesite?: string,
+    secure?: boolean
+  ): boolean {
+    return getOrInitCookie(name).setValue(value, ttl, path, domain, samesite, secure);
+  }
+
+  function deleteCookie(name: string, domainName?: string, sameSite?: string, secure?: boolean): void {
+    getOrInitCookie(name).deleteValue(domainName, sameSite, secure);
+  }
+
+  function clearCache(): void {
+    cache = {};
+  }
+
+  return {
+    getCookie,
+    setCookie,
+    deleteCookie,
+    clearCache,
+  };
+}
+
+/**
+ * Cookie storage instance with asynchronous cookie writes
+ */
+export const asyncCookieStorage = newCookieStorage();
+
+/**
+ * Cookie storage instance with synchronous cookie writes
+ */
+export const syncCookieStorage: CookieStorage = {
+    getCookie: cookie,
+    setCookie: (name, value, ttl, path, domain, samesite, secure) => {
+      cookie(name, value, ttl, path, domain, samesite, secure);
+      return document.cookie.indexOf(`${name}=`) !== -1 ? true : false;
+    },
+    deleteCookie: deleteCookie,
+    clearCache: () => {},
+};

--- a/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
+++ b/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
@@ -71,7 +71,7 @@ function newCookie(name: string): Cookie {
   let cacheExpireAt: Date | undefined;
   let flushed = true;
   const flushTimeout = 10; // milliseconds
-  const maxCacheTtl = 0.1; // seconds
+  const maxCacheTtl = 0.05; // seconds
 
   function getValue(): string {
     // Note: we can't cache the cookie value as we don't know the expiration date

--- a/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
+++ b/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
@@ -43,7 +43,7 @@ export interface CookieStorage {
    * @param sameSite - The cookie same site attribute
    * @param secure - Boolean to specify if cookie should be secure
    */
-  deleteCookie(name: string, domainName?: string, sameSite?: string, secure?: boolean): void;
+  deleteCookie(name: string, path?: string, domainName?: string, sameSite?: string, secure?: boolean): void;
 }
 
 export interface AsyncCookieStorage extends CookieStorage {
@@ -61,7 +61,7 @@ export interface AsyncCookieStorage extends CookieStorage {
 interface Cookie {
   getValue: () => string;
   setValue: (value?: string, ttl?: number, path?: string, domain?: string, samesite?: string, secure?: boolean) => boolean;
-  deleteValue: (domainName?: string, sameSite?: string, secure?: boolean) => void;
+  deleteValue: (path?: string, domainName?: string, sameSite?: string, secure?: boolean) => void;
   flush: () => void;
 }
 
@@ -98,8 +98,9 @@ function newCookie(name: string): Cookie {
     return true;
   }
 
-  function deleteValue(domainName?: string, sameSite?: string, secure?: boolean): void {
+  function deleteValue(path?: string, domainName?: string, sameSite?: string, secure?: boolean): void {
     lastSetValueArgs = undefined;
+    flushed = true;
 
     // cancel setting the cookie
     if (flushTimer !== undefined) {
@@ -107,7 +108,7 @@ function newCookie(name: string): Cookie {
       flushTimer = undefined;
     }
 
-    deleteCookie(name, domainName, sameSite, secure);
+    deleteCookie(name, path, domainName, sameSite, secure);
   }
 
   function flush(): void {
@@ -166,8 +167,8 @@ export function newCookieStorage(): AsyncCookieStorage {
     return getOrInitCookie(name).setValue(value, ttl, path, domain, samesite, secure);
   }
 
-  function deleteCookie(name: string, domainName?: string, sameSite?: string, secure?: boolean): void {
-    getOrInitCookie(name).deleteValue(domainName, sameSite, secure);
+  function deleteCookie(name: string, path?: string, domainName?: string, sameSite?: string, secure?: boolean): void {
+    getOrInitCookie(name).deleteValue(path, domainName, sameSite, secure);
   }
 
   function clearCache(): void {

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -16,11 +16,9 @@ import {
   getReferrer,
   addEventListener,
   getHostName,
-  cookie,
   attemptGetLocalStorage,
   attemptWriteLocalStorage,
   attemptDeleteLocalStorage,
-  deleteCookie,
   fixupTitle,
   fromQuerystring,
   isInteger,
@@ -69,6 +67,7 @@ import {
 } from './id_cookie';
 import { CLIENT_SESSION_SCHEMA, WEB_PAGE_SCHEMA, BROWSER_CONTEXT_SCHEMA } from './schemata';
 import { getBrowserProperties } from '../helpers/browser_props';
+import { asyncCookieStorage, syncCookieStorage } from './cookie_storage';
 
 declare global {
   interface Navigator {
@@ -171,6 +170,9 @@ export function Tracker(
           collectCrossDomainAttributes: crossDomainTrackingConfig,
         };
       };
+
+    // Create a new cookie storage instance with synchronous cookie write if configured
+    const cookieStorage = trackerConfiguration.synchronousCookieWrite ? syncCookieStorage : asyncCookieStorage;
 
     // Get all injected plugins
     browserPlugins.push(getBrowserDataPlugin());
@@ -479,7 +481,7 @@ export function Tracker(
       if (configStateStorageStrategy == 'localStorage') {
         return attemptGetLocalStorage(fullName);
       } else if (configStateStorageStrategy == 'cookie' || configStateStorageStrategy == 'cookieAndLocalStorage') {
-        return cookie(fullName);
+        return cookieStorage.getCookie(fullName);
       }
       return undefined;
     }
@@ -606,8 +608,7 @@ export function Tracker(
       if (configStateStorageStrategy == 'localStorage') {
         return attemptWriteLocalStorage(name, value, timeout);
       } else if (configStateStorageStrategy == 'cookie' || configStateStorageStrategy == 'cookieAndLocalStorage') {
-        cookie(name, value, timeout, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
-        return document.cookie.indexOf(`${name}=`) !== -1 ? true : false;
+        return cookieStorage.setCookie(name, value, timeout, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
       }
       return false;
     }
@@ -620,8 +621,8 @@ export function Tracker(
       const sesname = getSnowplowCookieName('ses');
       attemptDeleteLocalStorage(idname);
       attemptDeleteLocalStorage(sesname);
-      deleteCookie(idname, configCookieDomain, configCookieSameSite, configCookieSecure);
-      deleteCookie(sesname, configCookieDomain, configCookieSameSite, configCookieSecure);
+      cookieStorage.deleteCookie(idname, configCookieDomain, configCookieSameSite, configCookieSecure);
+      cookieStorage.deleteCookie(sesname, configCookieDomain, configCookieSameSite, configCookieSecure);
       if (!configuration?.preserveSession) {
         memorizedSessionId = uuid();
         memorizedVisitCount = 1;
@@ -832,7 +833,7 @@ export function Tracker(
           const isFirstEventInSession = eventIndexFromIdCookie(idCookie) === 0;
 
           if (configOptOutCookie) {
-            toOptoutByCookie = !!cookie(configOptOutCookie);
+            toOptoutByCookie = !!cookieStorage.getCookie(configOptOutCookie);
           } else {
             toOptoutByCookie = false;
           }
@@ -1299,7 +1300,7 @@ export function Tracker(
       },
 
       setUserIdFromCookie: function (cookieName: string) {
-        businessUserId = cookie(cookieName);
+        businessUserId = cookieStorage.getCookie(cookieName);
       },
 
       setCollectorUrl: function (collectorUrl: string) {

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -621,8 +621,8 @@ export function Tracker(
       const sesname = getSnowplowCookieName('ses');
       attemptDeleteLocalStorage(idname);
       attemptDeleteLocalStorage(sesname);
-      cookieStorage.deleteCookie(idname, configCookieDomain, configCookieSameSite, configCookieSecure);
-      cookieStorage.deleteCookie(sesname, configCookieDomain, configCookieSameSite, configCookieSecure);
+      cookieStorage.deleteCookie(idname, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
+      cookieStorage.deleteCookie(sesname, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
       if (!configuration?.preserveSession) {
         memorizedSessionId = uuid();
         memorizedVisitCount = 1;

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -190,6 +190,15 @@ export type TrackerConfiguration = {
    * Defaults to `false`.
    */
   preservePageViewIdForUrl?: PreservePageViewIdForUrl;
+
+  /**
+   * Whether to write the cookies synchronously.
+   * This can be useful for testing purposes to ensure that the cookies are written before the test continues.
+   * It also has the benefit of making sure that the cookie is correctly set before session information is used in events.
+   * The downside is that it is slower and blocks the main thread.
+   * @defaultValue false
+   */
+  synchronousCookieWrite?: boolean;
 } & EmitterConfigurationBase &
   LocalStorageEventStoreConfigurationBase;
 

--- a/libraries/browser-tracker-core/test/helpers/index.ts
+++ b/libraries/browser-tracker-core/test/helpers/index.ts
@@ -77,5 +77,6 @@ export function createTestSessionIdCookie(params?: CreateTestSessionIdCookie) {
 
 export function createTracker(configuration?: TrackerConfiguration, sharedState?: SharedState) {
   let id = 'sp-' + Math.random();
+  configuration = { ...configuration, synchronousCookieWrite: true };
   return addTracker(id, id, '', '', sharedState ?? new SharedState(), configuration);
 }

--- a/libraries/browser-tracker-core/test/tracker/cookie_storage.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/cookie_storage.test.ts
@@ -1,4 +1,4 @@
-import { newCookieStorage, syncCookieStorage } from "../../src/tracker/cookie_storage";
+import { asyncCookieStorage, newCookieStorage, syncCookieStorage } from "../../src/tracker/cookie_storage";
 
 test("cookieStorage sets, gets, and deletes value", () => {
   const cookieStorage = newCookieStorage();
@@ -37,4 +37,17 @@ test("cookieStorage sets value with synchronous cookie write", () => {
   const cookieStorage = syncCookieStorage;
   cookieStorage.setCookie("test", "value");
   expect(cookieStorage.getCookie("test")).toBe("value");
+});
+
+test("asyncCookieStorage flushes pending cookies", () => {
+  let cookieJar = '';
+
+  jest.spyOn(document, 'cookie', 'set').mockImplementation((cookieValue) => {
+    cookieJar = cookieValue;
+  });
+
+  asyncCookieStorage.setCookie("test", "value");
+  expect(cookieJar).toBe("");
+  asyncCookieStorage.flush();
+  expect(cookieJar).toBe("test=value");
 });

--- a/libraries/browser-tracker-core/test/tracker/cookie_storage.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/cookie_storage.test.ts
@@ -51,3 +51,19 @@ test("asyncCookieStorage flushes pending cookies", () => {
   asyncCookieStorage.flush();
   expect(cookieJar).toBe("test=value");
 });
+
+test('writes the latest cookie value', (done) => {
+  let cookieJar = '';
+
+  jest.spyOn(document, 'cookie', 'set').mockImplementation((cookieValue) => {
+    cookieJar = cookieValue;
+  });
+
+  for (let i = 0; i < 100; i++) {
+    asyncCookieStorage.setCookie("test", `value${i}`);
+  }
+  setTimeout(() => {
+    expect(cookieJar).toBe('test=value99');
+    done();
+  }, 100);
+});

--- a/libraries/browser-tracker-core/test/tracker/cookie_storage.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/cookie_storage.test.ts
@@ -1,0 +1,40 @@
+import { newCookieStorage, syncCookieStorage } from "../../src/tracker/cookie_storage";
+
+test("cookieStorage sets, gets, and deletes value", () => {
+  const cookieStorage = newCookieStorage();
+  cookieStorage.setCookie("test", "value");
+  expect(cookieStorage.getCookie("test")).toBe("value");
+
+  cookieStorage.deleteCookie("test");
+  expect(cookieStorage.getCookie("test")).toBeFalsy();
+});
+
+test("cookieStorage sets value with ttl and clears cache after ttl", (done) => {
+  const cookieStorage = newCookieStorage();
+  const ttl = 1;
+  cookieStorage.setCookie("test", "value", ttl);
+
+  expect(cookieStorage.getCookie("test")).toBe("value");
+
+  setTimeout(() => {
+    expect(cookieStorage.getCookie("test")).toBeFalsy();
+    done();
+  }, ttl * 1000 + 100);
+});
+
+test("cookieStorage sets value with path, domain, samesite, and secure", () => {
+  const cookieStorage = newCookieStorage();
+  const path = "/";
+  const domain = "example.com";
+  const samesite = "Strict";
+  const secure = true;
+
+  cookieStorage.setCookie("test", "value", undefined, path, domain, samesite, secure);
+  expect(cookieStorage.getCookie("test")).toBe("value");
+});
+
+test("cookieStorage sets value with synchronous cookie write", () => {
+  const cookieStorage = syncCookieStorage;
+  cookieStorage.setCookie("test", "value");
+  expect(cookieStorage.getCookie("test")).toBe("value");
+});

--- a/plugins/browser-plugin-form-tracking/src/helpers.ts
+++ b/plugins/browser-plugin-form-tracking/src/helpers.ts
@@ -1,5 +1,6 @@
 import {
   addEventListener,
+  flushPendingCookies,
   getCssClasses,
   getFilterByClass,
   getFilterByName,
@@ -423,6 +424,7 @@ function getFormSubmissionListener(
         }),
         resolveDynamicContext(context, target, elementsData)
       );
+      flushPendingCookies();
     }
   };
 }

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -34,6 +34,7 @@ import {
   getCssClasses,
   getFilterByClass,
   getHostName,
+  flushPendingCookies,
   type BrowserPlugin,
   type BrowserTracker,
   type FilterCriterion,
@@ -183,6 +184,8 @@ export function trackLinkClick(
     }
     if (payload) t.core.track(payload, event.context, event.timestamp);
   });
+
+  flushPendingCookies();
 }
 
 /**

--- a/plugins/browser-plugin-media/test/api.test.ts
+++ b/plugins/browser-plugin-media/test/api.test.ts
@@ -48,7 +48,7 @@ describe('Media Tracking API', () => {
         SnowplowMediaPlugin(),
         {
           beforeTrack: (pb: PayloadBuilder) => {
-            const { ue_pr, co, tna } = pb.getPayload();
+            const { ue_pr, co, tna } = pb.build();
             if (tna == `sp${idx - 1}`) {
               eventQueue.push({ event: JSON.parse(ue_pr as string).data, context: JSON.parse(co as string).data });
             }

--- a/plugins/browser-plugin-media/test/api.test.ts
+++ b/plugins/browser-plugin-media/test/api.test.ts
@@ -44,6 +44,7 @@ describe('Media Tracking API', () => {
     addTracker(`sp${idx++}`, `sp${idx++}`, 'js-3.9.0', '', new SharedState(), {
       stateStorageStrategy: 'cookie',
       encodeBase64: false,
+      synchronousCookieWrite: true,
       plugins: [
         SnowplowMediaPlugin(),
         {

--- a/trackers/javascript-tracker/test/pages/track_performance.html
+++ b/trackers/javascript-tracker/test/pages/track_performance.html
@@ -30,12 +30,13 @@
       }
     })(window, document, 'script', './snowplow.js', 'snowplow');
 
-    function testWithStorageStrategy(storageStrategy) {
+    function testWithStorageStrategy(storageStrategy, synchronousCookieWrite) {
       return new Promise((resolve) => {
         window.snowplow('newTracker', `sp-${storageStrategy}`, 'http://localhost:9090', {
           appId: 'sp-perf',
           cookieName: `sp-perf-${storageStrategy}`,
           stateStorageStrategy: storageStrategy,
+          synchronousCookieWrite: synchronousCookieWrite,
           customFetch: function (request) {
             return new Response(null, {
               status: 200,
@@ -50,7 +51,7 @@
             return {
               afterTrack: () => {
                 eventsTracked++;
-                if (eventsTracked === 5000) {
+                if (eventsTracked === 100) {
                   performance.mark('end');
                   resolve();
                 }
@@ -63,7 +64,7 @@
         window.snowplow(function () {
           setTimeout(() => {
             performance.mark('start');
-            for (var i = 0; i < 5000; i++) {
+            for (var i = 0; i < 100; i++) {
               window.snowplow(
                 'trackPageView',
                 {
@@ -84,8 +85,10 @@
       });
     }
 
-    const stateStorageStrategy = new URL(window.location.href).searchParams.get('stateStorageStrategy');
-    testWithStorageStrategy(stateStorageStrategy).then(() => {
+    const url = new URL(window.location.href);
+    const stateStorageStrategy = url.searchParams.get('stateStorageStrategy');
+    const synchronousCookieWrite = url.searchParams.get('synchronousCookieWrite') === 'true';
+    testWithStorageStrategy(stateStorageStrategy, synchronousCookieWrite).then(() => {
       console.log('done ' + stateStorageStrategy);
       document.getElementById('init').innerText = 'true';
     });

--- a/trackers/javascript-tracker/test/pages/track_performance.html
+++ b/trackers/javascript-tracker/test/pages/track_performance.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Track performance test page</title>
+</head>
+
+<body style="width: 2000px; height: 2000px; position: relative">
+  <p id="title">Page for sending requests to Snowplow Micro</p>
+  <div id="init"></div>
+
+  <script>
+    document.body.className += ' loaded';
+  </script>
+
+  <script>
+    (function (p, l, o, w, i, n, g) {
+      if (!p[i]) {
+        p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
+        p.GlobalSnowplowNamespace.push(i);
+        p[i] = function () {
+          (p[i].q = p[i].q || []).push(arguments);
+        };
+        p[i].q = p[i].q || [];
+        n = l.createElement(o);
+        g = l.getElementsByTagName(o)[0];
+        n.async = 1;
+        n.src = w;
+        g.parentNode.insertBefore(n, g);
+      }
+    })(window, document, 'script', './snowplow.js', 'snowplow');
+
+    function testWithStorageStrategy(storageStrategy) {
+      return new Promise((resolve) => {
+        window.snowplow('newTracker', `sp-${storageStrategy}`, 'http://localhost:9090', {
+          appId: 'sp-perf',
+          cookieName: `sp-perf-${storageStrategy}`,
+          stateStorageStrategy: storageStrategy,
+          customFetch: function (request) {
+            return new Response(null, {
+              status: 200,
+              statusText: 'OK',
+            });
+          },
+        });
+
+        let eventsTracked = 0;
+        const countPlugin = {
+          CountPlugin: function () {
+            return {
+              afterTrack: () => {
+                eventsTracked++;
+                if (eventsTracked === 5000) {
+                  performance.mark('end');
+                  resolve();
+                }
+              }
+            };
+          }
+        };
+        window.snowplow('addPlugin', countPlugin, 'CountPlugin');
+
+        window.snowplow(function () {
+          setTimeout(() => {
+            performance.mark('start');
+            for (var i = 0; i < 5000; i++) {
+              window.snowplow(
+                'trackPageView',
+                {
+                  title: `My Title ${i}`,
+                  context: [
+                    {
+                      schema: 'iglu:org.schema/WebPage/jsonschema/1-0-0',
+                      data: {
+                        keywords: ['tester'],
+                      },
+                    },
+                  ],
+                }
+              );
+            }
+          }, 100);
+        });
+      });
+    }
+
+    const stateStorageStrategy = new URL(window.location.href).searchParams.get('stateStorageStrategy');
+    testWithStorageStrategy(stateStorageStrategy).then(() => {
+      console.log('done ' + stateStorageStrategy);
+      document.getElementById('init').innerText = 'true';
+    });
+  </script>
+</body>
+
+</html>

--- a/trackers/javascript-tracker/test/performance/track_performance.test.ts
+++ b/trackers/javascript-tracker/test/performance/track_performance.test.ts
@@ -1,3 +1,5 @@
+import { Capabilities } from "@wdio/types";
+
 const loadUrlAndWait = async (url: string) => {
   await browser.url(url);
   await browser.pause(5000);
@@ -7,7 +9,17 @@ const loadUrlAndWait = async (url: string) => {
   });
 };
 
+const shouldSkipBrowser = (browser: any) => {
+  const capabilities = browser.capabilities as Capabilities.DesiredCapabilities;
+  return capabilities.browserName?.toLowerCase() === 'firefox';
+};
+
 describe('Performance of tracking', () => {
+  if (shouldSkipBrowser(browser)) {
+    fit('Skip browser', () => { });
+    return;
+  }
+
   let noneMeasure: PerformanceMeasure | undefined;
   let cookieMeasure: PerformanceMeasure | undefined;
   let cookieAndLocalStorageMeasure: PerformanceMeasure | undefined;

--- a/trackers/javascript-tracker/test/performance/track_performance.test.ts
+++ b/trackers/javascript-tracker/test/performance/track_performance.test.ts
@@ -11,6 +11,7 @@ describe('Performance of tracking', () => {
   let noneMeasure: PerformanceMeasure | undefined;
   let cookieMeasure: PerformanceMeasure | undefined;
   let cookieAndLocalStorageMeasure: PerformanceMeasure | undefined;
+  let cookieAndLocalStorageSyncMeasure: PerformanceMeasure | undefined;
 
   beforeAll(async () => {
     await loadUrlAndWait('/track_performance.html?stateStorageStrategy=none');
@@ -22,20 +23,26 @@ describe('Performance of tracking', () => {
     await loadUrlAndWait('/track_performance.html?stateStorageStrategy=cookieAndLocalStorage');
     cookieAndLocalStorageMeasure = await browser.execute(() => performance.measure('cookieAndLocalStorage', 'start', 'end'));
 
+    await loadUrlAndWait('/track_performance.html?stateStorageStrategy=cookieAndLocalStorage&synchronousCookieWrite=true');
+    cookieAndLocalStorageSyncMeasure = await browser.execute(() => performance.measure('cookieAndLocalStorageSync', 'start', 'end'));
+
     console.log('state storage strategy: none', noneMeasure?.duration);
     console.log('state storage strategy: cookie', cookieMeasure?.duration);
     console.log('state storage strategy: cookieAndLocalStorage', cookieAndLocalStorageMeasure?.duration);
+    console.log('state storage strategy: cookieAndLocalStorageSync', cookieAndLocalStorageSyncMeasure?.duration);
   });
 
   it('should have a performance log', () => {
     expect(noneMeasure).toBeDefined();
     expect(cookieMeasure).toBeDefined();
     expect(cookieAndLocalStorageMeasure).toBeDefined();
+    expect(cookieAndLocalStorageSyncMeasure).toBeDefined();
   });
 
   it('should have a performance log with a duration', () => {
     expect(noneMeasure?.duration).toBeLessThan(1000);
     expect(cookieMeasure?.duration).toBeLessThan((noneMeasure?.duration ?? 0) * 2);
     expect(cookieAndLocalStorageMeasure?.duration).toBeLessThan((cookieMeasure?.duration ?? 0) * 2);
+    expect(cookieAndLocalStorageSyncMeasure?.duration).toBeLessThan((cookieAndLocalStorageMeasure?.duration ?? 0) * 10);
   });
 });

--- a/trackers/javascript-tracker/test/performance/track_performance.test.ts
+++ b/trackers/javascript-tracker/test/performance/track_performance.test.ts
@@ -11,7 +11,8 @@ const loadUrlAndWait = async (url: string) => {
 
 const shouldSkipBrowser = (browser: any) => {
   const capabilities = browser.capabilities as Capabilities.DesiredCapabilities;
-  return capabilities.browserName?.toLowerCase() === 'firefox';
+  const browserName = capabilities.browserName?.toLowerCase();
+  return browserName === 'firefox' || browserName === 'safari';
 };
 
 describe('Performance of tracking', () => {

--- a/trackers/javascript-tracker/test/performance/track_performance.test.ts
+++ b/trackers/javascript-tracker/test/performance/track_performance.test.ts
@@ -1,0 +1,41 @@
+const loadUrlAndWait = async (url: string) => {
+  await browser.url(url);
+  await browser.pause(5000);
+  await browser.waitUntil(async () => (await $('#init').getText()) === 'true', {
+    timeout: 20000,
+    timeoutMsg: 'expected init after 20s',
+  });
+};
+
+describe('Performance of tracking', () => {
+  let noneMeasure: PerformanceMeasure | undefined;
+  let cookieMeasure: PerformanceMeasure | undefined;
+  let cookieAndLocalStorageMeasure: PerformanceMeasure | undefined;
+
+  beforeAll(async () => {
+    await loadUrlAndWait('/track_performance.html?stateStorageStrategy=none');
+    noneMeasure = await browser.execute(() => performance.measure('none', 'start', 'end'));
+
+    await loadUrlAndWait('/track_performance.html?stateStorageStrategy=cookie');
+    cookieMeasure = await browser.execute(() => performance.measure('cookie', 'start', 'end'));
+
+    await loadUrlAndWait('/track_performance.html?stateStorageStrategy=cookieAndLocalStorage');
+    cookieAndLocalStorageMeasure = await browser.execute(() => performance.measure('cookieAndLocalStorage', 'start', 'end'));
+
+    console.log('state storage strategy: none', noneMeasure?.duration);
+    console.log('state storage strategy: cookie', cookieMeasure?.duration);
+    console.log('state storage strategy: cookieAndLocalStorage', cookieAndLocalStorageMeasure?.duration);
+  });
+
+  it('should have a performance log', () => {
+    expect(noneMeasure).toBeDefined();
+    expect(cookieMeasure).toBeDefined();
+    expect(cookieAndLocalStorageMeasure).toBeDefined();
+  });
+
+  it('should have a performance log with a duration', () => {
+    expect(noneMeasure?.duration).toBeLessThan(1000);
+    expect(cookieMeasure?.duration).toBeLessThan((noneMeasure?.duration ?? 0) * 2);
+    expect(cookieAndLocalStorageMeasure?.duration).toBeLessThan((cookieMeasure?.duration ?? 0) * 2);
+  });
+});

--- a/trackers/javascript-tracker/test/wdio.default.conf.ts
+++ b/trackers/javascript-tracker/test/wdio.default.conf.ts
@@ -13,6 +13,7 @@ export const config: Omit<Options.Testrunner, 'capabilities'> = {
     getFullPath('test/functional/*.test.ts'),
     getFullPath('test/integration/*.test.ts'),
     getFullPath('test/media/media.test.ts'),
+    getFullPath('test/performance/*.test.ts'),
     // YouTube and Vimeo tests are disabled since they block SauceLabs on CI
   ]],
   logLevel: 'warn',


### PR DESCRIPTION
This PR makes cookie writes async by default on the browser tracker in order to improve performance of the tracker call (to block the app for a shorter period of time when an event is tracked).

It adds a wrapper around the calls to read and write cookies that caches the last written value and uses `setTimeout` with 10ms to schedule the cookie write (it also debounces if there are multiple cookie writes in short sequences).

There is also a new option to keep the previous behaviour and write cookies synchronously with the track calls – the `synchronousCookieWrite` option. This may be useful in tests and it also has the benefit of checking that the cookies were correctly set.

I added an e2e test that compares the performance of the different storage strategies and the sync option, results below.

<img width="599" alt="image" src="https://github.com/user-attachments/assets/ede4094a-db92-4948-a9ef-e016bddab194">

<img width="418" alt="Numbers 2024-09-03 13 53 01" src="https://github.com/user-attachments/assets/e9f30a9d-5609-4ea7-9bf0-c9c2f1bb243b">
