### PR TITLE
Fix message when a resource triggers errors

### DIFF
--- a/common/changes/@snowplow/browser-plugin-error-tracking/error-clarification_2024-09-06-06-28.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/error-clarification_2024-09-06-06-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-error-tracking",
+      "comment": "Fix message when a resource triggers error instead of script",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-error-tracking"
+}

--- a/plugins/browser-plugin-error-tracking/jest.config.js
+++ b/plugins/browser-plugin-error-tracking/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   reporters: ['jest-standard-reporter'],
   setupFilesAfterEnv: ['../../setupTestGlobals.ts'],
   testEnvironment: 'jest-environment-jsdom-global',
+  testEnvironmentOptions: { resources: 'usable', runScripts: 'dangerously' },
 };


### PR DESCRIPTION
The `error` event fires on the `window` both when an unhandled JavaScript exception is thrown _or_ a resource fails to load. Rather than track a message presuming the former, attempt to detect the latter and specify the failed resource.

See also:
- https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event

See also:
BCPF-1456