### PR TITLE
Handle optimizely.get not yet existing

### DIFF
--- a/common/changes/@snowplow/browser-plugin-optimizely-x/optim-x-race_2024-09-17-00-55.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/optim-x-race_2024-09-17-00-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-optimizely-x",
+      "comment": "Handle race when get method does not exist",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely-x"
+}


### PR DESCRIPTION
Fixes a regression from 24928acd08164d42f95e3c1de88f63d6cdef1b67 that undoes the fix from #798.

If `window.optimizely` exists, but `window.optimizely.get` does not yet exist, we never populate `state`.
The fix for #798 added checks for dereferencing methods directly on the result, but provided no default for `getActiveExperimentIds()` meaning `experiment_ids` would also be `undefined` if `state` was.

Originally the code used `lodash/map` to then iterate over `experiment_ids`, that was then updated to directly be `experiment_ids.map`; with no default this tries to dereference `undefined` to call the method, whereas `lodash/map` accepts `undefined` as a value and returns an empty array.

This changes the plugin to:
- bail out early if `state` isn't correctly populated
- change some types to remove some cases of `any` that were obscuring the error
- note that the global types are optional and may be `undefined`
- removes the code for extracting subproperties, as it's not used and obscures the return type of `getOptimizelyXData`
