### PR TITLE
Switch to GA4 as default for gaCookies plugin

### DIFF
--- a/common/changes/@snowplow/browser-plugin-ga-cookies/gacookies-switch-default_2024-10-04-03-42.json
+++ b/common/changes/@snowplow/browser-plugin-ga-cookies/gacookies-switch-default_2024-10-04-03-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-ga-cookies",
+      "comment": "Change default from UA to GA4",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ga-cookies"
+}

--- a/plugins/browser-plugin-ga-cookies/README.md
+++ b/plugins/browser-plugin-ga-cookies/README.md
@@ -5,17 +5,17 @@
 
 Browser Plugin to be used with `@snowplow/browser-tracker`.
 
-Adds Universal Analytics and Google Analytics 4 cookies to your Snowplow tracking.
+Adds Google Analytics 4 and optionally Universal Analytics cookies to your Snowplow tracking.
 
 ## Maintainer quick start
 
-Part of the Snowplow JavaScript Tracker monorepo.  
-Build with [Node.js](https://nodejs.org/en/) (14 or 16) and [Rush](https://rushjs.io/).
+Part of the Snowplow JavaScript Tracker monorepo.
+Build with [Node.js](https://nodejs.org/en/) (18+) and [Rush](https://rushjs.io/).
 
 ### Setup repository
 
 ```bash
-npm install -g @microsoft/rush 
+npm install -g @microsoft/rush
 git clone https://github.com/snowplow/snowplow-javascript-tracker.git
 rush update
 ```
@@ -40,14 +40,14 @@ newTracker('sp1', '{{collector}}', { plugins: [ GaCookiesPlugin(
     /* pluginOptions */
 ) ] });
 
-/* 
+/*
  * Available plugin options `GACookiesPluginOptions`:
  * {
- * ua: Send Universal Analytics specific cookie values. Defaults to true.
- * ga4: Send Google Analytics 4 specific cookie values. Defaults to false.
+ * ua: Send Universal Analytics specific cookie values. Defaults to false.
+ * ga4: Send Google Analytics 4 specific cookie values. Defaults to true.
  * ga4MeasurementId: Measurement id/ids to search the Google Analytics 4 session cookie. Can be a single measurement id as a string or an array of measurement id strings. The cookie has the form of <cookie_prefix>_ga_<container-id> where <container-id> is the data stream container id and <cookie_prefix> is the optional cookie_prefix option of the gtag.js tracker.
  * cookiePrefix: Cookie prefix set on the Google Analytics 4 cookies using the cookie_prefix option of the gtag.js tracker.
- * } 
+ * }
  */
 ```
 

--- a/plugins/browser-plugin-ga-cookies/src/index.ts
+++ b/plugins/browser-plugin-ga-cookies/src/index.ts
@@ -11,8 +11,8 @@ interface GACookiesPluginOptions {
 }
 
 const defaultPluginOptions: GACookiesPluginOptions = {
-  ua: true,
-  ga4: false,
+  ua: false,
+  ga4: true,
   ga4MeasurementId: '',
   cookiePrefix: [],
 };


### PR DESCRIPTION
This changes the default behaviour of the GA Cookies plugin to look for GA4 cookies instead of Universal Analytics cookies.

This uses the `iglu:com.google.ga4/cookies/jsonschema/1-0-0` schema instead of `iglu:com.google.analytics/cookies/jsonschema/1-0-0`, so it is a breaking change.