### PR TITLE
Update discoverRootDomain default behaviour

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/discover-root-default_2024-10-04-03-51.json
+++ b/common/changes/@snowplow/browser-tracker-core/discover-root-default_2024-10-04-03-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Re-allow unspecified cookies domains",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -224,7 +224,7 @@ export function Tracker(
       // First-party cookie domain
       // User agent defaults to origin hostname
       configCookieDomain = trackerConfiguration.cookieDomain ?? undefined,
-      discoverRootDomain = trackerConfiguration.discoverRootDomain || true,
+      discoverRootDomain = trackerConfiguration.discoverRootDomain ?? configCookieDomain === undefined,
       // First-party cookie path
       // Default is user agent defined.
       configCookiePath = '/',
@@ -608,7 +608,15 @@ export function Tracker(
       if (configStateStorageStrategy == 'localStorage') {
         return attemptWriteLocalStorage(name, value, timeout);
       } else if (configStateStorageStrategy == 'cookie' || configStateStorageStrategy == 'cookieAndLocalStorage') {
-        return cookieStorage.setCookie(name, value, timeout, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
+        return cookieStorage.setCookie(
+          name,
+          value,
+          timeout,
+          configCookiePath,
+          configCookieDomain,
+          configCookieSameSite,
+          configCookieSecure
+        );
       }
       return false;
     }
@@ -621,8 +629,20 @@ export function Tracker(
       const sesname = getSnowplowCookieName('ses');
       attemptDeleteLocalStorage(idname);
       attemptDeleteLocalStorage(sesname);
-      cookieStorage.deleteCookie(idname, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
-      cookieStorage.deleteCookie(sesname, configCookiePath, configCookieDomain, configCookieSameSite, configCookieSecure);
+      cookieStorage.deleteCookie(
+        idname,
+        configCookiePath,
+        configCookieDomain,
+        configCookieSameSite,
+        configCookieSecure
+      );
+      cookieStorage.deleteCookie(
+        sesname,
+        configCookiePath,
+        configCookieDomain,
+        configCookieSameSite,
+        configCookieSecure
+      );
       if (!configuration?.preserveSession) {
         memorizedSessionId = uuid();
         memorizedVisitCount = 1;


### PR DESCRIPTION
In v3, `discoverRootDomain` was disabled by default, and enabling it meant ignoring the `cookieDomain` configuration. If neither were set, cookies would have no `Domain` attribute attached and would bind to the current domain; cookies with no domain are unique in that they do not get shared to subdomains.

In 257ddb31198e48add33c4a39acdb0fdc55d9b248 we updated the `discoverRootDomain` setting to default to enabled, and changed how it interacted with the `cookieDomain` setting so that `discoverRootDomain` is essentially always enabled, but gets ignored if `cookieDomain` is also specified. This however made it impossible to use the 'no domain' behaviour available in v3, because disabling `discoverRootDomain` would have no effect without specifying `cookieDomain` as well.

This can be slightly confusing, so instead, this change allows explicitly disabling `discoverRootDomain` even if no `cookieDomain` is specified, allowing the same behaviour as all configurations available in v3.