### PR TITLE
Support events on buttons/links/forms in ShadowDOMs

### DIFF
--- a/common/changes/@snowplow/browser-plugin-button-click-tracking/shadow-clicks_2024-10-04-05-19.json
+++ b/common/changes/@snowplow/browser-plugin-button-click-tracking/shadow-clicks_2024-10-04-05-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-button-click-tracking",
+      "comment": "Detect button clicks within ShadowRoots",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-button-click-tracking"
+}

--- a/common/changes/@snowplow/browser-plugin-form-tracking/shadow-clicks_2024-10-08-04-36.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/shadow-clicks_2024-10-08-04-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-form-tracking",
+      "comment": "Detect form events within ShadowRoots",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking"
+}

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/shadow-clicks_2024-10-04-05-19.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/shadow-clicks_2024-10-04-05-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-link-click-tracking",
+      "comment": "Detect link clicks within ShadowRoots",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/shadow-clicks_2024-10-08-04-36.json
+++ b/common/changes/@snowplow/javascript-tracker/shadow-clicks_2024-10-08-04-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/plugins/browser-plugin-button-click-tracking/src/api.ts
+++ b/plugins/browser-plugin-button-click-tracking/src/api.ts
@@ -97,7 +97,7 @@ export function disableButtonClickTracking() {
  * @param context - The dynamic context which will be evaluated for each button click event
  */
 function eventHandler(event: MouseEvent, trackerId: string, filter: FilterFunction, context?: DynamicContext) {
-  let elem = event.target as HTMLElement | null;
+  let elem = (event.composed ? event.composedPath()[0] : event.target) as HTMLElement | null;
   while (elem) {
     if (elem instanceof HTMLButtonElement || (elem instanceof HTMLInputElement && elem.type === 'button')) {
       if (filter(elem)) {

--- a/plugins/browser-plugin-form-tracking/src/helpers.ts
+++ b/plugins/browser-plugin-form-tracking/src/helpers.ts
@@ -356,7 +356,20 @@ function getFormChangeListener(
   event_type: Exclude<FormTrackingEvent, FormTrackingEvent.SUBMIT_FORM>,
   context?: DynamicContext | null
 ) {
-  return function ({ target }: Event) {
+  return function (e: Event) {
+    const target = e.composed ? e.composedPath()[0] : e.target;
+
+    // `change` and `submit` are not composed and are thus invisible to us
+    // bind late to the forms/field directly on field focus in this case
+    if (target !== e.target && e.composed && isTrackableElement(target)) {
+      if (target.form) {
+        if (_changeListeners[tracker.id]) addEventListener(target.form, 'change', _changeListeners[tracker.id], true);
+        if (_submitListeners[tracker.id]) addEventListener(target.form, 'submit', _submitListeners[tracker.id], true);
+      } else {
+        if (_changeListeners[tracker.id]) addEventListener(target, 'change', _changeListeners[tracker.id], true);
+      }
+    }
+
     if (isTrackableElement(target) && config.fieldFilter(target)) {
       let value: string | null = null;
       let type: string | null = null;

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -259,7 +259,9 @@ function clickHandler(tracker: string, evt: MouseEvent | undefined): void {
   const event = evt || (window.event as MouseEvent);
 
   const button = event.which || event.button;
-  const target = findNearestEligibleElement(event.target || event.srcElement);
+
+  const clicked = event.composed ? event.composedPath()[0] : event.target || event.srcElement;
+  const target = findNearestEligibleElement(clicked);
 
   if (!target || target.href == null) return;
   if (filter && !filter(target)) return;

--- a/trackers/javascript-tracker/test/integration/autoTracking.test.ts
+++ b/trackers/javascript-tracker/test/integration/autoTracking.test.ts
@@ -1,6 +1,7 @@
 import F from 'lodash/fp';
 import { fetchResults } from '../micro';
 import { pageSetup } from './helpers';
+import { Key } from 'webdriverio';
 
 const isMatchWithCallback = F.isMatchWith((lt, rt) => (F.isFunction(rt) ? rt(lt) : undefined));
 
@@ -303,6 +304,12 @@ describe('Auto tracking', () => {
     let frame = await $('#form_iframe');
     await browser.switchToFrame(frame);
     await $('#fname').click();
+
+    await loadUrlAndWait('/form-tracking.html?filter=shadow');
+    const input = await (await $('shadow-form')).shadow$('input');
+    await input.click();
+    await input.setValue('test');
+    await browser.keys(Key.Enter); // submit
 
     // time for activity to register and request to arrive
     await browser.pause(2500);
@@ -807,6 +814,57 @@ describe('Auto tracking', () => {
           unstruct_event: {
             data: {
               schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+            },
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('should track events from form in a shadowdom', () => {
+    expect(
+      logContains({
+        event: {
+          event: 'unstruct',
+          app_id: 'autotracking-form-' + testIdentifier,
+          page_url: 'http://snowplow-js-tracker.local:8080/form-tracking.html?filter=shadow',
+          unstruct_event: {
+            data: {
+              schema: 'iglu:com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0',
+            },
+          },
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      logContains({
+        event: {
+          event: 'unstruct',
+          app_id: 'autotracking-form-' + testIdentifier,
+          page_url: 'http://snowplow-js-tracker.local:8080/form-tracking.html?filter=shadow',
+          unstruct_event: {
+            data: {
+              schema: 'iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0',
+            },
+          },
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      logContains({
+        event: {
+          event: 'unstruct',
+          app_id: 'autotracking-form-' + testIdentifier,
+          page_url: 'http://snowplow-js-tracker.local:8080/form-tracking.html?filter=shadow',
+          unstruct_event: {
+            data: {
+              schema: 'iglu:com.snowplowanalytics.snowplow/submit_form/jsonschema/1-0-0',
+              data: {
+                formId: 'shadow-form',
+                formClasses: ['shadow-form'],
+              },
             },
           },
         },

--- a/trackers/javascript-tracker/test/integration/buttonClick.test.ts
+++ b/trackers/javascript-tracker/test/integration/buttonClick.test.ts
@@ -70,6 +70,10 @@ describe('Snowplow Micro integration', () => {
       await (await $('#button-child')).click();
       await browser.pause(500);
 
+      // ShadowDOM
+      await (await $('#shadow')).shadow$('button').click();
+      await browser.pause(500);
+
       // Disable/enable
 
       await (await $('#disable')).click();
@@ -138,6 +142,11 @@ describe('Snowplow Micro integration', () => {
 
     it('should get button when click was on a child element', async () => {
       const ev = makeEvent({ label: 'TestChildren' }, method);
+      logContainsButtonClick(ev);
+    });
+
+    it('should get button when click was in a shadow dom', async () => {
+      const ev = makeEvent({ label: 'Shadow' }, method);
       logContainsButtonClick(ev);
     });
 

--- a/trackers/javascript-tracker/test/pages/button-click-tracking.html
+++ b/trackers/javascript-tracker/test/pages/button-click-tracking.html
@@ -36,6 +36,25 @@
     <!-- Ensure button tracked when children are clicked -->
     <button><span id="button-child">TestChildren</span></button>
 
+    <!-- Ensure button tracked when exists in ShadowDOM -->
+    <script>
+      window.customElements.define(
+        'shadow-btn',
+        class extends HTMLElement {
+          connectedCallback() {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.textContent = 'Shadow';
+
+            const shadowRoot = this.attachShadow({ mode: 'open' });
+            shadowRoot.appendChild(b);
+          }
+        }
+      );
+    </script>
+
+    <shadow-btn id="shadow"></shadow-btn>
+
     <!-- Enable/disable testing -->
     <button id="disable" onclick="snowplow('disableButtonClickTracking')">Disable</button>
     <button id="disabled-click">DisabledClick</button>

--- a/trackers/javascript-tracker/test/pages/form-tracking.html
+++ b/trackers/javascript-tracker/test/pages/form-tracking.html
@@ -79,7 +79,32 @@
       iframeDocument.open();
       iframeDocument.write(formHtml);
       iframeDocument.close();
+
+      window.customElements.define(
+        'shadow-form',
+        class extends HTMLElement {
+          connectedCallback() {
+            const form = Object.assign(document.createElement('form'), { id: 'shadow-form', className: 'shadow-form' });
+
+            form.addEventListener(
+              'submit',
+              function (e) {
+                e.preventDefault();
+              },
+              false
+            );
+
+            const input = document.createElement('input');
+            form.appendChild(input);
+
+            const shadowRoot = this.attachShadow({ mode: 'open' });
+            shadowRoot.appendChild(form);
+          }
+        }
+      );
     </script>
+
+    <shadow-form></shadow-form>
 
     <script>
       (function (p, l, o, w, i, n, g) {
@@ -148,6 +173,9 @@
         case 'iframeForm':
           var forms = iframe.contentWindow.document.getElementsByTagName('form');
           snowplow('enableFormTracking', { options: { forms: forms } });
+          break;
+        case 'shadow':
+          snowplow('enableFormTracking', { options: { forms: { allowlist: ['shadow-form'] } } });
           break;
         default:
           snowplow('enableFormTracking', {


### PR DESCRIPTION
When DOM events on elements within Custom Components/ShadowRoots trigger against the `document`, the `target` is set to the Custom Element/shadow host rather than the actual element that caused the event.

This change adds support to the from/button/link tracking plugins to detect when this occurs, and use the first element from the Event's [`composedPath`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) instead of the `target`. This enables them to see the actual even target and fire correctly in this scenario.

For the Form tracker, only `focus` events are considered `composed`, so `change` and `submit` events don't actually get reported outside the shadow DOM. As a workaround, when the `focus` events occur, if enabled the change/submit event listeners are bound directly to the form (or field if it has no associated form) rather than just the `document`.