### PR TITLE
Disable b64 for SDJ data on POST requests from browsers by default

### DIFF
--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -187,7 +187,7 @@ export function Tracker(
 
     let // Tracker core
       core = trackerCore({
-        base64: trackerConfiguration.encodeBase64,
+        base64: trackerConfiguration.encodeBase64 ?? trackerConfiguration.eventMethod !== 'post',
         corePlugins: browserPlugins,
         callback: sendRequest,
       }),

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -81,7 +81,7 @@ export interface LocalStorageEventStoreConfigurationBase extends EventStoreConfi
 export type TrackerConfiguration = {
   /**
    * Should event properties be base64 encoded where supported
-   * @defaultValue true
+   * @defaultValue false unless {@link EmitterConfigurationBase.eventMethod | eventMethod} is `get`
    */
   encodeBase64?: boolean;
   /**


### PR DESCRIPTION
In POST requests this usually results in a smaller payload size, and is easier to debug. The node tracker shares this setting across multiple emitters that may not all use POST so we can't make this assumption there, because it is considerably less efficient when used for GET requests.