### PR TITLE
Make base64 encoding an optional parameter in Node newTracker call

### DIFF
--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.selfdescribingevent.event.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.selfdescribingevent.event.md
@@ -9,5 +9,5 @@ The Self Describing JSON which describes the event
 <b>Signature:</b>
 
 ```typescript
-event: SelfDescribingJson;
+event: SelfDescribingJson<T>;
 ```

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.selfdescribingevent.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.selfdescribingevent.md
@@ -9,12 +9,12 @@ A Self Describing Event A custom event type, allowing for an event to be tracked
 <b>Signature:</b>
 
 ```typescript
-interface SelfDescribingEvent 
+interface SelfDescribingEvent<T = Record<string, unknown>> 
 ```
 
 ## Properties
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [event](./browser-tracker.selfdescribingevent.event.md) | SelfDescribingJson | The Self Describing JSON which describes the event |
+|  [event](./browser-tracker.selfdescribingevent.event.md) | SelfDescribingJson&lt;T&gt; | The Self Describing JSON which describes the event |
 

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.selfdescribingjson.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.selfdescribingjson.md
@@ -9,8 +9,8 @@ Export interface for any Self-Describing JSON such as context or Self Describing
 <b>Signature:</b>
 
 ```typescript
-type SelfDescribingJson<T extends Record<keyof T, unknown> = Record<string, unknown>> = {
+type SelfDescribingJson<T = Record<string, unknown>> = {
     schema: string;
-    data: T;
+    data: T extends any[] ? never : T extends {} ? T : never;
 };
 ```

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.trackselfdescribingevent.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.trackselfdescribingevent.md
@@ -9,14 +9,14 @@ Track a self-describing event happening on this page. A custom event type, allow
 <b>Signature:</b>
 
 ```typescript
-declare function trackSelfDescribingEvent(event: SelfDescribingEvent & CommonEventProperties, trackers?: Array<string>): void;
+declare function trackSelfDescribingEvent<T = Record<string, unknown>>(event: SelfDescribingEvent<T> & CommonEventProperties, trackers?: Array<string>): void;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  event | SelfDescribingEvent &amp; CommonEventProperties | The event information |
+|  event | SelfDescribingEvent&lt;T&gt; &amp; CommonEventProperties | The event information |
 |  trackers | Array&lt;string&gt; | The tracker identifiers which the event will be sent to |
 
 <b>Returns:</b>

--- a/api-docs/docs/node-tracker/markdown/node-tracker.buildselfdescribingevent.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.buildselfdescribingevent.md
@@ -9,14 +9,14 @@ Build a self-describing event A custom event type, allowing for an event to be t
 <b>Signature:</b>
 
 ```typescript
-declare function buildSelfDescribingEvent(event: SelfDescribingEvent): PayloadBuilder;
+declare function buildSelfDescribingEvent<T = Record<string, unknown>>(event: SelfDescribingEvent<T>): PayloadBuilder;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  event | SelfDescribingEvent | Contains the properties and schema location for the event |
+|  event | SelfDescribingEvent&lt;T&gt; | Contains the properties and schema location for the event |
 
 <b>Returns:</b>
 

--- a/api-docs/docs/node-tracker/markdown/node-tracker.selfdescribingevent.event.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.selfdescribingevent.event.md
@@ -9,5 +9,5 @@ The Self Describing JSON which describes the event
 <b>Signature:</b>
 
 ```typescript
-event: SelfDescribingJson;
+event: SelfDescribingJson<T>;
 ```

--- a/api-docs/docs/node-tracker/markdown/node-tracker.selfdescribingevent.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.selfdescribingevent.md
@@ -9,12 +9,12 @@ A Self Describing Event A custom event type, allowing for an event to be tracked
 <b>Signature:</b>
 
 ```typescript
-interface SelfDescribingEvent 
+interface SelfDescribingEvent<T = Record<string, unknown>> 
 ```
 
 ## Properties
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [event](./node-tracker.selfdescribingevent.event.md) | SelfDescribingJson | The Self Describing JSON which describes the event |
+|  [event](./node-tracker.selfdescribingevent.event.md) | SelfDescribingJson&lt;T&gt; | The Self Describing JSON which describes the event |
 

--- a/api-docs/docs/node-tracker/markdown/node-tracker.selfdescribingjson.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.selfdescribingjson.md
@@ -9,8 +9,8 @@ Export interface for any Self-Describing JSON such as context or Self Describing
 <b>Signature:</b>
 
 ```typescript
-type SelfDescribingJson<T extends Record<keyof T, unknown> = Record<string, unknown>> = {
+type SelfDescribingJson<T = Record<string, unknown>> = {
     schema: string;
-    data: T;
+    data: T extends any[] ? never : T extends {} ? T : never;
 };
 ```

--- a/api-docs/docs/node-tracker/markdown/node-tracker.trackerconfiguration.encodebase64.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.trackerconfiguration.encodebase64.md
@@ -7,5 +7,5 @@
 <b>Signature:</b>
 
 ```typescript
-encodeBase64: boolean;
+encodeBase64?: boolean;
 ```

--- a/api-docs/docs/node-tracker/markdown/node-tracker.trackerconfiguration.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.trackerconfiguration.md
@@ -15,6 +15,6 @@ interface TrackerConfiguration
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appId](./node-tracker.trackerconfiguration.appid.md) | string |  |
-|  [encodeBase64](./node-tracker.trackerconfiguration.encodebase64.md) | boolean |  |
+|  [encodeBase64?](./node-tracker.trackerconfiguration.encodebase64.md) | boolean | <i>(Optional)</i> |
 |  [namespace](./node-tracker.trackerconfiguration.namespace.md) | string |  |
 

--- a/api-docs/docs/node-tracker/node-tracker.api.md
+++ b/api-docs/docs/node-tracker/node-tracker.api.md
@@ -517,7 +517,7 @@ export interface TrackerConfiguration {
     appId: string;
     /* The application ID */
     // (undocumented)
-    encodeBase64: boolean;
+    encodeBase64?: boolean;
     /* The application ID */
     // (undocumented)
     namespace: string;

--- a/common/changes/@snowplow/node-tracker/issue-node_tracker_defaults_2024-10-15-06-13.json
+++ b/common/changes/@snowplow/node-tracker/issue-node_tracker_defaults_2024-10-15-06-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/node-tracker",
+      "comment": "Make base64 encoding an optional parameter in Node newTracker call",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/node-tracker"
+}

--- a/trackers/node-tracker/src/tracker.ts
+++ b/trackers/node-tracker/src/tracker.ts
@@ -73,7 +73,10 @@ export interface TrackerConfiguration {
   namespace: string;
   /* The application ID */
   appId: string;
-  /* Whether unstructured events and custom contexts should be base64 encoded. */
+  /**
+   * Whether unstructured events and custom contexts should be base64 encoded.
+   * @default true
+   **/
   encodeBase64?: boolean;
 }
 

--- a/trackers/node-tracker/src/tracker.ts
+++ b/trackers/node-tracker/src/tracker.ts
@@ -74,7 +74,7 @@ export interface TrackerConfiguration {
   /* The application ID */
   appId: string;
   /* Whether unstructured events and custom contexts should be base64 encoded. */
-  encodeBase64: boolean;
+  encodeBase64?: boolean;
 }
 
 export type CustomEmitter = {

--- a/trackers/node-tracker/test/tracker.ts
+++ b/trackers/node-tracker/test/tracker.ts
@@ -72,6 +72,12 @@ function checkPayload(payloadDict: Payload, expected: Payload, t: ExecutionConte
 
 const customFetch = () => Promise.resolve(new Response(null, { status: 200 }));
 
+test('newTracker called with default values', (t) => {
+  const tracker = newTracker({ namespace: 'cf', appId: 'cfe35' }, { endpoint });
+  t.truthy(tracker);
+  t.true(tracker.getBase64Encoding());
+});
+
 for (const eventMethod of testMethods) {
   test(eventMethod + ' method: track API should return eid in the payload', (t) => {
     const track = newTracker(


### PR DESCRIPTION
This PR makes the `encodeBase64` parameter in the `newTracker` call of the Node tracker optional. It keeps the default true setting.