### PR TITLE
Enable batching multiple events into a single POST request over buffer size if maxPostBytes setting is followed

### DIFF
--- a/libraries/tracker-core/src/emitter/emitter_request.ts
+++ b/libraries/tracker-core/src/emitter/emitter_request.ts
@@ -48,7 +48,6 @@ export interface EmitterRequestConfiguration {
   keepalive?: boolean;
   postPath?: string;
   useStm?: boolean;
-  bufferSize?: number;
   maxPostBytes?: number,
   credentials?: 'omit' | 'same-origin' | 'include';
 }
@@ -89,7 +88,6 @@ export function newEmitterRequest({
   keepalive = true,
   postPath = '/com.snowplowanalytics.snowplow/tp2',
   useStm = true,
-  bufferSize,
   maxPostBytes = 40000,
   credentials = 'include',
 }: EmitterRequestConfiguration): EmitterRequest {
@@ -128,9 +126,6 @@ export function newEmitterRequest({
 
   function isFull(): boolean {
     if (usePost) {
-      if (bufferSize !== undefined && countEvents() >= Math.max(1, bufferSize)) {
-        return true;
-      }
       return countBytes() >= maxPostBytes;
     } else {
       return events.length >= 1;

--- a/libraries/tracker-core/src/emitter/emitter_request.ts
+++ b/libraries/tracker-core/src/emitter/emitter_request.ts
@@ -100,10 +100,14 @@ export function newEmitterRequest({
   let abortController: AbortController | undefined;
 
   function countBytes(): number {
-    return events.reduce(
+    let count = events.reduce(
       (acc, event) => acc + (usePost ? event.getPOSTRequestBytesCount() : event.getGETRequestBytesCount()),
       0
     );
+    if (usePost) {
+      count += 88; // 88 bytes for the payload_data envelope
+    }
+    return count;
   }
 
   function countEvents(): number {

--- a/libraries/tracker-core/src/emitter/index.ts
+++ b/libraries/tracker-core/src/emitter/index.ts
@@ -326,7 +326,7 @@ export function newEmitter({
       LOG.warn('Event (' + bytes + 'B) too big, max is ' + maxBytes);
 
     if (usePost) {
-      const bytes = emitterEvent.getPOSTRequestBytesCount();
+      const bytes = emitterEvent.getPOSTRequestBytesCount() + 88; // 88 bytes for the payload_data envelope
       const tooBig = bytes > maxPostBytes;
       if (tooBig) {
         eventTooBigWarning(bytes, maxPostBytes);

--- a/libraries/tracker-core/src/emitter/index.ts
+++ b/libraries/tracker-core/src/emitter/index.ts
@@ -47,6 +47,7 @@ export interface EmitterConfigurationBase {
   bufferSize?: number;
   /**
    * The max size a POST request can be before the tracker will force send it
+   * Also dictates the max size of a POST request before a batch of events is split into multiple requests
    * @defaultValue 40000
    */
   maxPostBytes?: number;
@@ -312,7 +313,6 @@ export function newEmitter({
       customHeaders,
       connectionTimeout,
       keepalive,
-      bufferSize,
       maxPostBytes,
       useStm,
       credentials,

--- a/libraries/tracker-core/src/emitter/index.ts
+++ b/libraries/tracker-core/src/emitter/index.ts
@@ -275,7 +275,7 @@ export function newEmitter({
     try {
       const response = await customFetch(fetchRequest);
 
-      request.cancelTimeoutTimer();
+      request.closeRequest(true);
 
       if (response.ok) {
         callOnRequestSuccess(payloads, response);
@@ -294,6 +294,8 @@ export function newEmitter({
         return { success: false, retry: willRetry, status: response.status };
       }
     } catch (e) {
+      request.closeRequest(false);
+
       const message = typeof e === 'string' ? e : e ? (e as Error).message : 'Unknown error';
       callOnRequestFailure({
         events: payloads,

--- a/libraries/tracker-core/test/emitter/emitter_request.test.ts
+++ b/libraries/tracker-core/test/emitter/emitter_request.test.ts
@@ -6,7 +6,7 @@ import { newEventStorePayload } from '../../src/event_store_payload';
 
 const newEmitterEventFromPayload = (payload: Record<string, unknown>) => {
   return newEmitterEvent(newEventStorePayload({ payload }));
-}
+};
 
 // MARK: - addEvent
 
@@ -89,34 +89,31 @@ test('countEvents returns the correct event count', (t) => {
 
 // MARK: - isFull
 
-test('isFull returns false when not reached buffer size', (t) => {
+test('isFull returns false when not reached max post bytes', (t) => {
   const request = newEmitterRequest({
     endpoint: 'https://example.com',
     maxPostBytes: 1000,
-    bufferSize: 2,
   });
 
   t.true(request.addEvent(newEmitterEventFromPayload({ e: 'pv', p: 'web' })));
   t.false(request.isFull());
 });
 
-test('isFull returns true when reached buffer size', (t) => {
+test('isFull returns false when reached buffer size and not max post bytes', (t) => {
   const request = newEmitterRequest({
     endpoint: 'https://example.com',
     maxPostBytes: 1000,
-    bufferSize: 2,
   });
 
   t.true(request.addEvent(newEmitterEventFromPayload({ e: 'pv', p: 'web' })));
   t.true(request.addEvent(newEmitterEventFromPayload({ e: 'pv', p: 'mob' })));
-  t.true(request.isFull());
+  t.false(request.isFull());
 });
 
 test('isFull returns true when reached max post bytes', (t) => {
   const request = newEmitterRequest({
     endpoint: 'https://example.com',
     maxPostBytes: 10,
-    bufferSize: 2,
   });
 
   t.true(request.addEvent(newEmitterEventFromPayload({ e: 'pv', p: 'web' })));

--- a/libraries/tracker-core/test/emitter/emitter_request.test.ts
+++ b/libraries/tracker-core/test/emitter/emitter_request.test.ts
@@ -71,7 +71,7 @@ test('countBytes returns the correct byte count', (t) => {
 
   t.true(request.addEvent(newEmitterEventFromPayload({ e: 'pv', p: 'web' })));
   t.true(request.addEvent(newEmitterEventFromPayload({ e: 'pv', p: 'mob' })));
-  t.is(request.countBytes(), 40);
+  t.is(request.countBytes(), 40 + 88); // 40 bytes for each event, 88 bytes for the payload_data envelope
 });
 
 // MARK: - countEvents

--- a/libraries/tracker-core/test/emitter/index.test.ts
+++ b/libraries/tracker-core/test/emitter/index.test.ts
@@ -311,8 +311,9 @@ test('adds a timeout to the request', async (t) => {
 
     return new Promise((resolve, reject) => {
       let timer = setTimeout(() => {
+        t.fail('Request should have timed out');
         resolve(new Response(null, { status: 200 }));
-      }, 1000);
+      }, 500);
 
       input.signal?.addEventListener('abort', () => {
         clearTimeout(timer);

--- a/plugins/browser-plugin-media-tracking/tests/test.test.ts
+++ b/plugins/browser-plugin-media-tracking/tests/test.test.ts
@@ -62,6 +62,7 @@ describe('MediaTrackingPlugin', () => {
         },
       ],
       contexts: { webPage: false },
+      customFetch: async () => new Response(null, { status: 200 }),
     });
     id = `media-${idx}`;
   });

--- a/plugins/browser-plugin-media/test/api.test.ts
+++ b/plugins/browser-plugin-media/test/api.test.ts
@@ -57,6 +57,7 @@ describe('Media Tracking API', () => {
         },
       ],
       contexts: { webPage: false },
+      customFetch: async () => new Response(null, { status: 200 }),
     });
     id = `media-${idx}`;
   });

--- a/trackers/node-tracker/test/tracker.ts
+++ b/trackers/node-tracker/test/tracker.ts
@@ -244,11 +244,13 @@ for (const eventMethod of testMethods) {
             eventMethod,
             bufferSize: 0,
             onRequestSuccess: (batch) => {
-              const expected = batch[0]['e'] === 'tr' ? expectedTransaction : expectedItem;
+              batch.forEach((payload) => {
+                const expected = payload['e'] === 'tr' ? expectedTransaction : expectedItem;
 
-              checkPayload(batch[0], expected, t);
+                checkPayload(payload, expected, t);
 
-              requestCount--;
+                requestCount--;
+              });
               if (requestCount === 0) {
                 resolve(batch);
               }
@@ -472,11 +474,13 @@ for (const eventMethod of testMethods) {
         endpoint,
         eventMethod,
         bufferSize: 0,
-        onRequestSuccess: ([pl]) => {
-          checkPayload(pl, expected, t);
-          count--;
+        onRequestSuccess: (batch) => {
+          batch.forEach((pl) => {
+            checkPayload(pl, expected, t);
+            count--;
+          });
           if (count === 0) {
-            resolve(pl);
+            resolve(batch);
           }
         },
         onRequestFailure: reject,


### PR DESCRIPTION
This PR enables POST requests to contain more events than configured through `bufferSize` as long as they don't surpass the `maxPostBytes`.

The reason for this is to send events queued up in the event store in a single POST request rather than individually. This may happen for instance if some events didn't manage to be saved on the previous page visit (or the collector was not reachable). With this feature, they should be sent in one batch request on the next visit.

It may also happen in events are tracked right after each other – if they manage to be saved to the event store before the flush function is called, they will be batched together.

The change might be useful also with issue #1355 where part of the problem could be too many requests done shortly after each other.