### PR TITLE
Update uuid package dependency to version 9.0.1 (close #1305)

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^2.3.1
         version: 2.6.3
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@ampproject/rollup-plugin-closure-compiler':
         specifier: ~0.27.0
@@ -47,8 +47,8 @@ importers:
         specifier: ~1.1.3
         version: 1.1.5
       '@types/uuid':
-        specifier: ^8.3.2
-        version: 8.3.4
+        specifier: ^9.0.1
+        version: 9.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -101,8 +101,8 @@ importers:
         specifier: ^2.3.1
         version: 2.6.3
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@ampproject/rollup-plugin-closure-compiler':
         specifier: ~0.27.0
@@ -120,8 +120,8 @@ importers:
         specifier: ~14.6.0
         version: 14.6.4
       '@types/uuid':
-        specifier: ^8.3.2
-        version: 8.3.4
+        specifier: ^9.0.1
+        version: 9.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -1123,8 +1123,8 @@ importers:
         specifier: ^2.3.1
         version: 2.6.3
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@ampproject/rollup-plugin-closure-compiler':
         specifier: ~0.27.0
@@ -1142,8 +1142,8 @@ importers:
         specifier: ~16.2.14
         version: 16.2.15
       '@types/uuid':
-        specifier: ^8.3.2
-        version: 8.3.4
+        specifier: ^9.0.1
+        version: 9.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -1202,8 +1202,8 @@ importers:
         specifier: ^2.3.1
         version: 2.6.3
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@ampproject/rollup-plugin-closure-compiler':
         specifier: ~0.27.0
@@ -1221,8 +1221,8 @@ importers:
         specifier: ~16.2.14
         version: 16.2.15
       '@types/uuid':
-        specifier: ^8.3.2
-        version: 8.3.4
+        specifier: ^9.0.1
+        version: 9.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -1944,8 +1944,8 @@ importers:
         specifier: ^2.3.1
         version: 2.6.3
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@ampproject/rollup-plugin-closure-compiler':
         specifier: ~0.27.0
@@ -1963,8 +1963,8 @@ importers:
         specifier: ~16.2.14
         version: 16.2.15
       '@types/uuid':
-        specifier: ^8.3.2
-        version: 8.3.4
+        specifier: ^9.0.1
+        version: 9.0.8
       '@types/youtube':
         specifier: ~0.0.46
         version: 0.0.50
@@ -2973,8 +2973,8 @@ packages:
   '@types/ua-parser-js@0.7.39':
     resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
 
-  '@types/uuid@8.3.4':
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/vimeo__player@2.16.3':
     resolution: {integrity: sha512-hsOe6CZFTNyfjRjQUrNHBF4LDmjvjcU2yQIPWp5AglKeGxt11JYGToQhKUPM876gBXggqR6rMQ0/sNI06ec2Rg==}
@@ -7084,8 +7084,8 @@ packages:
     resolution: {integrity: sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==}
     hasBin: true
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -8239,7 +8239,7 @@ snapshots:
 
   '@types/ua-parser-js@0.7.39': {}
 
-  '@types/uuid@8.3.4': {}
+  '@types/uuid@9.0.8': {}
 
   '@types/vimeo__player@2.16.3': {}
 
@@ -13299,7 +13299,7 @@ snapshots:
 
   uuid@8.1.0: {}
 
-  uuid@8.3.2: {}
+  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "ee6607493b34d686c39a612fcb8e407675d4e985",
+  "pnpmShrinkwrapHash": "9e32dd40aacfa59661f34c45c0c6e814262e0315",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/browser-tracker-core/package.json
+++ b/libraries/browser-tracker-core/package.json
@@ -25,7 +25,7 @@
     "@snowplow/tracker-core": "workspace:*",
     "sha1": "^1.1.1",
     "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
@@ -34,7 +34,7 @@
     "@types/jest": "~27.4.1",
     "@types/jsdom": "~16.2.14",
     "@types/sha1": "~1.1.3",
-    "@types/uuid": "^8.3.2",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "eslint": "~8.11.0",

--- a/libraries/tracker-core/package.json
+++ b/libraries/tracker-core/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
@@ -53,7 +53,7 @@
     "@rollup/plugin-json": "~4.1.0",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/node": "~14.6.0",
-    "@types/uuid": "^8.3.2",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "ava": "~5.1.1",

--- a/plugins/browser-plugin-media-tracking/package.json
+++ b/plugins/browser-plugin-media-tracking/package.json
@@ -25,7 +25,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
@@ -33,7 +33,7 @@
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~27.4.1",
     "@types/jsdom": "~16.2.14",
-    "@types/uuid": "^8.3.2",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "eslint": "~8.11.0",

--- a/plugins/browser-plugin-media/package.json
+++ b/plugins/browser-plugin-media/package.json
@@ -25,7 +25,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
@@ -33,7 +33,7 @@
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~27.4.1",
     "@types/jsdom": "~16.2.14",
-    "@types/uuid": "^8.3.2",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "eslint": "~8.11.0",

--- a/plugins/browser-plugin-youtube-tracking/package.json
+++ b/plugins/browser-plugin-youtube-tracking/package.json
@@ -25,7 +25,7 @@
     "@snowplow/tracker-core": "workspace:*",
     "@snowplow/browser-plugin-media": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
@@ -33,7 +33,7 @@
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~27.4.1",
     "@types/jsdom": "~16.2.14",
-    "@types/uuid": "^8.3.2",
+    "@types/uuid": "^9.0.1",
     "@types/youtube": "~0.0.46",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",


### PR DESCRIPTION
This PR further updates the uuid package used by the tracker from v7 to v9. The reason for this is the performance improvements that they introduced:

1. optimize uuid.v1 by 1.3x uuid.v4 by 4.3x (430%) (https://github.com/uuidjs/uuid/issues/597) ([3a033f6](https://github.com/uuidjs/uuid/commit/3a033f6bab6bb3780ece6d645b902548043280bc))
2. use native crypto.randomUUID when available (https://github.com/uuidjs/uuid/issues/600) ([c9e076c](https://github.com/uuidjs/uuid/commit/c9e076c852edad7e9a06baaa1d148cf4eda6c6c4))

This uuid version drops support for older Node and browser versions:

* Drop Node.js 10.x support
* Drop IE 11 and Safari 10 support. Drop support for browsers that don't correctly implement const/let and default arguments, and no longer transpile the browser build to ES2015.

There already is version 11 of the uuid package, but that further drops browser and node support (already dropped 14), which I am not sure if we should do. 