### PR TITLE
Read the request response to avoid overlapping requests to collector

### DIFF
--- a/libraries/tracker-core/src/emitter/index.ts
+++ b/libraries/tracker-core/src/emitter/index.ts
@@ -274,6 +274,7 @@ export function newEmitter({
     const payloads = request.getEvents().map((event) => event.getPayload());
     try {
       const response = await customFetch(fetchRequest);
+      await response.text(); // wait for the response to be fully read
 
       request.closeRequest(true);
 


### PR DESCRIPTION
Aims to address issue #1355.

This PR adds an await for the response body to be read before continuing with the emitter loop. Previously it was possible that requests overlapped since the emitter could start a new request (for follow up events) before the previous response was fully received. This could have caused problems with the fetch keepalive limitations.