### PR TITLE
Change the default value for keepalive to false

### DIFF
--- a/libraries/tracker-core/src/emitter/emitter_request.ts
+++ b/libraries/tracker-core/src/emitter/emitter_request.ts
@@ -88,7 +88,7 @@ export function newEmitterRequest({
   eventMethod = 'post',
   customHeaders,
   connectionTimeout,
-  keepalive = true,
+  keepalive = false,
   postPath = '/com.snowplowanalytics.snowplow/tp2',
   useStm = true,
   maxPostBytes = 40000,

--- a/libraries/tracker-core/src/emitter/index.ts
+++ b/libraries/tracker-core/src/emitter/index.ts
@@ -116,7 +116,8 @@ export interface EmitterConfigurationBase {
   /**
    * Indicates that the request should be allowed to outlive the webpage that initiated it.
    * Enables collector requests to complete even if the page is closed or navigated away from.
-   * @defaultValue true (not supported in Node.js)
+   * Note: Browsers put a limit on keepalive requests of 64KB. In case of multiple keepalive requests in parallel (may happen in case of multiple trackers), the limit is shared.
+   * @defaultValue false
    */
   keepalive?: boolean;
   /**

--- a/libraries/tracker-core/test/emitter/emitter_request.test.ts
+++ b/libraries/tracker-core/test/emitter/emitter_request.test.ts
@@ -133,7 +133,6 @@ test('toRequest returns a Request object with default settings', (t) => {
   t.is(req.method, 'POST');
   t.is(req.headers.get('Content-Type'), 'application/json; charset=UTF-8');
   t.is(req.headers.get('SP-Anonymous'), null);
-  t.is(req.keepalive, true);
 });
 
 test('toRequest builds a GET request when method is get', (t) => {
@@ -194,12 +193,12 @@ test('toRequest includes server anonymization header', (t) => {
 test('toRequest contains keepalive', (t) => {
   const request = newEmitterRequest({
     endpoint: 'https://example.com',
-    keepalive: false,
+    keepalive: true,
   });
 
   t.true(request.addEvent(newEmitterEventFromPayload({ e: 'pv', p: 'web' })));
   const req = request.toRequest()!;
-  t.is(req.keepalive, false);
+  t.is(req.keepalive, true);
 });
 
 test('toRequest URL contains custom POST path', (t) => {


### PR DESCRIPTION
This PR disables fetch keepalive by default.

The reason for this is the 64KB limit that browsers put on the keepalive requests. Although the default `maxPostBytes` is under this limit so we shouldn't run into for single requests, the limit is shared for parallel requests. We have seen this when testing in internal apps that have multiple initialized trackers that send events at once – this caused the requests to go into a pending state and fail.

A related problem was reported in #1355 – I think we were able to fix this for the case where there is a single tracker instance sending events, but not for the multiple tracker instances case. Since we can't fix it for that case, we can't keep the default setting to true.