### PR TITLE
Fill empty targetUrl for link clicks with "about:nothing" to avoid failed events and output a warning

### DIFF
--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -190,6 +190,8 @@ export function trackLinkClick(
 
 /**
  * Process a clicked element into a link_click event payload.
+ * 
+ * In case the href of the element is empty, "about:invalid" is used as the target URL.
  *
  * @param sourceElement The trackable element to be used to build the payload
  * @param includeContent Whether to include the element's contents in the payload
@@ -210,9 +212,13 @@ function processClick(sourceElement: TrackableElement, includeContent: boolean =
     elementTarget = anchorElement.target;
     elementContent = includeContent ? anchorElement.innerHTML : undefined;
 
+    if (!targetUrl) {
+      console.warn('Link click target URL empty', anchorElement);
+    }
+
     // decodeUrl %xx
     return buildLinkClick({
-      targetUrl,
+      targetUrl: targetUrl || 'about:invalid',
       elementId,
       elementClasses,
       elementTarget,

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -213,7 +213,7 @@ function processClick(sourceElement: TrackableElement, includeContent: boolean =
     elementContent = includeContent ? anchorElement.innerHTML : undefined;
 
     if (!targetUrl) {
-      console.warn('Link click target URL empty', anchorElement);
+      _logger?.warn('Link click target URL empty', anchorElement);
     }
 
     // decodeUrl %xx

--- a/plugins/browser-plugin-link-click-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-link-click-tracking/test/events.test.ts
@@ -207,6 +207,26 @@ describe('LinkClickTrackingPlugin', () => {
       });
     });
 
+    it('tracks clicks on links without href', async () => {
+      enableLinkClickTracking();
+
+      const target = document.createElement('a');
+      document.body.appendChild(target);
+
+      target.click();
+
+      expect(
+        extractUeEvent('iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1').from(
+          await eventStore.getAllPayloads()
+        )
+      ).toMatchObject({
+        schema: 'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+        data: {
+          targetUrl: 'about:invalid',
+        },
+      });
+    });
+
     it('tracks clicks on child elements of links and contents', async () => {
       enableLinkClickTracking({ trackContent: true });
 


### PR DESCRIPTION
In case a click on a link with empty `href` is tracked, set `about:nothing` as the `targetUrl` in the event to avoid the event failing validation.

Also logs a `console.warn` to help users identify and fix these issues.