### PR TITLE
Fix removal of context generator functions

### DIFF
--- a/common/changes/@snowplow/tracker-core/remove-context-generators-v3_2024-10-25-00-04.json
+++ b/common/changes/@snowplow/tracker-core/remove-context-generators-v3_2024-10-25-00-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Fix removal of global context generators",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/tracker-core/test/contexts.ts
+++ b/libraries/tracker-core/test/contexts.ts
@@ -237,6 +237,21 @@ test('Remove one of two global context primitives', (t) => {
   t.deepEqual(globalContexts.getGlobalPrimitives(), [webPageContext]);
 });
 
+test('Remove one of two global context generators', (t) => {
+  function a(): undefined {
+    return;
+  }
+  function b(): undefined {
+    return;
+  }
+
+  const globalContexts = contexts.globalContexts();
+  globalContexts.addGlobalContexts([a, b]);
+  t.deepEqual(globalContexts.getGlobalPrimitives(), [a, b]);
+  globalContexts.removeGlobalContexts([a]);
+  t.deepEqual(globalContexts.getGlobalPrimitives(), [b]);
+});
+
 test('Remove one of two global context conditional providers', (t) => {
   const geolocationContext = {
     schema: 'iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-1-0',


### PR DESCRIPTION
This fixes an issue when using `removeGlobalContexts` to remove a [context generator function](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/custom-tracking-using-schemas/global-context/#context-generators) when multiple generator functions have been added.

In 3.0.0 the method of identifying the `ContextPrimitive` to remove was changed from equality/identity to comparing the JSON serialization of the entities. Unfortunately, this doesn't handle the generator function case, because `JSON.stringify(function(){})` returns `undefined`, which means all added context generators appear identical, so removing one generator actually removes all of them.

This changes the comparison to be identity-based for functions, and remain JSON-based for static entities.

It also fixes matching on for `ConditionalContextProviders` by implementing a deep comparison. A purely identity-based approach is much simpler, but only a partial solution; non-identical providers with the same static entities added with different filter functions would still collide if the identities of the array don't match correctly.