### PR TITLE
Allow 0x0 viewport in browser context to avoid schema validation errors

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-allow_zero_viewport_2024-10-28-09-31.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-allow_zero_viewport_2024-10-28-09-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Allow 0x0 viewport in browser context to avoid schema validation errors",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/helpers/browser_props.ts
+++ b/libraries/browser-tracker-core/src/helpers/browser_props.ts
@@ -103,11 +103,7 @@ function detectViewport() {
     height = e['clientHeight'];
   }
 
-  if (width >= 0 && height >= 0) {
-    return width + DIMENSION_SEPARATOR + height;
-  } else {
-    return null;
-  }
+  return Math.max(0, width) + DIMENSION_SEPARATOR + Math.max(0, height);
 }
 
 /**


### PR DESCRIPTION
This PR allows the viewport property in the [browser_context schema](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/browser_context/jsonschema/2-0-0) to be 0x0 instead of making it null. The property is required in the schema, so null caused validation errors.

I think it's sensible to allow the 0x0 values since we do the same for `documentSize` and `resolution` properties in the same context entity. I don't see why we should make it null in that case especially since it's causing failed events.