### PR TITLE
Release/3.24.6

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-allow_zero_viewport_2024-10-28-09-31.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-allow_zero_viewport_2024-10-28-09-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Allow 0x0 viewport in browser context to avoid schema validation errors",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/helpers/browser_props.ts
+++ b/libraries/browser-tracker-core/src/helpers/browser_props.ts
@@ -103,11 +103,7 @@ function detectViewport() {
     height = e['clientHeight'];
   }
 
-  if (width >= 0 && height >= 0) {
-    return width + DIMENSION_SEPARATOR + height;
-  } else {
-    return null;
-  }
+  return Math.max(0, width) + DIMENSION_SEPARATOR + Math.max(0, height);
 }
 
 /**


### PR DESCRIPTION
This PR addresses a problem with validation errors for the browser context entity in case browsers reported 0 width and height.

**Bug fixes**

- Allow 0x0 viewport in browser context to avoid schema validation errors (#1365)