### PR TITLE
Fix broken API docs generation by adding explicit type for EventStoreIteratorNextResult

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -287,12 +287,10 @@ export interface EventStoreConfiguration {
     maxSize?: number;
 }
 
-// @public (undocumented)
+// @public
 export interface EventStoreIterator {
-    next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+    // Warning: (ae-forgotten-export) The symbol "EventStoreIteratorNextResult" needs to be exported by the entry point index.module.d.ts
+    next: () => Promise<EventStoreIteratorNextResult>;
 }
 
 // @public (undocumented)

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.md
@@ -4,6 +4,8 @@
 
 ## EventStoreIterator interface
 
+EventStoreIterator allows iterating over all events in the store.
+
 <b>Signature:</b>
 
 ```typescript
@@ -14,5 +16,5 @@ interface EventStoreIterator
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [next](./browser-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;{ value: EventStorePayload \| undefined; done: boolean; }&gt; | Retrieve the next event in the store |
+|  [next](./browser-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;EventStoreIteratorNextResult&gt; | Retrieve the next event in the store |
 

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.next.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.next.md
@@ -9,8 +9,5 @@ Retrieve the next event in the store
 <b>Signature:</b>
 
 ```typescript
-next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+next: () => Promise<EventStoreIteratorNextResult>;
 ```

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.md
@@ -71,7 +71,7 @@
 |  [EventPayloadAndContext](./browser-tracker.eventpayloadandcontext.md) | Interface for returning a built event (PayloadBuilder) and context (Array of SelfDescribingJson). |
 |  [EventStore](./browser-tracker.eventstore.md) | EventStore allows storing and retrieving events before they are sent to the collector |
 |  [EventStoreConfiguration](./browser-tracker.eventstoreconfiguration.md) |  |
-|  [EventStoreIterator](./browser-tracker.eventstoreiterator.md) |  |
+|  [EventStoreIterator](./browser-tracker.eventstoreiterator.md) | EventStoreIterator allows iterating over all events in the store. |
 |  [EventStorePayload](./browser-tracker.eventstorepayload.md) |  |
 |  [FlushBufferConfiguration](./browser-tracker.flushbufferconfiguration.md) | The configuration that can be changed when flushing the buffer |
 |  [LocalStorageEventStoreConfigurationBase](./browser-tracker.localstorageeventstoreconfigurationbase.md) |  |

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.trackerconfiguration.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.trackerconfiguration.md
@@ -44,6 +44,5 @@ newTracker('sp1', 'collector.my-website.com', {
  plugins: [ PerformanceTimingPlugin(), AdTrackingPlugin() ],
  stateStorageStrategy: 'cookieAndLocalStorage'
 });
-
 ```
 

--- a/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.md
@@ -4,6 +4,8 @@
 
 ## EventStoreIterator interface
 
+EventStoreIterator allows iterating over all events in the store.
+
 <b>Signature:</b>
 
 ```typescript
@@ -14,5 +16,5 @@ interface EventStoreIterator
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [next](./node-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;{ value: EventStorePayload \| undefined; done: boolean; }&gt; | Retrieve the next event in the store |
+|  [next](./node-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;EventStoreIteratorNextResult&gt; | Retrieve the next event in the store |
 

--- a/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.next.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.next.md
@@ -9,8 +9,5 @@ Retrieve the next event in the store
 <b>Signature:</b>
 
 ```typescript
-next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+next: () => Promise<EventStoreIteratorNextResult>;
 ```

--- a/api-docs/docs/node-tracker/markdown/node-tracker.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.md
@@ -58,7 +58,7 @@
 |  [EventPayloadAndContext](./node-tracker.eventpayloadandcontext.md) | Interface for returning a built event (PayloadBuilder) and context (Array of SelfDescribingJson). |
 |  [EventStore](./node-tracker.eventstore.md) | EventStore allows storing and retrieving events before they are sent to the collector |
 |  [EventStoreConfiguration](./node-tracker.eventstoreconfiguration.md) |  |
-|  [EventStoreIterator](./node-tracker.eventstoreiterator.md) |  |
+|  [EventStoreIterator](./node-tracker.eventstoreiterator.md) | EventStoreIterator allows iterating over all events in the store. |
 |  [EventStorePayload](./node-tracker.eventstorepayload.md) |  |
 |  [FormFocusOrChangeEvent](./node-tracker.formfocusorchangeevent.md) | Represents either a Form Focus or Form Change event When a user focuses on a form element or when a user makes a change to a form element. |
 |  [FormSubmissionEvent](./node-tracker.formsubmissionevent.md) | A Form Submission Event Used to track when a user submits a form |

--- a/api-docs/docs/node-tracker/node-tracker.api.md
+++ b/api-docs/docs/node-tracker/node-tracker.api.md
@@ -298,12 +298,10 @@ export interface EventStoreConfiguration {
     maxSize?: number;
 }
 
-// @public (undocumented)
+// @public
 export interface EventStoreIterator {
-    next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+    // Warning: (ae-forgotten-export) The symbol "EventStoreIteratorNextResult" needs to be exported by the entry point index.module.d.ts
+    next: () => Promise<EventStoreIteratorNextResult>;
 }
 
 // @public (undocumented)

--- a/common/changes/@snowplow/tracker-core/issue-fix_api_docs_2024-10-28-13-31.json
+++ b/common/changes/@snowplow/tracker-core/issue-fix_api_docs_2024-10-28-13-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Fix broken API docs generation by adding explicit type for EventStoreIteratorNextResult",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/tracker-core/src/event_store.ts
+++ b/libraries/tracker-core/src/event_store.ts
@@ -1,11 +1,28 @@
 import { EventStorePayload } from './event_store_payload';
 import { Payload } from './payload';
 
+/**
+ * Result of the next operation on an EventStoreIterator.
+ */
+export interface EventStoreIteratorNextResult {
+  /**
+   * The next event in the store, or undefined if there are no more events.
+   */
+  value: EventStorePayload | undefined;
+  /**
+   * True if there are no more events in the store.
+   */
+  done: boolean;
+}
+
+/**
+ * EventStoreIterator allows iterating over all events in the store.
+ */
 export interface EventStoreIterator {
   /**
    * Retrieve the next event in the store
    */
-  next: () => Promise<{ value: EventStorePayload | undefined; done: boolean }>;
+  next: () => Promise<EventStoreIteratorNextResult>;
 }
 
 /**


### PR DESCRIPTION
The API docs action failed on publishing the last release because the return type of the `next()` function in the `EventStoreIterator` did not have an explicit type definition, which the API docs don't support.

This PR adds the type and updates the API docs.