### PR TITLE
Fix initialization of the HTML5 media tracking plugin so that it initializes the parent media plugin

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_media_tracking_plugin_init_2024-11-01-09-22.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_media_tracking_plugin_init_2024-11-01-09-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Fix initialization of the HTML5 media tracking plugin so that it initializes the parent media plugin (#1369)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/plugins/browser-plugin-media-tracking/src/api.ts
+++ b/plugins/browser-plugin-media-tracking/src/api.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@snowplow/tracker-core';
-import { BrowserPlugin, BrowserTracker } from '@snowplow/browser-tracker-core';
+import { BrowserPlugin } from '@snowplow/browser-tracker-core';
 import { waitForElement } from './findElem';
 import { Config, isElementConfig, isStringConfig } from './config';
 import { setUpListeners } from './player';
@@ -14,16 +14,13 @@ import { HTML5MediaEventTypes } from './config';
 // @ts-ignore: TS6133
 import { FilterOutRepeatedEvents } from '@snowplow/browser-plugin-media/src/types';
 
-import { endMediaTracking } from '@snowplow/browser-plugin-media';
+import { endMediaTracking, SnowplowMediaPlugin } from '@snowplow/browser-plugin-media';
 
 let LOG: Logger;
-const _trackers: Record<string, BrowserTracker> = {};
 
 export function MediaTrackingPlugin(): BrowserPlugin {
   return {
-    activateBrowserPlugin: (tracker: BrowserTracker) => {
-      _trackers[tracker.id] = tracker;
-    },
+    ...SnowplowMediaPlugin(),
     logger: (logger) => {
       LOG = logger;
     },


### PR DESCRIPTION
This PR fixes a bug in the v4 HTML5 media tracking plugin in that it didn't initialize the trackers in the parent media plugin which then couldn't track any events. The fix is the same as in the YouTube and Vimeo plugins to make sure the `activateBrowserPlugin` function from the media plugin is propagated from the media tracking one as well.