### PR TITLE
Release/4.0.1

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -287,12 +287,10 @@ export interface EventStoreConfiguration {
     maxSize?: number;
 }
 
-// @public (undocumented)
+// @public
 export interface EventStoreIterator {
-    next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+    // Warning: (ae-forgotten-export) The symbol "EventStoreIteratorNextResult" needs to be exported by the entry point index.module.d.ts
+    next: () => Promise<EventStoreIteratorNextResult>;
 }
 
 // @public (undocumented)

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.md
@@ -4,6 +4,8 @@
 
 ## EventStoreIterator interface
 
+EventStoreIterator allows iterating over all events in the store.
+
 <b>Signature:</b>
 
 ```typescript
@@ -14,5 +16,5 @@ interface EventStoreIterator
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [next](./browser-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;{ value: EventStorePayload \| undefined; done: boolean; }&gt; | Retrieve the next event in the store |
+|  [next](./browser-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;EventStoreIteratorNextResult&gt; | Retrieve the next event in the store |
 

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.next.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.eventstoreiterator.next.md
@@ -9,8 +9,5 @@ Retrieve the next event in the store
 <b>Signature:</b>
 
 ```typescript
-next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+next: () => Promise<EventStoreIteratorNextResult>;
 ```

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.md
@@ -71,7 +71,7 @@
 |  [EventPayloadAndContext](./browser-tracker.eventpayloadandcontext.md) | Interface for returning a built event (PayloadBuilder) and context (Array of SelfDescribingJson). |
 |  [EventStore](./browser-tracker.eventstore.md) | EventStore allows storing and retrieving events before they are sent to the collector |
 |  [EventStoreConfiguration](./browser-tracker.eventstoreconfiguration.md) |  |
-|  [EventStoreIterator](./browser-tracker.eventstoreiterator.md) |  |
+|  [EventStoreIterator](./browser-tracker.eventstoreiterator.md) | EventStoreIterator allows iterating over all events in the store. |
 |  [EventStorePayload](./browser-tracker.eventstorepayload.md) |  |
 |  [FlushBufferConfiguration](./browser-tracker.flushbufferconfiguration.md) | The configuration that can be changed when flushing the buffer |
 |  [LocalStorageEventStoreConfigurationBase](./browser-tracker.localstorageeventstoreconfigurationbase.md) |  |

--- a/api-docs/docs/browser-tracker/markdown/browser-tracker.trackerconfiguration.md
+++ b/api-docs/docs/browser-tracker/markdown/browser-tracker.trackerconfiguration.md
@@ -44,6 +44,5 @@ newTracker('sp1', 'collector.my-website.com', {
  plugins: [ PerformanceTimingPlugin(), AdTrackingPlugin() ],
  stateStorageStrategy: 'cookieAndLocalStorage'
 });
-
 ```
 

--- a/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.md
@@ -4,6 +4,8 @@
 
 ## EventStoreIterator interface
 
+EventStoreIterator allows iterating over all events in the store.
+
 <b>Signature:</b>
 
 ```typescript
@@ -14,5 +16,5 @@ interface EventStoreIterator
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [next](./node-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;{ value: EventStorePayload \| undefined; done: boolean; }&gt; | Retrieve the next event in the store |
+|  [next](./node-tracker.eventstoreiterator.next.md) | () =&gt; Promise&lt;EventStoreIteratorNextResult&gt; | Retrieve the next event in the store |
 

--- a/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.next.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.eventstoreiterator.next.md
@@ -9,8 +9,5 @@ Retrieve the next event in the store
 <b>Signature:</b>
 
 ```typescript
-next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+next: () => Promise<EventStoreIteratorNextResult>;
 ```

--- a/api-docs/docs/node-tracker/markdown/node-tracker.md
+++ b/api-docs/docs/node-tracker/markdown/node-tracker.md
@@ -58,7 +58,7 @@
 |  [EventPayloadAndContext](./node-tracker.eventpayloadandcontext.md) | Interface for returning a built event (PayloadBuilder) and context (Array of SelfDescribingJson). |
 |  [EventStore](./node-tracker.eventstore.md) | EventStore allows storing and retrieving events before they are sent to the collector |
 |  [EventStoreConfiguration](./node-tracker.eventstoreconfiguration.md) |  |
-|  [EventStoreIterator](./node-tracker.eventstoreiterator.md) |  |
+|  [EventStoreIterator](./node-tracker.eventstoreiterator.md) | EventStoreIterator allows iterating over all events in the store. |
 |  [EventStorePayload](./node-tracker.eventstorepayload.md) |  |
 |  [FormFocusOrChangeEvent](./node-tracker.formfocusorchangeevent.md) | Represents either a Form Focus or Form Change event When a user focuses on a form element or when a user makes a change to a form element. |
 |  [FormSubmissionEvent](./node-tracker.formsubmissionevent.md) | A Form Submission Event Used to track when a user submits a form |

--- a/api-docs/docs/node-tracker/node-tracker.api.md
+++ b/api-docs/docs/node-tracker/node-tracker.api.md
@@ -298,12 +298,10 @@ export interface EventStoreConfiguration {
     maxSize?: number;
 }
 
-// @public (undocumented)
+// @public
 export interface EventStoreIterator {
-    next: () => Promise<{
-        value: EventStorePayload | undefined;
-        done: boolean;
-    }>;
+    // Warning: (ae-forgotten-export) The symbol "EventStoreIteratorNextResult" needs to be exported by the entry point index.module.d.ts
+    next: () => Promise<EventStoreIteratorNextResult>;
 }
 
 // @public (undocumented)

--- a/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_media_tracking_plugin_init_2024-11-01-09-22.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_media_tracking_plugin_init_2024-11-01-09-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Fix initialization of the HTML5 media tracking plugin so that it initializes the parent media plugin (#1369)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/common/changes/@snowplow/tracker-core/issue-fix_api_docs_2024-10-28-13-31.json
+++ b/common/changes/@snowplow/tracker-core/issue-fix_api_docs_2024-10-28-13-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Fix broken API docs generation by adding explicit type for EventStoreIteratorNextResult",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -42,6 +42,6 @@
      *
      * Valid values are: "prerelease", "release", "minor", "patch", "major"
      */
-    "nextBump": "major"
+    "nextBump": "patch"
   }
 ]

--- a/libraries/tracker-core/src/event_store.ts
+++ b/libraries/tracker-core/src/event_store.ts
@@ -1,11 +1,28 @@
 import { EventStorePayload } from './event_store_payload';
 import { Payload } from './payload';
 
+/**
+ * Result of the next operation on an EventStoreIterator.
+ */
+export interface EventStoreIteratorNextResult {
+  /**
+   * The next event in the store, or undefined if there are no more events.
+   */
+  value: EventStorePayload | undefined;
+  /**
+   * True if there are no more events in the store.
+   */
+  done: boolean;
+}
+
+/**
+ * EventStoreIterator allows iterating over all events in the store.
+ */
 export interface EventStoreIterator {
   /**
    * Retrieve the next event in the store
    */
-  next: () => Promise<{ value: EventStorePayload | undefined; done: boolean }>;
+  next: () => Promise<EventStoreIteratorNextResult>;
 }
 
 /**

--- a/plugins/browser-plugin-media-tracking/src/api.ts
+++ b/plugins/browser-plugin-media-tracking/src/api.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@snowplow/tracker-core';
-import { BrowserPlugin, BrowserTracker } from '@snowplow/browser-tracker-core';
+import { BrowserPlugin } from '@snowplow/browser-tracker-core';
 import { waitForElement } from './findElem';
 import { Config, isElementConfig, isStringConfig } from './config';
 import { setUpListeners } from './player';
@@ -14,16 +14,13 @@ import { HTML5MediaEventTypes } from './config';
 // @ts-ignore: TS6133
 import { FilterOutRepeatedEvents } from '@snowplow/browser-plugin-media/src/types';
 
-import { endMediaTracking } from '@snowplow/browser-plugin-media';
+import { endMediaTracking, SnowplowMediaPlugin } from '@snowplow/browser-plugin-media';
 
 let LOG: Logger;
-const _trackers: Record<string, BrowserTracker> = {};
 
 export function MediaTrackingPlugin(): BrowserPlugin {
   return {
-    activateBrowserPlugin: (tracker: BrowserTracker) => {
-      _trackers[tracker.id] = tracker;
-    },
+    ...SnowplowMediaPlugin(),
     logger: (logger) => {
       LOG = logger;
     },


### PR DESCRIPTION
This patch release fixes an issue in the HTML5 media tracking plugin in that it didn't correctly initialize and failed to track events.

**Bug fixes**

- Fix initialization of the HTML5 media tracking plugin so that it initializes the parent media plugin (#1369)

**Under the hood**

- Fix broken API docs generation by adding explicit type for EventStoreIteratorNextResult (#1367)