### PR TITLE
Fix postPath configuration being ignored (close #1376)

### DIFF
--- a/common/changes/@snowplow/tracker-core/issue-fix_post_path_2024-11-11-14-42.json
+++ b/common/changes/@snowplow/tracker-core/issue-fix_post_path_2024-11-11-14-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Fix customPostPath configuration being ignored (close #1376)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/tracker-core/src/emitter/index.ts
+++ b/libraries/tracker-core/src/emitter/index.ts
@@ -198,6 +198,7 @@ interface RequestResult {
 export function newEmitter({
   endpoint,
   eventMethod = 'post',
+  postPath,
   protocol,
   port,
   maxPostBytes = 40000,
@@ -320,6 +321,7 @@ export function newEmitter({
       maxPostBytes,
       useStm,
       credentials,
+      postPath,
     });
   }
 

--- a/libraries/tracker-core/test/emitter/index.test.ts
+++ b/libraries/tracker-core/test/emitter/index.test.ts
@@ -333,3 +333,21 @@ test('adds a timeout to the request', async (t) => {
   t.is(requests.length, 1);
   t.is(await eventStore.count(), 1);
 });
+
+test('uses custom POST path configured in the emitter', async (t) => {
+  const requests: Request[] = [];
+  const mockFetch = createMockFetch(200, requests);
+  const eventStore = newInMemoryEventStore({});
+  const emitter: Emitter = newEmitter({
+    endpoint: 'https://example.com',
+    customFetch: mockFetch,
+    postPath: '/custom',
+    eventStore,
+  });
+
+  await emitter.input({ e: 'pv' });
+  await emitter.flush();
+
+  t.is(requests.length, 1);
+  t.is(requests[0].url, 'https://example.com/custom');
+});


### PR DESCRIPTION
Issue #1376

In the v4 release, a bug was introduced that the `postPath` configuration option was ignored by the tracker – despite it being configured, the tracker is still using the default tp2 path.

This PR fixes the issue and makes sure to use the configuration option.