### PR TITLE
Fix ignored label property in the startHtml5MediaTracking call

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_ignored_label_in_media_tracking_2024-11-11-15-16.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_ignored_label_in_media_tracking_2024-11-11-15-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Fix ignored label property in the startHtml5MediaTracking call",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/plugins/browser-plugin-media-tracking/src/player.ts
+++ b/plugins/browser-plugin-media-tracking/src/player.ts
@@ -59,12 +59,15 @@ function htmlContext(el: HTMLMediaElement): (() => SelfDescribingJson)[] {
 }
 
 export function setUpListeners(config: ElementConfig) {
-  const { id, video } = config;
+  const { id, video, label } = config;
 
   startMediaTracking({
     ...config,
     id,
-    player: updatePlayer(video),
+    player: {
+      label,
+      ...updatePlayer(video)
+    },
     context: (config.context ?? []).concat(htmlContext(video)),
   });
 

--- a/plugins/browser-plugin-media-tracking/tests/test.test.ts
+++ b/plugins/browser-plugin-media-tracking/tests/test.test.ts
@@ -312,4 +312,20 @@ describe('MediaTrackingPlugin', () => {
 
     expect(eventQueue.length).toBe(0);
   });
+
+  it("adds label to tracked event", async () => {
+    const video = document.createElement('video');
+    video.id = id;
+    document.body.appendChild(video);
+
+    startHtml5MediaTracking({ id: 'id', label: 'foo', video, captureEvents: [MediaEventType.Play] });
+
+    video.play();
+
+    let playerContext = eventQueue[0].context.find(
+      (c) => c.schema === 'iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0'
+    )?.data;
+
+    expect(playerContext?.label).toEqual('foo');
+  });
 });


### PR DESCRIPTION
This PR fixes an issue where the `label` configuration option passed to the `startHtml5MediaTracking` call was ignored.