### PR TITLE
Release/4.0.2

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_ignored_label_in_media_tracking_2024-11-11-15-16.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_ignored_label_in_media_tracking_2024-11-11-15-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Fix ignored label property in the startHtml5MediaTracking call",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/performance-navigation-timing-config_2024-11-11-14-14.json
+++ b/common/changes/@snowplow/javascript-tracker/performance-navigation-timing-config_2024-11-11-14-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Add `performanceNavigationTiming` option to JS contexts config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/changes/@snowplow/tracker-core/issue-fix_post_path_2024-11-11-14-42.json
+++ b/common/changes/@snowplow/tracker-core/issue-fix_post_path_2024-11-11-14-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/tracker-core",
+      "comment": "Fix customPostPath configuration being ignored (close #1376)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core"
+}

--- a/libraries/tracker-core/src/emitter/index.ts
+++ b/libraries/tracker-core/src/emitter/index.ts
@@ -198,6 +198,7 @@ interface RequestResult {
 export function newEmitter({
   endpoint,
   eventMethod = 'post',
+  postPath,
   protocol,
   port,
   maxPostBytes = 40000,
@@ -320,6 +321,7 @@ export function newEmitter({
       maxPostBytes,
       useStm,
       credentials,
+      postPath,
     });
   }
 

--- a/libraries/tracker-core/test/emitter/index.test.ts
+++ b/libraries/tracker-core/test/emitter/index.test.ts
@@ -333,3 +333,21 @@ test('adds a timeout to the request', async (t) => {
   t.is(requests.length, 1);
   t.is(await eventStore.count(), 1);
 });
+
+test('uses custom POST path configured in the emitter', async (t) => {
+  const requests: Request[] = [];
+  const mockFetch = createMockFetch(200, requests);
+  const eventStore = newInMemoryEventStore({});
+  const emitter: Emitter = newEmitter({
+    endpoint: 'https://example.com',
+    customFetch: mockFetch,
+    postPath: '/custom',
+    eventStore,
+  });
+
+  await emitter.input({ e: 'pv' });
+  await emitter.flush();
+
+  t.is(requests.length, 1);
+  t.is(requests[0].url, 'https://example.com/custom');
+});

--- a/plugins/browser-plugin-media-tracking/src/player.ts
+++ b/plugins/browser-plugin-media-tracking/src/player.ts
@@ -59,12 +59,15 @@ function htmlContext(el: HTMLMediaElement): (() => SelfDescribingJson)[] {
 }
 
 export function setUpListeners(config: ElementConfig) {
-  const { id, video } = config;
+  const { id, video, label } = config;
 
   startMediaTracking({
     ...config,
     id,
-    player: updatePlayer(video),
+    player: {
+      label,
+      ...updatePlayer(video)
+    },
     context: (config.context ?? []).concat(htmlContext(video)),
   });
 

--- a/plugins/browser-plugin-media-tracking/tests/test.test.ts
+++ b/plugins/browser-plugin-media-tracking/tests/test.test.ts
@@ -312,4 +312,20 @@ describe('MediaTrackingPlugin', () => {
 
     expect(eventQueue.length).toBe(0);
   });
+
+  it("adds label to tracked event", async () => {
+    const video = document.createElement('video');
+    video.id = id;
+    document.body.appendChild(video);
+
+    startHtml5MediaTracking({ id: 'id', label: 'foo', video, captureEvents: [MediaEventType.Play] });
+
+    video.play();
+
+    let playerContext = eventQueue[0].context.find(
+      (c) => c.schema === 'iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0'
+    )?.data;
+
+    expect(playerContext?.label).toEqual('foo');
+  });
 });

--- a/trackers/javascript-tracker/src/configuration.ts
+++ b/trackers/javascript-tracker/src/configuration.ts
@@ -39,5 +39,6 @@ export interface JavaScriptTrackerConfiguration extends TrackerConfiguration {
     geolocation: boolean;
     clientHints: boolean | { includeHighEntropy: boolean };
     webVitals: boolean | { loadWebVitalsScript?: boolean; webVitalsSource?: string };
+    performanceNavigationTiming: boolean;
   };
 }

--- a/trackers/javascript-tracker/src/features.ts
+++ b/trackers/javascript-tracker/src/features.ts
@@ -30,13 +30,8 @@ import * as WebVitals from '@snowplow/browser-plugin-web-vitals';
  * @param configuration - The tracker configuration object
  */
 export function Plugins(configuration: JavaScriptTrackerConfiguration) {
-  const {
-    performanceTiming,
-    gaCookies,
-    geolocation,
-    clientHints,
-    webVitals
-  } = configuration?.contexts ?? {};
+  const { performanceTiming, gaCookies, geolocation, clientHints, webVitals, performanceNavigationTiming } =
+    configuration?.contexts ?? {};
   const activatedPlugins: Array<[BrowserPlugin, {} | Record<string, Function>]> = [];
 
   if (plugins.performanceTiming && performanceTiming) {
@@ -148,7 +143,7 @@ export function Plugins(configuration: JavaScriptTrackerConfiguration) {
     activatedPlugins.push([EventSpecificationsPlugin(), apiMethods]);
   }
 
-  if (plugins.performanceNavigationTiming) {
+  if (plugins.performanceNavigationTiming && performanceNavigationTiming) {
     const { PerformanceNavigationTimingPlugin, ...apiMethods } = PerformanceNavigationTiming;
     activatedPlugins.push([PerformanceNavigationTimingPlugin(), apiMethods]);
   }

--- a/trackers/javascript-tracker/test/unit/plugin_features.test.ts
+++ b/trackers/javascript-tracker/test/unit/plugin_features.test.ts
@@ -1,0 +1,61 @@
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+import { Plugins } from '../../src/features';
+
+describe('Performance Navigation Timing', () => {
+  let windowSpy: any;
+
+  const otherContexts = {
+    webPage: false,
+    session: false,
+    performanceTiming: false,
+    gaCookies: false,
+    geolocation: false,
+    clientHints: false,
+    webVitals: false,
+  };
+
+  const hasPerformanceNavigationTimingContext = (plugins: ReturnType<typeof Plugins>): boolean => {
+    const pluginContexts = plugins.map((plugin) => plugin[0]?.contexts?.());
+    const hasPerformanceContext = pluginContexts.some((contexts?: SelfDescribingJson[]) =>
+      contexts?.some(
+        (context: { schema?: string }) => context.schema === 'iglu:org.w3/PerformanceNavigationTiming/jsonschema/1-0-0'
+      )
+    );
+    return hasPerformanceContext;
+  };
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(global, 'window', 'get');
+
+    // The PerformanceNavigationTiming context will only be added if the plugin can:
+    // - Access the `performance` object on the window
+    // - See that a value is returned from `getEntriesByType`
+    windowSpy.mockImplementation(() => ({
+      performance: {
+        getEntriesByType: () => [{}],
+      },
+    }));
+  });
+
+  it('Is enabled if contexts.performanceNavigationTiming is true', () => {
+    const plugins = Plugins({
+      contexts: {
+        performanceNavigationTiming: true,
+        ...otherContexts,
+      },
+    });
+
+    expect(hasPerformanceNavigationTimingContext(plugins)).toBe(true);
+  });
+
+  it('Is disabled if contexts.performanceNavigationTiming is false', () => {
+    const plugins = Plugins({
+      contexts: {
+        performanceNavigationTiming: false,
+        ...otherContexts,
+      },
+    });
+
+    expect(hasPerformanceNavigationTimingContext(plugins)).toBe(false);
+  });
+});


### PR DESCRIPTION
This release fixes a bug that caused the `postPath` configuration option to be ignored when making requests to the collector. It also fixes a bug in the media tracking plugin which didn't add the configured label to media events.

In the tag-based JavaScript tracker, we added a new `contexts.performanceNavigationTiming` option to enable/disable the performance navigation timing context entity. Since the option was previously missing, the context was added to all events. Now the context is disabled by default.

**Bug fixes**

- Fix ignored label property in the startHtml5MediaTracking call (#1378)
- Fix postPath configuration being ignored (close #1376)
- Add option to disable `performanceNavigationTiming` plugin (#1375)