### PR TITLE
Serialize new session cookie synchronously to avoid overlapping sessions (close #1381)

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-duplicate_sessions_2024-11-18-13-57.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-duplicate_sessions_2024-11-18-13-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Serialize new session cookie synchronously to avoid overlapping sessions (#1381)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-duplicate_sessions_2024-11-18-13-57.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-duplicate_sessions_2024-11-18-13-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Serialize new session cookie synchronously to avoid overlapping sessions (#1381)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2241,8 +2241,8 @@ importers:
         specifier: 4.1.2
         version: 4.1.2
       chromedriver:
-        specifier: ~129.0.0
-        version: 129.0.4
+        specifier: ~131.0.0
+        version: 131.0.0
       dockerode:
         specifier: ~3.3.1
         version: 3.3.5
@@ -2299,7 +2299,7 @@ importers:
         version: 4.6.4
       wdio-chromedriver-service:
         specifier: ~8.1.1
-        version: 8.1.1(@wdio/types@8.39.0)(chromedriver@129.0.4)(webdriverio@8.39.1(encoding@0.1.13)(typescript@4.6.4))
+        version: 8.1.1(@wdio/types@8.39.0)(chromedriver@131.0.0)(webdriverio@8.39.1(encoding@0.1.13)(typescript@4.6.4))
       wdio-edgedriver-service:
         specifier: ~3.0.3
         version: 3.0.3(@wdio/types@8.39.0)
@@ -3604,8 +3604,8 @@ packages:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
 
-  chromedriver@129.0.4:
-    resolution: {integrity: sha512-j5I55cQwodFJUaYa1tWUmj2ss9KcPRBWmUa5Qonq3X8kqv2ASPyTboFYb4YB/YLztkYTUUw2E43txXw0wYzT/A==}
+  chromedriver@131.0.0:
+    resolution: {integrity: sha512-ukYmdCox2eRsjpCYUB4AOLV1fSfWQ1ZPfcUc0PIUWZKoyjyXKEl8i4DJ14bcNzNbEvaVx2Z2pnx/nLK2CM+ruQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9185,7 +9185,7 @@ snapshots:
 
   chownr@2.0.0: {}
 
-  chromedriver@129.0.4:
+  chromedriver@131.0.0:
     dependencies:
       '@testim/chrome-version': 1.1.4
       axios: 1.7.7
@@ -13367,7 +13367,7 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  wdio-chromedriver-service@8.1.1(@wdio/types@8.39.0)(chromedriver@129.0.4)(webdriverio@8.39.1(encoding@0.1.13)(typescript@4.6.4)):
+  wdio-chromedriver-service@8.1.1(@wdio/types@8.39.0)(chromedriver@131.0.0)(webdriverio@8.39.1(encoding@0.1.13)(typescript@4.6.4)):
     dependencies:
       '@wdio/logger': 8.38.0
       fs-extra: 11.2.0
@@ -13376,7 +13376,7 @@ snapshots:
       webdriverio: 8.39.1(encoding@0.1.13)(typescript@4.6.4)
     optionalDependencies:
       '@wdio/types': 8.39.0
-      chromedriver: 129.0.4
+      chromedriver: 131.0.0
     transitivePeerDependencies:
       - supports-color
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6693fc661ad5b6461d8a0fbbecf81c5f61d703bb",
+  "pnpmShrinkwrapHash": "77e8d084b2ff087ff8f5dfa5df436f42dbaa623c",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
+++ b/libraries/browser-tracker-core/src/tracker/cookie_storage.ts
@@ -44,6 +44,11 @@ export interface CookieStorage {
    * @param secure - Boolean to specify if cookie should be secure
    */
   deleteCookie(name: string, path?: string, domainName?: string, sameSite?: string, secure?: boolean): void;
+
+  /**
+   * Write all pending cookies.
+   */
+  flush(): void;
 }
 
 export interface AsyncCookieStorage extends CookieStorage {
@@ -51,11 +56,6 @@ export interface AsyncCookieStorage extends CookieStorage {
    * Clear the cookie storage cache (does not delete any cookies)
    */
   clearCache(): void;
-
-  /**
-   * Write all pending cookies.
-   */
-  flush(): void;
 }
 
 interface Cookie {
@@ -203,5 +203,6 @@ export const syncCookieStorage: CookieStorage = {
     cookie(name, value, ttl, path, domain, samesite, secure);
     return document.cookie.indexOf(`${name}=`) !== -1;
   },
-  deleteCookie
+  deleteCookie,
+  flush: () => {},
 };

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -701,6 +701,11 @@ export function Tracker(
         // Update currentVisitTs
         updateNowTsInIdCookie(idCookie);
         setDomainUserIdCookie(idCookie);
+
+        if (!eventIndexFromIdCookie(idCookie)) {
+          // Synchronously update the cookies to persist the new session ASAP
+          cookieStorage.flush();
+        }
       }
     }
 
@@ -920,6 +925,9 @@ export function Tracker(
               onSessionUpdateCallback &&
               !manualSessionUpdateCalled
             ) {
+              // Synchronously update the cookies to persist the new session ASAP
+              cookieStorage.flush();
+
               onSessionUpdateCallback(clientSession);
               manualSessionUpdateCalled = false;
             }
@@ -969,6 +977,10 @@ export function Tracker(
         const clientSession = clientSessionFromIdCookie(idCookie, configStateStorageStrategy, configAnonymousTracking);
         setDomainUserIdCookie(idCookie);
         const sessionIdentifierPersisted = setSessionCookie();
+
+        // Synchronously update the cookies to persist the new session ASAP
+        cookieStorage.flush();
+
         if (sessionIdentifierPersisted && onSessionUpdateCallback) {
           manualSessionUpdateCalled = true;
           onSessionUpdateCallback(clientSession);

--- a/libraries/browser-tracker-core/test/helpers/index.ts
+++ b/libraries/browser-tracker-core/test/helpers/index.ts
@@ -75,8 +75,12 @@ export function createTestSessionIdCookie(params?: CreateTestSessionIdCookie) {
   return `_sp_ses.${domainHash}=*; Expires=; Path=/; SameSite=Lax; Secure;`;
 }
 
-export function createTracker(configuration?: TrackerConfiguration, sharedState?: SharedState) {
+export function createTracker(
+  configuration?: TrackerConfiguration,
+  sharedState?: SharedState,
+  syncCookieWrite: boolean = true
+) {
   let id = 'sp-' + Math.random();
-  configuration = { ...configuration, synchronousCookieWrite: true };
+  configuration = { ...configuration, synchronousCookieWrite: syncCookieWrite };
   return addTracker(id, id, '', '', sharedState ?? new SharedState(), configuration);
 }

--- a/libraries/browser-tracker-core/test/tracker/session_data.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/session_data.test.ts
@@ -57,6 +57,15 @@ describe('Tracker API: ', () => {
     jest.clearAllMocks();
   });
 
+  it('Writes cookies synchronously on session change', () => {
+    const tracker = createTracker(undefined, undefined, false); // async cookie writes enabled
+
+    expect(cookieJar).toContain('_sp_ses');
+
+    tracker?.newSession();
+    expect(cookieJar).toContain(tracker?.getDomainUserInfo().slice(1).join('.'));
+  });
+
   it('Sets initial domain session index on first session', () => {
     const tracker = createTracker();
 

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -87,7 +87,7 @@
     "@wdio/static-server-service": "~8.39.0",
     "@wdio/types": "~8.39.0",
     "chalk": "4.1.2",
-    "chromedriver": "~129.0.0",
+    "chromedriver": "~131.0.0",
     "dockerode": "~3.3.1",
     "jest": "~27.5.1",
     "jest-environment-jsdom": "~27.5.1",

--- a/trackers/javascript-tracker/test/integration/cookies.test.ts
+++ b/trackers/javascript-tracker/test/integration/cookies.test.ts
@@ -1,0 +1,24 @@
+import { fetchResults } from '../micro';
+import { pageSetup } from './helpers';
+
+describe('Tracker created domain cookies across multiple pages', () => {
+  let log: Array<unknown> = [];
+  let testIdentifier = '';
+
+  beforeAll(async () => {
+    testIdentifier = await pageSetup();
+    await browser.url('/multi_page_cookies');
+    await browser.pause(5000);
+
+    log = await browser.call(async () => await fetchResults());
+    log = log.filter((ev) => (ev as any).event.app_id === 'cookies-iframe-' + testIdentifier);
+  });
+
+  it('all events should have the same session id', () => {
+    expect(log.length).toBeGreaterThanOrEqual(15);
+
+    const sessionIds = log.map((ev) => (ev as any).event.domain_sessionid);
+    const uniqueSessionIds = Array.from(new Set(sessionIds));
+    expect(uniqueSessionIds.length).toBe(1);
+  });
+});

--- a/trackers/javascript-tracker/test/pages/multi_page_cookies/iframe.html
+++ b/trackers/javascript-tracker/test/pages/multi_page_cookies/iframe.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Cookies iframe test page</title>
+  </head>
+  <body>
+    <div id="init"></div>
+    <div id="cookies"></div>
+    <script>
+      (function (p, l, o, w, i, n, g) {
+        if (!p[i]) {
+          p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
+          p.GlobalSnowplowNamespace.push(i);
+          p[i] = function () {
+            (p[i].q = p[i].q || []).push(arguments);
+          };
+          p[i].q = p[i].q || [];
+          n = l.createElement(o);
+          g = l.getElementsByTagName(o)[0];
+          n.async = 1;
+          n.src = w;
+          g.parentNode.insertBefore(n, g);
+        }
+      })(window, document, 'script', '../snowplow.js', 'snowplow');
+
+      var testIdentifier = document.cookie.split('testIdentifier=')[1].split(';')[0].trim();
+      var collector_endpoint = document.cookie.split('container=')[1].split(';')[0];
+
+      snowplow('newTracker', 'sp0', collector_endpoint, {
+        appId: 'cookies-iframe-' + testIdentifier,
+        cookieName: testIdentifier,
+        cookieSecure: false,
+      });
+      snowplow('trackPageView');
+
+      snowplow(function () {
+        document.getElementById('init').innerText = 'true';
+      });
+
+      setTimeout(function () {
+        document.getElementById('cookies').innerText = document.cookie;
+      }, 3000); // Wait 3 seconds so sp3 cookies expires
+    </script>
+  </body>
+</html>

--- a/trackers/javascript-tracker/test/pages/multi_page_cookies/index.html
+++ b/trackers/javascript-tracker/test/pages/multi_page_cookies/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Cookies test page</title>
+</head>
+
+<body>
+  <script>
+    for (let i = 0; i < 15; i++) {
+      const iframe = document.createElement('iframe');
+      iframe.src = `/multi_page_cookies/iframe.html`;
+      iframe.width = "600";
+      iframe.height = "400";
+      iframe.style.margin = "10px";
+      document.body.appendChild(iframe);
+    }
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Issue #1381 

The issue reported that after upgrading to v4, there is a higher number of very short sessions in very short sequences. The hypothesis was that this is due to the async cookie access introduced in v4.

I was able to reproduce the problem with a simple setup that I added to the integration tests – a single page that embeds 15 iframe pages. The iframes are loaded at the same time and each initializes a new tracker and tracks a page view. Since the iframes share the same cookies, we should only see a single session id across all tracked page views.

With this setup, I was getting multiple different session ids across the page views. It was usually around 10 different session IDs.

The change I made was to flush the cookies (write them synchronously) each time the session changes. That means the first session or every subsequent new session. When a new event is tracked without triggering a new session, the cookies are still updated async by default.

This fixed the problem in the iframe test setup. Now I am only getting a single session ID across all page views. Have kept this test in the integration tests so that we don't regress on the behaviour.