### PR TITLE
Fix multiple link click events tracked for a single tracker in case multiple trackers are initialized on the page (close #1384)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/issue-1384-link_click_fix_2024-11-20-11-36.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/issue-1384-link_click_fix_2024-11-20-11-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-link-click-tracking",
+      "comment": "Fix multiple link click events tracked for a single tracker in case multiple trackers are initialized on the page (#1384)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking"
+}

--- a/plugins/browser-plugin-link-click-tracking/src/index.ts
+++ b/plugins/browser-plugin-link-click-tracking/src/index.ts
@@ -274,10 +274,13 @@ function clickHandler(tracker: string, evt: MouseEvent | undefined): void {
 
   // Using evt.type (added in IE4), we avoid defining separate handlers for mouseup and mousedown.
   if (event.type === 'click') {
-    trackLinkClick({
-      element: target,
-      context: resolveDynamicContext(context, target),
-    });
+    trackLinkClick(
+      {
+        element: target,
+        context: resolveDynamicContext(context, target),
+      },
+      [tracker]
+    );
   } else if (event.type === 'mousedown') {
     if (button === 1 || button === 2) {
       _configuration[tracker].lastButton = button;
@@ -287,10 +290,13 @@ function clickHandler(tracker: string, evt: MouseEvent | undefined): void {
     }
   } else if (event.type === 'mouseup') {
     if (button === _configuration[tracker].lastButton && target === _configuration[tracker].lastTarget) {
-      trackLinkClick({
-        element: target,
-        context: resolveDynamicContext(context, target),
-      });
+      trackLinkClick(
+        {
+          element: target,
+          context: resolveDynamicContext(context, target),
+        },
+        [tracker]
+      );
     }
     delete _configuration[tracker].lastButton;
     delete _configuration[tracker].lastTarget;

--- a/plugins/browser-plugin-link-click-tracking/test/events.test.ts
+++ b/plugins/browser-plugin-link-click-tracking/test/events.test.ts
@@ -342,6 +342,26 @@ describe('LinkClickTrackingPlugin', () => {
 
       expect(await eventStore.getAllPayloads()).toHaveLength(1);
     });
+
+    it('tracks a single link click with each tracker', async () => {
+      addTracker('sp2', 'sp2', 'js-3.0.0', '', new SharedState(), {
+        stateStorageStrategy: 'cookie',
+        encodeBase64: false,
+        plugins: [LinkClickTrackingPlugin()],
+        eventStore,
+        customFetch: async () => new Response(null, { status: 500 }),
+      });
+
+      enableLinkClickTracking();
+
+      const target = document.createElement('a');
+      target.href = 'https://www.example.com/exists';
+      document.body.appendChild(target);
+
+      target.click();
+
+      expect(await eventStore.getAllPayloads()).toHaveLength(2);
+    });
   });
 
   describe('disableLinkClickTracking', () => {
@@ -351,7 +371,7 @@ describe('LinkClickTrackingPlugin', () => {
 
       const addCalls = $addEventListener.mock.calls;
 
-      expect(addCalls).toHaveLength(1);
+      expect(addCalls).toHaveLength(2);
       expect($removeEventListener.mock.calls).toContainEqual(addCalls[0]);
     });
   });


### PR DESCRIPTION
Issue #1384

Since the v4 release, in case multiple trackers were initialized on the same page, link click tracking tracked multiple events on each tracker for each link click.

For instance, in case 3 trackers were initialized and link click tracking was enabled, each link click would result in 3 events on each tracker.

This PR fixes the problem by qualifying which tracker should be used in the `trackLinkClick` function call from the click handler.