### PR TITLE
Round resolution in mobile context to avoid validation failures on Android

### DIFF
--- a/common/changes/@snowplow/react-native-tracker/issue-round_resolution_in_mobile_context_2025-01-07-10-56.json
+++ b/common/changes/@snowplow/react-native-tracker/issue-round_resolution_in_mobile_context_2025-01-07-10-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/react-native-tracker",
+      "comment": "Round resolution in mobile context to avoid validation failures on Android",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/trackers/react-native-tracker/src/plugins/platform_context/index.ts
+++ b/trackers/react-native-tracker/src/plugins/platform_context/index.ts
@@ -230,7 +230,7 @@ export async function newPlatformContextPlugin({
       platformContextProperties?.includes(PlatformContextProperty.Resolution) ?? true
         ? platformContextRetriever?.getResolution
           ? await platformContextRetriever?.getResolution()
-          : Dimensions.get('window').width + 'x' + Dimensions.get('window').height
+          : Math.floor(Dimensions.get('window').width) + 'x' + Math.floor(Dimensions.get('window').height)
         : undefined;
     scale =
       platformContextProperties?.includes(PlatformContextProperty.Scale) ?? true

--- a/trackers/react-native-tracker/test/plugins/platform_context_android.test.ts
+++ b/trackers/react-native-tracker/test/plugins/platform_context_android.test.ts
@@ -2,6 +2,7 @@ import { buildPageView, Payload, trackerCore } from '@snowplow/tracker-core';
 import { newPlatformContextPlugin } from '../../src/plugins/platform_context';
 import { MOBILE_CONTEXT_SCHEMA } from '../../src/constants';
 import { NativeModules } from 'react-native';
+import { Dimensions } from 'react-native';
 
 describe('PlatformContextPlugin on Android', () => {
   beforeAll(() => {
@@ -17,6 +18,12 @@ describe('PlatformContextPlugin on Android', () => {
       },
       select: () => null,
     }));
+    jest.spyOn(Dimensions, 'get').mockReturnValue({
+      width: 123.4567,
+      height: 89.1234,
+      scale: 0,
+      fontScale: 0,
+    });
     NativeModules.I18nManager = {
       localeIdentifier: 'en-GB',
     };
@@ -46,5 +53,6 @@ describe('PlatformContextPlugin on Android', () => {
     expect(payload?.co).toContain('"Google"');
     expect(payload?.co).toContain('"Google"');
     expect(payload?.co).toContain('"en-GB"');
+    expect(payload?.co).toContain('"123x89"');
   });
 });

--- a/trackers/react-native-tracker/test/plugins/platform_context_ios.test.ts
+++ b/trackers/react-native-tracker/test/plugins/platform_context_ios.test.ts
@@ -2,6 +2,7 @@ import { buildPageView, Payload, trackerCore } from '@snowplow/tracker-core';
 import { newPlatformContextPlugin } from '../../src/plugins/platform_context';
 import { NativeModules } from 'react-native';
 import { MOBILE_CONTEXT_SCHEMA } from '../../src/constants';
+import { Dimensions } from 'react-native';
 
 describe('PlatformContextPlugin on iOS', () => {
   beforeAll(() => {
@@ -22,6 +23,12 @@ describe('PlatformContextPlugin on iOS', () => {
       isVision: false,
       select: () => null,
     }));
+    jest.spyOn(Dimensions, 'get').mockReturnValue({
+      width: 123.4567,
+      height: 89.1234,
+      scale: 0,
+      fontScale: 0,
+    });
     NativeModules.SettingsManager = {
       settings: {
         AppleLanguages: ['en-GB'],
@@ -51,6 +58,7 @@ describe('PlatformContextPlugin on iOS', () => {
     expect(payload?.co).toContain('"iOS"');
     expect(payload?.co).toContain('"18.0"');
     expect(payload?.co).toContain('"en-GB"');
+    expect(payload?.co).toContain('"123x89"');
   });
 
   it('does not add platform context to events if disabled', async () => {


### PR DESCRIPTION
Fixes a bug identified in https://github.com/snowplow-incubator/snowplow-javascript-tracker-examples/pull/60 where the mobile_context entity failed validation due to the resolution field being too long.

The change converts the width and height to integer by taking the floor of the values.