### PR TITLE
Allow for usage of `snowplow` callback without `this`

### DIFF
--- a/common/changes/@snowplow/javascript-tracker/issue-1085-snowplow-callback-without-this_2025-01-22-17-05.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1085-snowplow-callback-without-this_2025-01-22-17-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Allow usage of Snowplow callback without 'this' keyword",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/src/in_queue.ts
+++ b/trackers/javascript-tracker/src/in_queue.ts
@@ -265,7 +265,15 @@ export function InQueueManager(functionName: string, asyncQueue: Array<unknown>)
             // Strip GlobalSnowplowNamespace from ID
             fnTrackers[tracker.id.replace(`${functionName}_`, '')] = tracker;
           }
-          input.apply(fnTrackers, parameterArray);
+
+          // Create a new array from `parameterArray` to avoid mutating the original
+          const parameterArrayCopy = Array.prototype.slice.call(parameterArray);
+
+          // Add the `fnTrackers` object as the last element of the new array to allow it to be accessed in the callback
+          // as the final argument, useful in environments that don't support `this` (GTM)
+          const args = Array.prototype.concat.apply(parameterArrayCopy, [fnTrackers]);
+
+          input.apply(fnTrackers, args);
         } catch (ex) {
           LOG.error('Tracker callback failed', ex);
         } finally {


### PR DESCRIPTION
This PR allows for the `snowplow(function() {})` callback to get tracker information without requiring the `this` keyword, which is useful in environments that don't support the keyword _*(GTM)*_ and is a non-breaking change.

The callback has been updated to pass the tracker dictionary (the object that is referred to by `this`) as the last argument. This allows for it to be used as a simple replacement for `this`, like so:
```js
snowplow(function (trackers) {
    var sp = trackers.sp;
    var domainUserId = sp.getDomainUserId();
});
```

As it is the last parameter, it still allows for the passing of arguments in the `snowplow` function:
```js
snowplow(function(a, b, trackers) {
    console.log(a, b); // 1, 2
    var sp = trackers.sp;
    var domainUserId = sp.getDomainUserId();
}, 1, 2);
```

The `this` keyword is still supported in conjunction with the parameter:
```js
snowplow(function(trackers) {
  trackers.sp.getDomainUserId() === this.sp.getDomainUserId() // true
});