### PR TITLE
Allow for usage of `snowplow` callback without `this` (close #1085)

### DIFF
--- a/common/changes/@snowplow/javascript-tracker/issue-1085-snowplow-callback-without-this_2025-01-22-17-05.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1085-snowplow-callback-without-this_2025-01-22-17-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Allow usage of Snowplow callback without 'this' keyword",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/src/in_queue.ts
+++ b/trackers/javascript-tracker/src/in_queue.ts
@@ -265,7 +265,15 @@ export function InQueueManager(functionName: string, asyncQueue: Array<unknown>)
             // Strip GlobalSnowplowNamespace from ID
             fnTrackers[tracker.id.replace(`${functionName}_`, '')] = tracker;
           }
-          input.apply(fnTrackers, parameterArray);
+
+          // Create a new array from `parameterArray` to avoid mutating the original
+          const parameterArrayCopy = Array.prototype.slice.call(parameterArray);
+
+          // Add the `fnTrackers` object as the last element of the new array to allow it to be accessed in the callback
+          // as the final argument, useful in environments that don't support `this` (GTM)
+          const args = Array.prototype.concat.apply(parameterArrayCopy, [fnTrackers]);
+
+          input.apply(fnTrackers, args);
         } catch (ex) {
           LOG.error('Tracker callback failed', ex);
         } finally {


### PR DESCRIPTION
This PR backports the patch in https://github.com/snowplow/snowplow-javascript-tracker/commit/6f87b5a429580e760f05fd08534ae0d647ad2353 to v3 of the tracker.