### PR TITLE
Add react-native-get-random-values as a peer dependency in the React Native tracker (close #1409)

### DIFF
--- a/common/changes/@snowplow/react-native-tracker/issue-react_native_dependency_2025-03-07-15-11.json
+++ b/common/changes/@snowplow/react-native-tracker/issue-react_native_dependency_2025-03-07-15-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/react-native-tracker",
+      "comment": "Add react-native-get-random-values as a peer dependency in the React Native tracker (close #1409)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -44,14 +44,14 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-get-random-values": "^1.11.0"
   },
   "dependencies": {
     "@snowplow/tracker-core": "workspace:*",
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/browser-plugin-screen-tracking": "workspace:*",
     "@react-native-async-storage/async-storage": "~2.0.0",
-    "react-native-get-random-values": "~1.11.0",
     "tslib": "^2.3.1",
     "uuid": "^10.0.0"
   },
@@ -70,7 +70,8 @@
     "@types/react": "^18.2.44",
     "react-native": "0.74.5",
     "node-fetch": "~3.3.2",
-    "react-native-builder-bob": "^0.30.3"
+    "react-native-builder-bob": "^0.30.3",
+    "react-native-get-random-values": "^1.11.0"
   },
   "resolutions": {
     "@types/react": "^18.2.44"


### PR DESCRIPTION
Relates to issue #1409 that reported the tracker can't be used without adding a dependency on `react-native-get-random-values` (even though it is in tracker dependencies as well).

This PR moves the dependency to `peerDependencies` to explictly require apps to include that dependency.