### PR TITLE
Release/4.4.0

### DIFF
--- a/common/changes/@snowplow/browser-plugin-web-vitals/feat-web-vitals-bump_2025-03-06-01-39.json
+++ b/common/changes/@snowplow/browser-plugin-web-vitals/feat-web-vitals-bump_2025-03-06-01-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-web-vitals",
+      "comment": "Update default external library version to v4. Add compatibility for future v5, which deprecates the FID metric.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-web-vitals"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-1085-snowplow-callback-without-this_2025-01-22-17-05.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-1085-snowplow-callback-without-this_2025-01-22-17-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Allow usage of Snowplow callback without 'this' keyword",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/common/changes/@snowplow/react-native-tracker/issue-react_native_dependency_2025-03-07-15-11.json
+++ b/common/changes/@snowplow/react-native-tracker/issue-react_native_dependency_2025-03-07-15-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/react-native-tracker",
+      "comment": "Add react-native-get-random-values as a peer dependency in the React Native tracker (close #1409)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1950,8 +1950,8 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       web-vitals:
-        specifier: ~3.3.2
-        version: 3.3.2
+        specifier: ~4.2.4
+        version: 4.2.4
     devDependencies:
       '@ampproject/rollup-plugin-closure-compiler':
         specifier: ~0.27.0
@@ -8871,8 +8871,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-vitals@3.3.2:
-    resolution: {integrity: sha512-qRkpmSeKfEWAzNhtX541xA8gCJ+pqCqBmUlDVkVDSCSYUvfvNqF+k9g8I+uyreRcDBdfiJrd0/aLbTy5ydo49Q==}
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
   webdriver@8.39.0:
     resolution: {integrity: sha512-Kc3+SfiH4ufyrIht683VT2vnJocx0pfH8rYdyPvEh1b2OYewtFTHK36k9rBDHZiBmk6jcSXs4M2xeFgOuon9Lg==}
@@ -17179,7 +17179,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-vitals@3.3.2: {}
+  web-vitals@4.2.4: {}
 
   webdriver@8.39.0:
     dependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6f4a24fea0d73ed30b10703fd10b02f67710f7ba",
+  "pnpmShrinkwrapHash": "483ab7c144cc1201cfba40405c05ebf190586e79",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -42,6 +42,6 @@
      *
      * Valid values are: "prerelease", "release", "minor", "patch", "major"
      */
-    "nextBump": "patch"
+    "nextBump": "minor"
   }
 ]

--- a/plugins/browser-plugin-web-vitals/package.json
+++ b/plugins/browser-plugin-web-vitals/package.json
@@ -25,7 +25,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "web-vitals": "~3.3.2"
+    "web-vitals": "~4.2.4"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",

--- a/plugins/browser-plugin-web-vitals/src/index.ts
+++ b/plugins/browser-plugin-web-vitals/src/index.ts
@@ -4,7 +4,7 @@ import { WEB_VITALS_SCHEMA } from './schemata';
 import { attachWebVitalsPageListeners, createWebVitalsScript, webVitalsListener } from './utils';
 
 const _trackers: Record<string, BrowserTracker> = {};
-const WEB_VITALS_SOURCE = 'https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js';
+const WEB_VITALS_SOURCE = 'https://unpkg.com/web-vitals@4/dist/web-vitals.iife.js';
 let listenersAttached = false;
 
 interface WebVitalsPluginOptions {

--- a/plugins/browser-plugin-web-vitals/src/types.ts
+++ b/plugins/browser-plugin-web-vitals/src/types.ts
@@ -1,12 +1,18 @@
-import type { ReportCallback, Metric, WebVitalsGlobal, onCLS, onLCP, onFID, onFCP, onINP, onTTFB } from 'web-vitals';
+import type { MetricType, Metric, onCLS, onLCP, onFID, onFCP, onINP, onTTFB } from 'web-vitals';
 
-export interface WebVitals extends WebVitalsGlobal {
-  onCLS: typeof onCLS;
-  onFID: typeof onFID;
-  onLCP: typeof onLCP;
-  onFCP: typeof onFCP;
-  onINP: typeof onINP;
-  onTTFB: typeof onTTFB;
+export interface WebVitals {
+  onCLS?: typeof onCLS;
+  onFID?: typeof onFID;
+  onLCP?: typeof onLCP;
+  onFCP?: typeof onFCP;
+  onINP?: typeof onINP;
+  onTTFB?: typeof onTTFB;
 }
 
-export { Metric, ReportCallback };
+declare global {
+  interface Window {
+    webVitals?: WebVitals;
+  }
+}
+
+export { Metric, MetricType };

--- a/plugins/browser-plugin-web-vitals/src/utils.ts
+++ b/plugins/browser-plugin-web-vitals/src/utils.ts
@@ -1,5 +1,5 @@
 import { LOG } from '@snowplow/tracker-core';
-import { ReportCallback, WebVitals } from './types';
+import { MetricType } from './types';
 
 /**
  * Attach page listeners to collect the Web Vitals values
@@ -51,22 +51,23 @@ export function createWebVitalsScript(webVitalsSource: string) {
  * @return {void}
  */
 export function webVitalsListener(webVitalsObject: Record<string, unknown>) {
-  function addWebVitalsMeasurement(metricSchemaName: string): ReportCallback {
+  function addWebVitalsMeasurement(metricSchemaName: string): (arg: MetricType) => void {
     return (arg) => {
       webVitalsObject[metricSchemaName] = arg.value;
       webVitalsObject.navigationType = arg.navigationType;
     };
   }
-  if (!window.webVitals) {
+
+  const webVitals = window.webVitals;
+  if (!webVitals) {
     LOG.warn('The window.webVitals API is currently unavailable. web_vitals events will not be collected.');
     return;
   }
 
-  const webVitals = window.webVitals as WebVitals;
-  webVitals.onCLS(addWebVitalsMeasurement('cls'));
-  webVitals.onFID(addWebVitalsMeasurement('fid'));
-  webVitals.onLCP(addWebVitalsMeasurement('lcp'));
-  webVitals.onFCP(addWebVitalsMeasurement('fcp'));
-  webVitals.onINP(addWebVitalsMeasurement('inp'));
-  webVitals.onTTFB(addWebVitalsMeasurement('ttfb'));
+  webVitals.onCLS?.(addWebVitalsMeasurement('cls'));
+  webVitals.onFID?.(addWebVitalsMeasurement('fid'));
+  webVitals.onLCP?.(addWebVitalsMeasurement('lcp'));
+  webVitals.onFCP?.(addWebVitalsMeasurement('fcp'));
+  webVitals.onINP?.(addWebVitalsMeasurement('inp'));
+  webVitals.onTTFB?.(addWebVitalsMeasurement('ttfb'));
 }

--- a/plugins/browser-plugin-web-vitals/test/web-vitals.test.ts
+++ b/plugins/browser-plugin-web-vitals/test/web-vitals.test.ts
@@ -5,7 +5,6 @@ import { BrowserTracker } from '@snowplow/browser-tracker-core';
 
 declare var jsdom: JSDOM;
 
-// @ts-expect-error
 jsdom.window.webVitals = {};
 
 describe('Web Vitals plugin', () => {

--- a/trackers/javascript-tracker/src/in_queue.ts
+++ b/trackers/javascript-tracker/src/in_queue.ts
@@ -265,7 +265,15 @@ export function InQueueManager(functionName: string, asyncQueue: Array<unknown>)
             // Strip GlobalSnowplowNamespace from ID
             fnTrackers[tracker.id.replace(`${functionName}_`, '')] = tracker;
           }
-          input.apply(fnTrackers, parameterArray);
+
+          // Create a new array from `parameterArray` to avoid mutating the original
+          const parameterArrayCopy = Array.prototype.slice.call(parameterArray);
+
+          // Add the `fnTrackers` object as the last element of the new array to allow it to be accessed in the callback
+          // as the final argument, useful in environments that don't support `this` (GTM)
+          const args = Array.prototype.concat.apply(parameterArrayCopy, [fnTrackers]);
+
+          input.apply(fnTrackers, args);
         } catch (ex) {
           LOG.error('Tracker callback failed', ex);
         } finally {

--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -44,14 +44,14 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-get-random-values": "^1.11.0"
   },
   "dependencies": {
     "@snowplow/tracker-core": "workspace:*",
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/browser-plugin-screen-tracking": "workspace:*",
     "@react-native-async-storage/async-storage": "~2.0.0",
-    "react-native-get-random-values": "~1.11.0",
     "tslib": "^2.3.1",
     "uuid": "^10.0.0"
   },
@@ -70,7 +70,8 @@
     "@types/react": "^18.2.44",
     "react-native": "0.74.5",
     "node-fetch": "~3.3.2",
-    "react-native-builder-bob": "^0.30.3"
+    "react-native-builder-bob": "^0.30.3",
+    "react-native-get-random-values": "^1.11.0"
   },
   "resolutions": {
     "@types/react": "^18.2.44"


### PR DESCRIPTION
- Bump web-vitals version
- Allow for usage of `snowplow` callback without `this`
- Add react-native-get-random-values as a peer dependency in the React Native tracker