### PR TITLE
Allow configuring a custom event store in React Native tracker (closes #1413)

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2513,9 +2513,6 @@ importers:
 
   ../../trackers/react-native-tracker:
     dependencies:
-      '@react-native-async-storage/async-storage':
-        specifier: ~2.0.0
-        version: 2.0.0(react-native@0.74.5(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(encoding@0.1.13)(react@18.2.0))
       '@snowplow/browser-plugin-screen-tracking':
         specifier: workspace:*
         version: link:../../plugins/browser-plugin-screen-tracking
@@ -2525,9 +2522,6 @@ importers:
       '@snowplow/tracker-core':
         specifier: workspace:*
         version: link:../../libraries/tracker-core
-      react-native-get-random-values:
-        specifier: ~1.11.0
-        version: 1.11.0(react-native@0.74.5(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(encoding@0.1.13)(react@18.2.0))
       tslib:
         specifier: ^2.3.1
         version: 2.8.1
@@ -2574,6 +2568,9 @@ importers:
       react-native-builder-bob:
         specifier: ^0.30.3
         version: 0.30.3(typescript@4.6.4)
+      react-native-get-random-values:
+        specifier: ^1.11.0
+        version: 1.11.0(react-native@0.74.5(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(encoding@0.1.13)(react@18.2.0))
       ts-jest:
         specifier: ~28.0.8
         version: 28.0.8(@babel/core@7.26.0)(@jest/types@28.1.3)(babel-jest@28.1.3(@babel/core@7.26.0))(jest@28.1.3(@types/node@14.6.4)(ts-node@10.9.2(@types/node@14.6.4)(typescript@4.6.4)))(typescript@4.6.4)
@@ -3586,11 +3583,6 @@ packages:
     resolution: {integrity: sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==}
     engines: {node: '>=16.3.0'}
     hasBin: true
-
-  '@react-native-async-storage/async-storage@2.0.0':
-    resolution: {integrity: sha512-af6H9JjfL6G/PktBfUivvexoiFKQTJGQCtSWxMdivLzNIY94mu9DdiY0JqCSg/LyPCLGKhHPUlRQhNvpu3/KVA==}
-    peerDependencies:
-      react-native: ^0.0.0-0 || >=0.65 <1.0
 
   '@react-native-community/cli-clean@13.6.9':
     resolution: {integrity: sha512-7Dj5+4p9JggxuVNOjPbduZBAP1SUgNhLKVw5noBUzT/3ZpUZkDM+RCSwyoyg8xKWoE4OrdUAXwAFlMcFDPKykA==}
@@ -6193,10 +6185,6 @@ packages:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
 
-  is-plain-obj@2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
-    engines: {node: '>=8'}
-
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -6881,10 +6869,6 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
-
-  merge-options@3.0.4:
-    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
-    engines: {node: '>=10'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -10480,11 +10464,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native-async-storage/async-storage@2.0.0(react-native@0.74.5(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(encoding@0.1.13)(react@18.2.0))':
-    dependencies:
-      merge-options: 3.0.4
-      react-native: 0.74.5(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(encoding@0.1.13)(react@18.2.0)
-
   '@react-native-community/cli-clean@13.6.9(encoding@0.1.13)':
     dependencies:
       '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
@@ -13814,8 +13793,6 @@ snapshots:
 
   is-path-inside@4.0.0: {}
 
-  is-plain-obj@2.1.0: {}
-
   is-plain-obj@4.1.0: {}
 
   is-plain-object@2.0.4:
@@ -14848,10 +14825,6 @@ snapshots:
   memorystream@0.3.1: {}
 
   merge-descriptors@1.0.3: {}
-
-  merge-options@3.0.4:
-    dependencies:
-      is-plain-obj: 2.1.0
 
   merge-stream@2.0.0: {}
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "483ab7c144cc1201cfba40405c05ebf190586e79",
+  "pnpmShrinkwrapHash": "b8ff89ae0d8384f6dc92006db7f2e8218780e8d6",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -51,7 +51,6 @@
     "@snowplow/tracker-core": "workspace:*",
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/browser-plugin-screen-tracking": "workspace:*",
-    "@react-native-async-storage/async-storage": "~2.0.0",
     "tslib": "^2.3.1",
     "uuid": "^10.0.0"
   },

--- a/trackers/react-native-tracker/src/__mocks__/@react-native-async-storage/async-storage.js
+++ b/trackers/react-native-tracker/src/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,2 +1,0 @@
-import AsyncStorage from "@react-native-async-storage/async-storage/jest/async-storage-mock";
-export default AsyncStorage;

--- a/trackers/react-native-tracker/src/app_storage.ts
+++ b/trackers/react-native-tracker/src/app_storage.ts
@@ -1,0 +1,18 @@
+export type AppStorage = {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+};
+
+let appStorage: AppStorage | undefined;
+
+export function setAppStorage(storage: AppStorage) {
+  appStorage = storage;
+}
+
+export function getAppStorage() {
+  if (!appStorage) {
+    throw new Error('Snowplow storage is not set');
+  }
+
+  return appStorage;
+}

--- a/trackers/react-native-tracker/src/event_store.ts
+++ b/trackers/react-native-tracker/src/event_store.ts
@@ -1,17 +1,19 @@
-import { EventStore, newInMemoryEventStore, EventStorePayload } from '@snowplow/tracker-core';
+import { EventStore, EventStorePayload, newInMemoryEventStore } from '@snowplow/tracker-core';
+import { getAppStorage } from './app_storage';
 import { EventStoreConfiguration, TrackerConfiguration } from './types';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export async function newReactNativeEventStore({
   namespace,
   maxEventStoreSize = 1000,
-  useAsyncStorageForEventStore: useAsyncStorage = true,
+  useAppStorageForEventStore = true,
 }: EventStoreConfiguration & TrackerConfiguration): Promise<EventStore> {
   const queueName = `snowplow_${namespace}`;
 
   async function newInMemoryEventStoreForReactNative() {
-    if (useAsyncStorage) {
-      const data = await AsyncStorage.getItem(queueName);
+    const appStorage = getAppStorage();
+
+    if (useAppStorageForEventStore) {
+      const data = await appStorage.getItem(queueName);
       const events: EventStorePayload[] = data ? JSON.parse(data) : [];
       return newInMemoryEventStore({ maxSize: maxEventStoreSize, events });
     } else {
@@ -24,9 +26,11 @@ export async function newReactNativeEventStore({
   const { getAll, getAllPayloads, add, count, iterator, removeHead } = eventStore;
 
   async function sync() {
-    if (useAsyncStorage) {
+    const appStorage = getAppStorage();
+
+    if (useAppStorageForEventStore) {
       const events = await getAll();
-      await AsyncStorage.setItem(queueName, JSON.stringify(events));
+      await appStorage.setItem(queueName, JSON.stringify(events));
     }
   }
 

--- a/trackers/react-native-tracker/src/plugins/app_install/index.ts
+++ b/trackers/react-native-tracker/src/plugins/app_install/index.ts
@@ -1,11 +1,11 @@
 import { buildSelfDescribingEvent, CorePluginConfiguration, TrackerCore } from '@snowplow/tracker-core';
-import { AppLifecycleConfiguration, TrackerConfiguration } from '../../types';
+import { getAppStorage } from '../../app_storage';
 import { APPLICATION_INSTALL_EVENT_SCHEMA } from '../../constants';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AppLifecycleConfiguration, TrackerConfiguration } from '../../types';
 
 /**
  * Tracks an application install event on the first run of the app.
- * Stores the install event in AsyncStorage to prevent tracking on subsequent runs.
+ * Stores the install event in defined application storage to prevent tracking on subsequent runs.
  *
  * Event schema: `iglu:com.snowplowanalytics.mobile/application_install/jsonschema/1-0-0`
  */
@@ -17,7 +17,8 @@ export function newAppInstallPlugin(
     // Track install event on first run
     const key = `snowplow_${namespace}_install`;
     setTimeout(async () => {
-      const installEvent = await AsyncStorage.getItem(key);
+      const appStorage = getAppStorage();
+      const installEvent = await appStorage.getItem(key);
       if (!installEvent) {
         core.track(
           buildSelfDescribingEvent({
@@ -27,7 +28,7 @@ export function newAppInstallPlugin(
             },
           })
         );
-        await AsyncStorage.setItem(key, new Date().toISOString());
+        await appStorage.setItem(key, new Date().toISOString());
       }
     }, 0);
   }

--- a/trackers/react-native-tracker/src/plugins/session/index.ts
+++ b/trackers/react-native-tracker/src/plugins/session/index.ts
@@ -1,8 +1,8 @@
 import { CorePluginConfiguration, PayloadBuilder } from '@snowplow/tracker-core';
-import { SessionConfiguration, SessionState, TrackerConfiguration } from '../../types';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { v4 as uuidv4 } from 'uuid';
+import { getAppStorage } from '../../app_storage';
 import { BACKGROUND_EVENT_SCHEMA, CLIENT_SESSION_ENTITY_SCHEMA, FOREGROUND_EVENT_SCHEMA } from '../../constants';
+import { SessionConfiguration, SessionState, TrackerConfiguration } from '../../types';
 import { getUsefulSchema } from '../../utils';
 
 interface StoredSessionState {
@@ -21,11 +21,13 @@ interface SessionPlugin extends CorePluginConfiguration {
 
 async function storeSessionState(namespace: string, state: StoredSessionState) {
   const { userId, sessionId, sessionIndex } = state;
-  await AsyncStorage.setItem(`snowplow_${namespace}_session`, JSON.stringify({ userId, sessionId, sessionIndex }));
+  const appStorage = getAppStorage();
+  await appStorage.setItem(`snowplow_${namespace}_session`, JSON.stringify({ userId, sessionId, sessionIndex }));
 }
 
 async function resumeStoredSession(namespace: string): Promise<SessionState> {
-  const storedState = await AsyncStorage.getItem(`snowplow_${namespace}_session`);
+  const appStorage = getAppStorage();
+  const storedState = await appStorage.getItem(`snowplow_${namespace}_session`);
   if (storedState) {
     const state = JSON.parse(storedState) as StoredSessionState;
     return {
@@ -48,8 +50,8 @@ async function resumeStoredSession(namespace: string): Promise<SessionState> {
 /**
  * Creates a new session plugin for tracking the session information.
  * The plugin will add the session context to all events and start a new session if the current one has timed out.
- * 
- * The session state is stored in AsyncStorage.
+ *
+ * The session state is stored in the defined application storage.
  * Each restart of the app or creation of a new tracker instance will trigger a new session with reference to the previous session.
  */
 export async function newSessionPlugin({

--- a/trackers/react-native-tracker/src/tracker.ts
+++ b/trackers/react-native-tracker/src/tracker.ts
@@ -1,6 +1,5 @@
-import { trackerCore, PayloadBuilder, version, EmitterConfiguration, TrackerCore } from '@snowplow/tracker-core';
-
-import { newEmitter } from '@snowplow/tracker-core';
+import { trackerCore, PayloadBuilder, version, EmitterConfiguration, TrackerCore, newEmitter } from '@snowplow/tracker-core';
+import { setAppStorage } from './app_storage';
 import { newReactNativeEventStore } from './event_store';
 import { newTrackEventFunctions } from './events';
 import { newSubject } from './subject';
@@ -15,6 +14,7 @@ import {
 import {
   DeepLinkConfiguration,
   AppLifecycleConfiguration,
+  AppStorageConfiguration,
   EventContext,
   EventStoreConfiguration,
   ListItemViewProps,
@@ -50,9 +50,13 @@ export async function newTracker(
     ScreenTrackingConfiguration &
     PlatformContextConfiguration &
     DeepLinkConfiguration &
-    AppLifecycleConfiguration
+    AppLifecycleConfiguration &
+    AppStorageConfiguration
 ): Promise<ReactNativeTracker> {
   const { namespace, appId, encodeBase64 = false } = configuration;
+
+  setAppStorage(configuration.appStorage);
+
   if (configuration.eventStore === undefined) {
     configuration.eventStore = await newReactNativeEventStore(configuration);
   }

--- a/trackers/react-native-tracker/src/types.ts
+++ b/trackers/react-native-tracker/src/types.ts
@@ -6,6 +6,7 @@ import {
   SelfDescribingJson,
   StructuredEvent,
 } from '@snowplow/tracker-core';
+import { AppStorage } from './app_storage';
 
 /**
  * Configuration for the event store
@@ -18,12 +19,11 @@ export interface EventStoreConfiguration {
    * @defaultValue 1000
    */
   maxEventStoreSize?: number;
-
   /**
-   * Whether to use the AsyncStorage library as the persistent event store for the event store
+   * Whether to use the defined app storage as the persistent event store for the event store
    * @defaultValue true
    */
-  useAsyncStorageForEventStore?: boolean;
+  useAppStorageForEventStore?: boolean;
 }
 
 /**
@@ -108,6 +108,11 @@ export interface TrackerConfiguration {
    * @defaultValue 'mob'
    */
   devicePlatform?: Platform;
+}
+
+export interface AppStorageConfiguration {
+  /** The storage belonging to the app where Snowplow will store events among different sessions */
+  appStorage: AppStorage;
 }
 
 export enum PlatformContextProperty {
@@ -905,6 +910,7 @@ export type ReactNativeTracker = {
    */
   readonly refreshPlatformContext: () => Promise<void>;
 };
+
 
 export {
   version,

--- a/trackers/react-native-tracker/test/ecommerce.test.ts
+++ b/trackers/react-native-tracker/test/ecommerce.test.ts
@@ -1,11 +1,28 @@
+import {
+  setEcommerceUser,
+  SnowplowEcommercePlugin,
+  trackProductView,
+} from '@snowplow/browser-plugin-snowplow-ecommerce';
 import { newTracker } from '../src';
-import { setEcommerceUser, SnowplowEcommercePlugin, trackProductView } from '@snowplow/browser-plugin-snowplow-ecommerce';
 
 function createMockFetch(status: number, requests: Request[]) {
   return async (input: Request) => {
     requests.push(input);
     let response = new Response(null, { status });
     return response;
+  };
+}
+
+function createMockAppStorage() {
+  const storage: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => Promise.resolve(storage[key] ?? null),
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+
+      return Promise.resolve();
+    },
   };
 }
 
@@ -20,6 +37,7 @@ describe('Tracking ecommerce events using the ecomerce plugin', () => {
 
   it('tracks ecommerce events', async () => {
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       endpoint: 'http://localhost:9090',
       customFetch: mockFetch,
@@ -37,7 +55,7 @@ describe('Tracking ecommerce events using the ecomerce plugin', () => {
       category: 'my-category',
       price: 100,
       currency: 'USD',
-    })
+    });
 
     await tracker.flush();
     expect(requests.length).toBe(1);

--- a/trackers/react-native-tracker/test/event_store.test.ts
+++ b/trackers/react-native-tracker/test/event_store.test.ts
@@ -1,6 +1,20 @@
+import { setAppStorage } from '../src/app_storage';
 import { newReactNativeEventStore } from '../src/event_store';
 
 describe('React Native event store', () => {
+  beforeEach(() => {
+    const storageState: Record<string, string> = {};
+
+    setAppStorage({
+      getItem: (key: string) => Promise.resolve(storageState[key] ?? null),
+      setItem: (key: string, value: string) => {
+        storageState[key] = value;
+
+        return Promise.resolve();
+      },
+    });
+  });
+
   it('keeps track of added events', async () => {
     const eventStore = await newReactNativeEventStore({
       namespace: 'test',
@@ -37,7 +51,7 @@ describe('React Native event store', () => {
     expect(await eventStore2.getAll()).toEqual([{ payload: { e: 'pv2' } }]);
   });
 
-  it('syncs with AsyncStorage', async () => {
+  it('syncs with the defined app storage', async () => {
     const eventStore1 = await newReactNativeEventStore({
       namespace: 'testA',
     });

--- a/trackers/react-native-tracker/test/events.test.ts
+++ b/trackers/react-native-tracker/test/events.test.ts
@@ -6,8 +6,21 @@ describe('Events', () => {
   let payloads: Payload[];
 
   beforeEach(async () => {
+    const storageState: Record<string, string> = {};
+
     payloads = [];
-    tracker = await newTracker({ namespace: 'test', endpoint: 'http://localhost:9090' });
+    tracker = await newTracker({
+      appStorage: {
+        getItem: (key: string) => Promise.resolve(storageState[key] ?? null),
+        setItem: (key: string, value: string) => {
+          storageState[key] = value;
+
+          return Promise.resolve();
+        },
+      },
+      namespace: 'test',
+      endpoint: 'http://localhost:9090',
+    });
     tracker.addPlugin({
       plugin: {
         filter: (payload) => {

--- a/trackers/react-native-tracker/test/plugins/app_install.test.ts
+++ b/trackers/react-native-tracker/test/plugins/app_install.test.ts
@@ -1,11 +1,22 @@
 import { Payload, trackerCore } from '@snowplow/tracker-core';
-import { newAppInstallPlugin } from '../../src/plugins/app_install';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { setAppStorage } from '../../src/app_storage';
 import { APPLICATION_INSTALL_EVENT_SCHEMA } from '../../src/constants';
+import { newAppInstallPlugin } from '../../src/plugins/app_install';
 
 describe('Application install plugin', () => {
+  let storageState: Record<string, string> = {};
+
+  setAppStorage({
+    getItem: (key: string) => Promise.resolve(storageState[key] ?? null),
+    setItem: (key: string, value: string) => {
+      storageState[key] = value;
+
+      return Promise.resolve();
+    },
+  });
+
   beforeEach(async () => {
-    await AsyncStorage.clear();
+    storageState = {};
   });
 
   it('tracks an app install event on first tracker init', async () => {

--- a/trackers/react-native-tracker/test/plugins/session.test.ts
+++ b/trackers/react-native-tracker/test/plugins/session.test.ts
@@ -1,14 +1,25 @@
-import { newSessionPlugin } from '../../src/plugins/session';
 import { buildPageView, buildSelfDescribingEvent, Payload, trackerCore } from '@snowplow/tracker-core';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { setAppStorage } from '../../src/app_storage';
+import { newSessionPlugin } from '../../src/plugins/session';
 
 describe('Session plugin', () => {
+  let storage: Record<string, string> = {};
+
+  setAppStorage({
+    getItem: (key: string) => Promise.resolve(storage[key] ?? null),
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+
+      return Promise.resolve();
+    },
+  });
+
   beforeAll(() => {
     jest.useFakeTimers();
   });
 
   beforeEach(async () => {
-    await AsyncStorage.clear();
+    storage = {};
   });
 
   afterAll(() => {
@@ -119,12 +130,14 @@ describe('Session plugin', () => {
     });
 
     const tracker = trackerCore({ corePlugins: [sessionPlugin.plugin] });
-    tracker.track(buildSelfDescribingEvent({
-      event: {
-        schema: 'iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0',
-        data: {},
-      }
-    }));
+    tracker.track(
+      buildSelfDescribingEvent({
+        event: {
+          schema: 'iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0',
+          data: {},
+        },
+      })
+    );
 
     let sessionState = await sessionPlugin.getSessionState();
     expect(sessionState.sessionIndex).toBe(1);

--- a/trackers/react-native-tracker/test/subject.test.ts
+++ b/trackers/react-native-tracker/test/subject.test.ts
@@ -1,6 +1,19 @@
 import { CorePluginConfiguration, Payload } from '@snowplow/tracker-core';
 import { newTracker, ReactNativeTracker } from '../src';
 
+function createMockAppStorage() {
+  const storageState: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => Promise.resolve(storageState[key] ?? null),
+    setItem: (key: string, value: string) => {
+      storageState[key] = value;
+
+      return Promise.resolve();
+    },
+  };
+}
+
 describe('Subject', () => {
   let tracker: ReactNativeTracker;
   let payloads: Payload[];
@@ -20,6 +33,7 @@ describe('Subject', () => {
   describe('Subject configuration', () => {
     beforeEach(async () => {
       tracker = await newTracker({
+        appStorage: createMockAppStorage(),
         namespace: 'test',
         endpoint: 'http://localhost:9090',
         userId: 'user-id',
@@ -56,7 +70,11 @@ describe('Subject', () => {
 
   describe('Subject methods', () => {
     beforeEach(async () => {
-      tracker = await newTracker({ namespace: 'test', endpoint: 'http://localhost:9090' });
+      tracker = await newTracker({
+        appStorage: createMockAppStorage(),
+        namespace: 'test',
+        endpoint: 'http://localhost:9090',
+      });
       tracker.addPlugin(plugin);
     });
 

--- a/trackers/react-native-tracker/test/tracker.test.ts
+++ b/trackers/react-native-tracker/test/tracker.test.ts
@@ -9,6 +9,19 @@ function createMockFetch(status: number, requests: Request[]) {
   };
 }
 
+function createMockAppStorage() {
+  const storageState: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => Promise.resolve(storageState[key] ?? null),
+    setItem: (key: string, value: string) => {
+      storageState[key] = value;
+
+      return Promise.resolve();
+    },
+  };
+}
+
 describe('Tracker', () => {
   let requests: Request[];
   let mockFetch: ReturnType<typeof createMockFetch>;
@@ -19,24 +32,30 @@ describe('Tracker', () => {
   });
 
   it('creates a tracker with minimal config', async () => {
-    expect(await newTracker({ namespace: 'test', endpoint: 'http://localhost:9090' })).toBeDefined();
+    expect(
+      await newTracker({ appStorage: createMockAppStorage(), namespace: 'test', endpoint: 'http://localhost:9090' })
+    ).toBeDefined();
   });
 
   it('retrieves an existing tracker', async () => {
-    const tracker = await newTracker({ namespace: 'test', endpoint: 'http://localhost:9090' });
+    const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
+      namespace: 'test',
+      endpoint: 'http://localhost:9090',
+    });
     expect(getTracker('test')).toBe(tracker);
     expect(getTracker('non-existent')).toBeUndefined();
   });
 
   it('removes a tracker', async () => {
-    await newTracker({ namespace: 'test', endpoint: 'http://localhost:9090' });
+    await newTracker({ appStorage: createMockAppStorage(), namespace: 'test', endpoint: 'http://localhost:9090' });
     expect(getTracker('test')).toBeDefined();
     removeTracker('test');
     expect(getTracker('test')).toBeUndefined();
   });
 
   it('removes all trackers', async () => {
-    await newTracker({ namespace: 'test', endpoint: 'http://localhost:9090' });
+    await newTracker({ appStorage: createMockAppStorage(), namespace: 'test', endpoint: 'http://localhost:9090' });
     expect(getTracker('test')).toBeDefined();
     removeAllTrackers();
     expect(getTracker('test')).toBeUndefined();
@@ -44,6 +63,7 @@ describe('Tracker', () => {
 
   it('tracks a page view event with tracker properties', async () => {
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       appId: 'my-app',
       endpoint: 'http://localhost:9090',
@@ -71,6 +91,7 @@ describe('Tracker', () => {
 
   it('tracks session along with events', async () => {
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       appId: 'my-app',
       endpoint: 'http://localhost:9090',
@@ -95,6 +116,7 @@ describe('Tracker', () => {
 
   it('attaches application context to events', async () => {
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       appId: 'my-app',
       appVersion: '1.0.1',
@@ -117,6 +139,7 @@ describe('Tracker', () => {
 
   it('tracks screen engagement events', async () => {
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       endpoint: 'http://localhost:9090',
       customFetch: mockFetch,
@@ -160,6 +183,7 @@ describe('Tracker', () => {
 
   it('doesnt track screen engagement events if disabled', async () => {
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       endpoint: 'http://localhost:9090',
       customFetch: mockFetch,
@@ -193,6 +217,7 @@ describe('Tracker', () => {
 
   it('adds a tracker plugin', async () => {
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       endpoint: 'http://localhost:9090',
       customFetch: mockFetch,
@@ -227,6 +252,7 @@ describe('Tracker', () => {
     }));
 
     const tracker = await newTracker({
+      appStorage: createMockAppStorage(),
       namespace: 'test',
       endpoint: 'http://localhost:9090',
       customFetch: mockFetch,
@@ -264,6 +290,7 @@ describe('Tracker', () => {
   describe('Global contexts', () => {
     it('adds a global context', async () => {
       const tracker = await newTracker({
+        appStorage: createMockAppStorage(),
         namespace: 'test',
         endpoint: 'http://localhost:9090',
         customFetch: mockFetch,
@@ -299,6 +326,7 @@ describe('Tracker', () => {
 
     it('removes a global context', async () => {
       const tracker = await newTracker({
+        appStorage: createMockAppStorage(),
         namespace: 'test',
         endpoint: 'http://localhost:9090',
         customFetch: mockFetch,

--- a/trackers/react-native-tracker/test/web_view_interface.test.ts
+++ b/trackers/react-native-tracker/test/web_view_interface.test.ts
@@ -8,6 +8,19 @@ function createMockFetch(status: number, requests: Request[]) {
   };
 }
 
+function createAppStorageMock() {
+  const storageState: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => Promise.resolve(storageState[key] ?? null),
+    setItem: (key: string, value: string) => {
+      storageState[key] = value;
+
+      return Promise.resolve();
+    },
+  };
+}
+
 describe('WebView interface', () => {
   let requests: Request[];
   let mockFetch: ReturnType<typeof createMockFetch>;
@@ -23,6 +36,7 @@ describe('WebView interface', () => {
 
   it('tracks a page view event', async () => {
     const tracker = await newTracker({
+      appStorage: createAppStorageMock(),
       namespace: 'test',
       appId: 'my-app',
       endpoint: 'http://localhost:9090',
@@ -59,6 +73,7 @@ describe('WebView interface', () => {
 
   it('tracks a self-describing event', async () => {
     const tracker = await newTracker({
+      appStorage: createAppStorageMock(),
       namespace: 'test',
       appId: 'my-app',
       endpoint: 'http://localhost:9090',
@@ -99,6 +114,7 @@ describe('WebView interface', () => {
 
   it('tracks a structured event', async () => {
     const tracker = await newTracker({
+      appStorage: createAppStorageMock(),
       namespace: 'test',
       appId: 'my-app',
       endpoint: 'http://localhost:9090',
@@ -140,6 +156,7 @@ describe('WebView interface', () => {
 
   it('tracks a screen view event', async () => {
     const tracker = await newTracker({
+      appStorage: createAppStorageMock(),
       namespace: 'test',
       appId: 'my-app',
       endpoint: 'http://localhost:9090',
@@ -177,15 +194,15 @@ describe('WebView interface', () => {
   });
 
   describe('WebView event tracking', () => {
-
     it('tracks a page view event', async () => {
       const tracker = await newTracker({
+        appStorage: createAppStorageMock(),
         namespace: 'test',
         appId: 'my-app',
         endpoint: 'http://localhost:9090',
         customFetch: mockFetch,
       });
-  
+
       const webViewInterface = getWebViewCallback();
       webViewInterface({
         nativeEvent: {
@@ -200,14 +217,14 @@ describe('WebView interface', () => {
           }),
         },
       });
-  
+
       await tracker.flush();
       expect(requests.length).toBe(1);
-  
+
       const [request] = requests;
       const payload = await request?.json();
       expect(payload.data.length).toBe(1);
-  
+
       const [event] = payload.data;
       expect(event.e).toBe('pv');
       expect(event.url).toBe('http://localhost:9090');
@@ -217,13 +234,14 @@ describe('WebView interface', () => {
 
     it('tracks a self-describing event', async () => {
       const tracker = await newTracker({
+        appStorage: createAppStorageMock(),
         namespace: 'test',
         appId: 'my-app',
         endpoint: 'http://localhost:9090',
         customFetch: mockFetch,
         encodeBase64: false,
       });
-  
+
       const webViewInterface = getWebViewCallback();
       webViewInterface({
         nativeEvent: {
@@ -240,14 +258,14 @@ describe('WebView interface', () => {
           }),
         },
       });
-  
+
       await tracker.flush();
       expect(requests.length).toBe(1);
-  
+
       const [request] = requests;
       const payload = await request?.json();
       expect(payload.data.length).toBe(1);
-  
+
       const [event] = payload.data;
       const { e, ue_pr } = event;
       expect(e).toBe('ue');
@@ -259,12 +277,13 @@ describe('WebView interface', () => {
 
     it('tracks a structured event', async () => {
       const tracker = await newTracker({
+        appStorage: createAppStorageMock(),
         namespace: 'test',
         appId: 'my-app',
         endpoint: 'http://localhost:9090',
         customFetch: mockFetch,
       });
-  
+
       const webViewInterface = getWebViewCallback();
       webViewInterface({
         nativeEvent: {
@@ -281,14 +300,14 @@ describe('WebView interface', () => {
           }),
         },
       });
-  
+
       await tracker.flush();
       expect(requests.length).toBe(1);
-  
+
       const [request] = requests;
       const payload = await request?.json();
       expect(payload.data.length).toBe(1);
-  
+
       const [event] = payload.data;
       const { e, se_ca, se_ac, se_la, se_pr, se_va } = event;
       expect(e).toBe('se');
@@ -301,12 +320,13 @@ describe('WebView interface', () => {
 
     it('tracks a page ping event', async () => {
       const tracker = await newTracker({
+        appStorage: createAppStorageMock(),
         namespace: 'test',
         appId: 'my-app',
         endpoint: 'http://localhost:9090',
         customFetch: mockFetch,
       });
-  
+
       const webViewInterface = getWebViewCallback();
       webViewInterface({
         nativeEvent: {
@@ -325,14 +345,14 @@ describe('WebView interface', () => {
           }),
         },
       });
-  
+
       await tracker.flush();
       expect(requests.length).toBe(1);
-  
+
       const [request] = requests;
       const payload = await request?.json();
       expect(payload.data.length).toBe(1);
-  
+
       const [event] = payload.data;
       expect(event.e).toBe('pp');
       expect(event.url).toBe('http://localhost:9090');
@@ -347,6 +367,7 @@ describe('WebView interface', () => {
 
   it('tracks tracker version and useragent', async () => {
     const tracker = await newTracker({
+      appStorage: createAppStorageMock(),
       namespace: 'test',
       appId: 'my-app',
       endpoint: 'http://localhost:9090',


### PR DESCRIPTION
This PR proposes an approach to avoid the intrinsic usage of AsyncStorage, as discussed in https://github.com/snowplow/snowplow-javascript-tracker/issues/1413. The why resides in the fact that the React Native community is now accustomed to using different solutions to keep data in local storage (e.g., https://github.com/mrousavy/react-native-mmkv, https://github.com/react-native-async-storage/async-storage). 

Forcing the use of AsyncStorage might be undesirable, especially for projects bootstrapped with MMKV, as it would introduce a duplication of intents.