### PR TITLE
Add a default 0 value for start and end in the media_element entity time ranges

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_missing_end_in_seekable_property_2025-05-05-13-43.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_missing_end_in_seekable_property_2025-05-05-13-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Add a default 0 value for start and end in the media_element entity time ranges",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
+++ b/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
@@ -53,7 +53,7 @@ type TimeRange = { start: number; end: number };
 export function timeRangesToObjectArray(t: TimeRanges): TimeRange[] {
   const out: TimeRange[] = [];
   for (let i = 0; i < t.length; i++) {
-    out.push({ start: t.start(i), end: t.end(i) });
+    out.push({ start: t.start(i) || 0, end: t.end(i) || 0 });
   }
   return out;
 }

--- a/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
+++ b/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
@@ -53,7 +53,11 @@ type TimeRange = { start: number; end: number };
 export function timeRangesToObjectArray(t: TimeRanges): TimeRange[] {
   const out: TimeRange[] = [];
   for (let i = 0; i < t.length; i++) {
-    out.push({ start: t.start(i) || 0, end: t.end(i) || 0 });
+    const start = t.start(i);
+    const end = t.end(i);
+    if (isFinite(start) && isFinite(end)) {
+      out.push({ start: start || 0, end: end || 0 });
+    }
   }
   return out;
 }


### PR DESCRIPTION
This PR aims to prevent a schema validation error occurs for some mobile browsers which seem to be omitting the `end` value in timeranges within the `seekable` [property in the `media_element` entity schema](https://github.com/snowplow/iglu-central/blob/master/schemas/org.whatwg/media_element/jsonschema/1-0-0#L170).

I couldn't reproduce this unfortunately but assume it is some type of browser bug, so the best I can think of doing is to add a default 0 value to the `start` and `end` properties within the time ranges.

If you have some better ideas, please let me know!

The majority of failed events for the customer have the following value for the seekable property:

``` 
"seekable": [
  {
    "start": 0
  }
]
```