### PR TITLE
Release 4.6.1

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_missing_end_in_seekable_property_2025-05-05-13-43.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/issue-fix_missing_end_in_seekable_property_2025-05-05-13-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Add a default 0 value for start and end in the media_element entity time ranges",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -42,6 +42,6 @@
      *
      * Valid values are: "prerelease", "release", "minor", "patch", "major"
      */
-    "nextBump": "minor"
+    "nextBump": "patch"
   }
 ]

--- a/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
+++ b/plugins/browser-plugin-media-tracking/src/helperFunctions.ts
@@ -53,7 +53,11 @@ type TimeRange = { start: number; end: number };
 export function timeRangesToObjectArray(t: TimeRanges): TimeRange[] {
   const out: TimeRange[] = [];
   for (let i = 0; i < t.length; i++) {
-    out.push({ start: t.start(i), end: t.end(i) });
+    const start = t.start(i);
+    const end = t.end(i);
+    if (isFinite(start) && isFinite(end)) {
+      out.push({ start: start || 0, end: end || 0 });
+    }
   }
   return out;
 }


### PR DESCRIPTION
**Bug fixes**

- Add a default 0 value for start and end in the media_element entity time ranges (#1428)