### PR TITLE
Fix Element Tracking element_content entity properties

### DIFF
--- a/common/changes/@snowplow/browser-plugin-element-tracking/element-tracker-schemafix_2025-05-16-01-10.json
+++ b/common/changes/@snowplow/browser-plugin-element-tracking/element-tracker-schemafix_2025-05-16-01-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-element-tracking",
+      "comment": "Fix element_content schema implementation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-element-tracking"
+}

--- a/plugins/browser-plugin-element-tracking/src/data.ts
+++ b/plugins/browser-plugin-element-tracking/src/data.ts
@@ -192,17 +192,18 @@ export function buildContentTree(
       const contents = getMatchingElements(contentConfig, element);
 
       contents.forEach((contentElement, i) => {
-        context.push({
+        const entity: ElementContentEntity = {
           schema: Entities.ELEMENT_CONTENT,
           data: {
-            element_name: contentConfig.name,
             parent_name: config.name,
-            parent_position: parentPosition,
-            position: i + 1,
+            parent_index: parentPosition,
+            element_name: contentConfig.name,
+            element_index: i + 1,
             attributes: extractSelectorDetails(contentElement, contentConfig.selector, contentConfig.details),
           },
-        });
+        };
 
+        context.push(entity);
         context.push(...contentConfig.context(contentElement, contentConfig));
         context.push(...buildContentTree(contentConfig, contentElement, i + 1));
       });

--- a/plugins/browser-plugin-element-tracking/test/api.test.ts
+++ b/plugins/browser-plugin-element-tracking/test/api.test.ts
@@ -241,10 +241,10 @@ describe('Element Tracking Plugin API', () => {
         ]);
         expect(entityOf(eventQueue[0], 'element_content')).toEqual([
           {
-            element_name: 'h1',
             parent_name: '.advanced',
-            parent_position: 1,
-            position: 1,
+            parent_index: 1,
+            element_name: 'h1',
+            element_index: 1,
             attributes: [
               {
                 source: 'content',


### PR DESCRIPTION
In preparation for publishing the Element Tracking schemas to Iglu Central, changes were made to the `element_content` schema to be more consistent with the other related schemas.

The type definition in the plugin implementation was updated to match, but the function that builds the context with that entity also includes the entities from the user's custom entity generators, so accepts arbitrary `SelfDescribingJson` to build a context of type `(ElementContentEntity | SelfDescribingJson)[]`. Since the implementation for that entity was not updated, it no longer satisfied `ElementContentEntity` but _did_ still satisfy `SelfDescribingJson`, so passed the type check and compiled successfully, despite no longer matching the schema.

This builds the entity in a type-safer way, declaring it explicitly as `ElementContentEntity`, and fixes the implementation to match the schema.