### PR TITLE
Fix session resumption when changing storage strategy with disableAnonymousTracking

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/issue-bcpf-1813-stratchange-resume_2025-05-23-06-07.json
+++ b/common/changes/@snowplow/browser-tracker-core/issue-bcpf-1813-stratchange-resume_2025-05-23-06-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Resume sessions when disabling anonymous tracking that was already tracking session state",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/javascript-tracker/issue-bcpf-1813-stratchange-resume_2025-05-23-08-06.json
+++ b/common/changes/@snowplow/javascript-tracker/issue-bcpf-1813-stratchange-resume_2025-05-23-08-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "Resume sessions when disabling anonymous tracking that was already tracking session state",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/test/integration/sessionStorage.test.ts
+++ b/trackers/javascript-tracker/test/integration/sessionStorage.test.ts
@@ -181,7 +181,20 @@ describe('Sessions', () => {
           log
         )
       )
-    ).toBe(3);
+    ).toBe(4);
+    expect(
+      F.size(
+        F.uniqBy(
+          F.get('event.domain_sessionid'),
+          F.filter(
+            (e) =>
+              F.get('event.name_tracker', e) === 'anonymousSessionTracker' &&
+              F.get('event.app_id', e) === 'session-integration-' + testIdentifier,
+            log
+          )
+        )
+      )
+    ).toBe(2);
   });
 
   it('should only increment domain_sessionidx outside of session timeout (cookie storage)', () => {

--- a/trackers/javascript-tracker/test/pages/session-integration.html
+++ b/trackers/javascript-tracker/test/pages/session-integration.html
@@ -52,7 +52,7 @@
 
       window.snowplow('newTracker', 'anonymousSessionTracker', collector_endpoint, {
         appId: 'session-integration-' + testIdentifier,
-        cookieName: testIdentifier,
+        cookieName: testIdentifier + 'anon',
         sessionCookieTimeout: 1,
         stateStorageStrategy: 'localStorage',
         anonymousTracking: { withSessionTracking: true },
@@ -60,12 +60,16 @@
 
       const currentUrl = window.location.href;
       const url = new URL(currentUrl);
-      if (url.searchParams.has("delayed")) {
+      if (url.searchParams.has('delayed')) {
         setTimeout(function () {
           window.snowplow('trackPageView:cookieSessionTracker');
 
           window.snowplow('trackPageView:localStorageSessionTracker');
 
+          window.snowplow('trackPageView:anonymousSessionTracker');
+          window.snowplow('disableAnonymousTracking:anonymousSessionTracker', {
+            stateStorageStrategy: 'cookieAndLocalStorage',
+          });
           window.snowplow('trackPageView:anonymousSessionTracker');
         }, 0);
       } else {
@@ -81,7 +85,7 @@
         }, 0);
 
         setTimeout(function () {
-          url.searchParams.set("delayed", "1");
+          url.searchParams.set('delayed', '1');
           window.location.href = url.toString();
         }, 3000);
       }


### PR DESCRIPTION
If you create a tracker in anonymousTracking mode with session tracking enabled, and then change the storage strategy when disabling anonymousTracking mode, the tracker looks for the `ses` cookie using the new strategy rather than the old one, which fails. This makes it think a new session has begun. In order to tie the anonymous behaviour to the non-anonymous behaviour, you have to stitch via pageview ID or network user ID rather than the expected session ID.

If this is the initial pageview, this can cause interesting cases like events from a single pageview with two different `domain_sessionid` values, both with `domain_sessionidx` = 1.

With this change, we detect when a storage strategy is being changed, and if we are already in a session with the old strategy, update the `ses` cookie with the new strategy before loading the ID. This allows the tracker to notice a session is already in progress with the new strategy, and resume it with the existing session ID/index.

If there is no change to the storage strategy, or there is currently no session in progress, the behavior remains unchanged.

E.g.

```javascript

snowplow('newTracker', 'sp', 'http://localhost:9090', {
    anonymousTracking: {
      withSessionTracking: true,
      withServerAnonymisation: true
    },
    stateStorageStrategy: 'localStorage',
});

snowplow('trackPageView'); // session ID 1

snowplow('disableAnonymousTracking', {stateStorageStrategy: 'cookieAndLocalStorage'}); // got consent, switch to cookies

snowplow('trackStructEvent', { // session ID 2 - oops!
  category: 'Mixes',
  action: 'Play',
  label: 'MrC/fabric-0503-mix',
  property: '',
  value: 0.0
});
```