### PR TITLE
Add onSessionChangeCallback to react-native tracker

### DIFF
--- a/trackers/react-native-tracker/src/plugins/session/index.ts
+++ b/trackers/react-native-tracker/src/plugins/session/index.ts
@@ -57,7 +57,7 @@ export async function newSessionPlugin({
   sessionContext = true,
   foregroundSessionTimeout,
   backgroundSessionTimeout,
-  onSessionChangeCallback,
+  onSessionUpdateCallback,
 }: TrackerConfiguration & SessionConfiguration & { asyncStorage: AsyncStorage }): Promise<SessionPlugin> {
   let sessionState = await resumeStoredSession(namespace, asyncStorage);
   await storeSessionState(namespace, sessionState, asyncStorage);
@@ -117,7 +117,7 @@ export async function newSessionPlugin({
     }
 
     if (didPreviousSessionTimeout || isFirstEvent) {
-      onSessionChangeCallback?.(sessionState);
+      onSessionUpdateCallback?.(sessionState);
     }
   };
 

--- a/trackers/react-native-tracker/src/types.ts
+++ b/trackers/react-native-tracker/src/types.ts
@@ -62,7 +62,7 @@ export interface SessionConfiguration {
   /**
    * A callback function that is called when the session changes
    */
-  onSessionChangeCallback?: (session: SessionState) => void;
+  onSessionUpdateCallback?: (session: SessionState) => void;
 }
 
 /**

--- a/trackers/react-native-tracker/src/types.ts
+++ b/trackers/react-native-tracker/src/types.ts
@@ -59,6 +59,10 @@ export interface SessionConfiguration {
    * @defaultValue true
    */
   sessionContext?: boolean;
+  /**
+   * A callback function that is called when the session changes
+   */
+  onSessionChangeCallback?: (session: SessionState) => void;
 }
 
 /**


### PR DESCRIPTION
This PR resolves https://github.com/snowplow/snowplow-javascript-tracker/issues/1432 by adding the ability to pass an onSessionUpdateCallback callback to the react-native tracker.

This has worked for our team when used as a patch. However, please let me know if there are any further changes required to get this merged into the library. For example, it looks like the session plugin exposes the startNewSession method, which as far as I can tell is not called anywhere right now. Perhaps the team has additional context or future plans that would require adjusting the implementation to account for sessions updated this way?