### PR TITLE
Release/4.6.5

### DIFF
--- a/trackers/react-native-tracker/src/plugins/platform_context/index.ts
+++ b/trackers/react-native-tracker/src/plugins/platform_context/index.ts
@@ -239,11 +239,11 @@ export async function newPlatformContextPlugin({
           : PixelRatio.get()
         : undefined;
     language =
-      platformContextProperties?.includes(PlatformContextProperty.Language) ?? true
+      (platformContextProperties?.includes(PlatformContextProperty.Language) ?? true
         ? platformContextRetriever?.getLanguage
           ? await platformContextRetriever?.getLanguage()
           : constants?.language
-        : undefined;
+        : undefined)?.substring(0, 8);
     appSetId =
       platformContextProperties?.includes(PlatformContextProperty.AppSetId) ?? true
         ? platformContextRetriever?.getAppSetId

--- a/trackers/react-native-tracker/test/plugins/platform_context_ios.test.ts
+++ b/trackers/react-native-tracker/test/plugins/platform_context_ios.test.ts
@@ -167,4 +167,27 @@ describe('PlatformContextPlugin on iOS', () => {
       appSetIdScope: 'my-app-set-scope',
     });
   });
+
+  it('truncates language to 8 characters', async () => {
+    const sessionPlugin = await newPlatformContextPlugin({
+      platformContextRetriever: {
+        getLanguage: () => Promise.resolve('1234567890'),
+      },
+    });
+
+    const payloads: Payload[] = [];
+    const tracker = trackerCore({
+      corePlugins: [sessionPlugin.plugin],
+      callback: (pb) => payloads.push(pb.build()),
+      base64: false,
+    });
+    tracker.track(buildPageView({ pageUrl: 'http://localhost' }));
+
+    expect(payloads.length).toBe(1);
+    const [payload] = payloads;
+    expect(payload?.co).toBeDefined();
+    const entities = JSON.parse(payload?.co as string).data;
+    const mobileContext = entities.find((entity: any) => entity.schema === MOBILE_CONTEXT_SCHEMA);
+    expect(mobileContext?.data.language).toBe('12345678');
+  });
 });


### PR DESCRIPTION
This patch release truncates the language property in the platform context entity on the React Native tracker to avoid validation errors with the entity schema.

**Bug fixes**

- Truncate language in platform context entity to max 8 characters