### PR TITLE
Truncate browser context hardwareConcurrency value

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/fix-AISP-629-trunc-hwc_2025-08-15-01-47.json
+++ b/common/changes/@snowplow/browser-tracker-core/fix-AISP-629-trunc-hwc_2025-08-15-01-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "Truncate browser context hardwareConcurrency value to prevent invalid events",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/libraries/browser-tracker-core/src/helpers/browser_props.ts
+++ b/libraries/browser-tracker-core/src/helpers/browser_props.ts
@@ -86,7 +86,7 @@ function readBrowserProperties(): BrowserProperties {
     documentLanguage: document.documentElement.lang,
     webdriver: window.navigator.webdriver,
     deviceMemory: (window.navigator as any).deviceMemory,
-    hardwareConcurrency: (window.navigator as any).hardwareConcurrency,
+    hardwareConcurrency: Math.floor(window.navigator.hardwareConcurrency) || undefined,
   };
 }
 


### PR DESCRIPTION
We have received reports of some UAs providing this value as a floating point rather than integral value (contrary to the web standards). This causes events from those agents to be invalid because the schema requires it to be an integer. To meet the documented behavior and schema expectations, floor the value to ensure it is a whole integer. If the UA doesn't have this value, Math.floor should return NaN which we will turn into undefined to exclude from the event. This will also occur with '0', which shouldn't be a valid value according to the standard anyway so is deemed acceptable.

Issue: AISP-629