### PR TITLE
HTML5 Media plugin: allow CSS selectors

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media-tracking/feature-BCPF-1956-html5-selector_2025-08-15-02-42.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/feature-BCPF-1956-html5-selector_2025-08-15-02-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media-tracking",
+      "comment": "Allow using a CSS selector to find media elements",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking"
+}

--- a/plugins/browser-plugin-media-tracking/README.md
+++ b/plugins/browser-plugin-media-tracking/README.md
@@ -9,13 +9,13 @@ Adds HTML5 Video and Audio tracking events to your Snowplow tracking.
 
 ## Maintainer quick start
 
-Part of the Snowplow JavaScript Tracker monorepo.  
+Part of the Snowplow JavaScript Tracker monorepo.
 Build with [Node.js](https://nodejs.org/en/) (18 - 20) and [Rush](https://rushjs.io/).
 
 ### Setup repository
 
 ```bash
-npm install -g @microsoft/rush 
+npm install -g @microsoft/rush
 git clone https://github.com/snowplow/snowplow-javascript-tracker.git
 rush update
 ```
@@ -34,24 +34,23 @@ Initialize your tracker with the MediaTrackingPlugin:
 
 ```js
 import { newTracker } from '@snowplow/browser-tracker';
-import { MediaTrackingPlugin } from 'snowplow-browser-media-tracker';
+import { MediaTrackingPlugin, startHtml5MediaTracking, endHtml5MediaTracking } from '@snowplow/browser-plugin-media-tracking';
 
 newTracker('sp2', '{{collector}}', { plugins: [ MediaTrackingPlugin() ] }); // Also stores reference at module level
 ```
 
-Then, use the `enableMediaTracking` function described below to produce events from your HTML5 Video/Audio element(s).
+Then, use the `startHtml5MediaTracking` function described below to produce events from your HTML5 Video/Audio element(s).
 
 ```js
-enableMediaTracking({ id, options?: { label?, captureEvents?, boundaries?, volumeChangeTrackingInterval? } })
+startHtml5MediaTracking({ video, id })
 ```
 
-| Parameter                              | Type       | Default             | Description                                               | Required |
-| -------------------------------------- | ---------- | ------------------- | --------------------------------------------------------- | -------- |
-| `id`                                   | `string`   | -                   | The HTML id attribute of the media element                | Yes      |
-| `options.label`                        | `string`   | -                   | An identifiable custom label sent with the event          | No       |
-| `options.captureEvents`                | `string[]` | `['DefaultEvents']` | The name(s) of the events to capture                      | No       |
-| `options.boundaries`                   | `number[]` | `[10, 25, 50, 75]`  | The progress percentages to fire an event at (if enabled) | No       |
-| `options.volumeChangeTrackingInterval` | `number`   | `250`               | The rate at which volume events can be sent               | No       |
+| Parameter | Type                     | Description                                                                            | Required |
+| ----------| ------------------------ | -------------------------------------------------------------------------------------- | -------- |
+| `id`      | `string`                 | A UUID identifier to use as the media session ID                                       | Yes      |
+| `video`   | `string` / `HTMLElement` | The HTML id attribute, CSS selector, or actual media element to track media events for | Yes      |
+
+See the [full documentation](https://docs.snowplow.io/docs/sources/trackers/web-trackers/tracking-events/media/html5/#starthtml5mediatracking) for optional parameters.
 
 ## Example Usage
 
@@ -62,20 +61,23 @@ enableMediaTracking({ id, options?: { label?, captureEvents?, boundaries?, volum
 ```
 
 ```js
-import { enableMediaTracking } from '@snowplow/browser-plugin-media-tracking'
+import { startHtml5MediaTracking, endHtml5MediaTracking } from '@snowplow/browser-plugin-media-tracking';
 
-enableMediaTracking({
-  id: 'my-video',
-  options: {
-    label: "My Custom Video Label",
-    captureEvents: ["DefaultEvents"],
-    boundaries: [10, 25, 50, 75],
-    volumeChangeTrackingInterval: 250,
-  }
-})
+const sessionId = crypto.randomUUID();
+
+startHtml5MediaTracking({
+  id: sessionId,
+  video: 'my-video',
+  label: "My Custom Video Label",
+  boundaries: [10, 25, 50, 75],
+});
+
+/* ... */
+
+endHtml5MediaTracking(sessionId);
 ```
 
- For a full list of trackable events, head over to the [docs page](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/media-tracking/)
+ For a full list of parameters and trackable events, head over to the [docs page](https://docs.snowplow.io/docs/sources/trackers/web-trackers/tracking-events/media/html5/#events).
 
 ## Copyright and license
 

--- a/plugins/browser-plugin-media-tracking/src/entities.ts
+++ b/plugins/browser-plugin-media-tracking/src/entities.ts
@@ -18,7 +18,7 @@ export function buildHTMLMediaElementEntity(el: HTMLAudioElement | HTMLVideoElem
     autoPlay: el.autoplay,
     buffered: timeRangesToObjectArray(el.buffered),
     controls: el.controls,
-    currentSrc: el.currentSrc,
+    currentSrc: el.currentSrc || el.src,
     defaultMuted: el.defaultMuted || false,
     defaultPlaybackRate: el.defaultPlaybackRate,
     error: el.error ? { code: el.error?.code, message: el.error?.message } : null,

--- a/plugins/browser-plugin-media-tracking/src/findElem.ts
+++ b/plugins/browser-plugin-media-tracking/src/findElem.ts
@@ -43,9 +43,15 @@ export function waitForElement(config: StringConfig, callback: (element: Element
 }
 
 export function findMediaElement(id: string): SearchResult {
-  let el: HTMLElement | null = document.getElementById(id);
+  let el: HTMLElement | null = null;
 
-  if (!el) return { err: SEARCH_ERROR.NOT_FOUND };
+  try {
+    el = document.getElementById(id) ?? document.querySelector(id);
+  } catch (e) {}
+
+  if (!el) {
+    return { err: SEARCH_ERROR.NOT_FOUND };
+  }
   if (isHtmlAudioElement(el)) return { el };
 
   if (isHtmlVideoElement(el)) {

--- a/plugins/browser-plugin-media-tracking/tests/media.test.ts
+++ b/plugins/browser-plugin-media-tracking/tests/media.test.ts
@@ -41,6 +41,12 @@ describe('element searcher', () => {
     const output = findMediaElement('parentElem');
     expect(output).toStrictEqual({ err: 'More than one media element in the provided node' });
   });
+
+  it('falls back to css selector if can not find by id', () => {
+    document.body.innerHTML = '<div id="parentElem"><video></video><video></video><video></video></div>';
+    const output = findMediaElement('#parentElem > video');
+    expect(output.el?.tagName).toBe('VIDEO');
+  });
 });
 
 describe('dataUrlHandler', () => {


### PR DESCRIPTION
Some users have reported that when using the GTM Tag Template with the HTML5 Media Tracking plugin, they are not able to pass their media elements directly to the plugin to enable tracking. The GTM Tag Template runs in a sandbox where DOM elements are replaced with `null` values when passed as arguments to functions created in the sandbox (i.e. the `snowplow()` command queue). If the element has an ID (or is a child of an element with an ID), you can work around this issue by passing the ID as a string; the plugin itself is not sandboxxed, so if it selects the element itself it finds the element successfully and proceeds as expected.

Unfortunately, if your element has no ID or ancestor with an ID, you can not use this workaround with the current implementation.

This extends the plugin to try using the passed ID string as a CSS selector to find an element (using `document.querySelector()`) if the passed string fails to succeed as an exact ID match. This allows the plugin to work on pages that don't use IDs often in their layout by using more complex CSS selectors.

This introduces an odd edge case where it may now match elements that previously did not match in cases where IDs happen to also be valid CSS selectors.
For example, if you had an element on one page like `<video id="video" />` and on another page just had `<video />`, selecting via `id: 'video'`:
- without this change only the first element would generate events
- with this change both elements will generate events.

I'm hoping this is rare enough to not be a big deal.

I have also updated the README to reflect this information, and the API changes from v4.0.0 which it seems it was not updated for. I have also made the `media_element` `currentSrc` value fallback to the `src` attribute if it has no value, as this has been reported as a source for invalid events. This should make the events valid but the state is still observable from the `networkState` field which should be `NETWORK_NO_SOURCE` when this is the case.