### PR TITLE
Make mobile_context values more consistent with earlier tracker versions

### DIFF
--- a/common/changes/@snowplow/react-native-tracker/fix-rn-android-osversion_2025-08-19-01-16.json
+++ b/common/changes/@snowplow/react-native-tracker/fix-rn-android-osversion_2025-08-19-01-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/react-native-tracker",
+      "comment": "Make mobile_context values more consistent with v2 tracker",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/trackers/react-native-tracker/test/plugins/platform_context_android.test.ts
+++ b/trackers/react-native-tracker/test/plugins/platform_context_android.test.ts
@@ -48,7 +48,7 @@ describe('PlatformContextPlugin on Android', () => {
     const [payload] = payloads;
     expect(payload?.co).toBeDefined();
     expect(payload?.co).toContain(MOBILE_CONTEXT_SCHEMA);
-    expect(payload?.co).toContain('"33"');
+    expect(payload?.co).toContain('"13"');
     expect(payload?.co).toContain('"sdk_gphone64_arm64"');
     expect(payload?.co).toContain('"Google"');
     expect(payload?.co).toContain('"Google"');


### PR DESCRIPTION
Change some of the values used in the React Native tracker's `mobile_context` entity to match those from the earlier v2 tracker that was based on the mobile trackers.

In particular:

- On Android, make `osVersion` be the Android version rather than API version
- On Android, make `osType` lowercase to match the previous format
- On iOS, make `deviceManufacturer` match the previous value

I also cleaned up some of the type casts and pre-commit prettified the code.

For `osVersion`:
- The v2 tracker deferred to the native Android tracker, which pulled from [android.os.Build.VERSION.RELEASE](https://developer.android.com/reference/android/os/Build.VERSION).
- The v4 tracker pulls from React Native's [Platform.constants.Version](https://reactnative.dev/docs/platform#constants)
- React Native populates `Version` based on `android.os.Build.VERSION.SDK_INT`, we [should be using](https://github.com/facebook/react-native/blob/25104de5c47845c0edbdfb38df30f8c406da832e/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.kt#L47-L48) `Release` instead to continue using `android.os.Build.VERSION.RELEASE`