### PR TITLE
Add TypeScript definitions to "package.json" for "react-native-tracker"

### DIFF
--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -23,6 +23,7 @@
   "source": "./src/index.tsx",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/module/index.js",
+  "types": "./dist/typescript/module/src/index.d.ts",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
### Issue:

When importing `@snowplow/react-native-tracker`, we got the following error:

```
This result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.
```

Changing the "moduleResolution" to "node16" fixes this issue, but breaks part of our build pipeline.

### Similar issue:

https://github.com/snowplow/snowplow-react-native-tracker/issues/217

### Proposed Solution:

This PR makes sure to add support for other module types.