### PR TITLE
Fix documentation build properly

### DIFF
--- a/api-docs/docs/react-native-tracker/markdown/react-native-tracker.getwebviewcallback.md
+++ b/api-docs/docs/react-native-tracker/markdown/react-native-tracker.getwebviewcallback.md
@@ -6,7 +6,7 @@
 
 Enables tracking events from apps rendered in react-native-webview components. The apps need to use the Snowplow WebView tracker to track the events.
 
-To subscribe for the events, set the `onMessage` attribute: `<WebView onMessage={getWebViewCallback()} ... />`
+To subscribe for the events, use as the `onMessage` prop for a `WebView` component.
 
 <b>Signature:</b>
 

--- a/api-docs/docs/react-native-tracker/markdown/react-native-tracker.md
+++ b/api-docs/docs/react-native-tracker/markdown/react-native-tracker.md
@@ -17,7 +17,7 @@
 |  --- | --- |
 |  [getAllTrackers()](./react-native-tracker.getalltrackers.md) | Retrieves all initialized trackers |
 |  [getTracker(trackerNamespace)](./react-native-tracker.gettracker.md) | Retrieves an initialized tracker given its namespace |
-|  [getWebViewCallback()](./react-native-tracker.getwebviewcallback.md) | Enables tracking events from apps rendered in react-native-webview components. The apps need to use the Snowplow WebView tracker to track the events.<!-- -->To subscribe for the events, set the <code>onMessage</code> attribute: <code>&lt;WebView onMessage={getWebViewCallback()} ... /&gt;</code> |
+|  [getWebViewCallback()](./react-native-tracker.getwebviewcallback.md) | Enables tracking events from apps rendered in react-native-webview components. The apps need to use the Snowplow WebView tracker to track the events.<!-- -->To subscribe for the events, use as the <code>onMessage</code> prop for a <code>WebView</code> component. |
 |  [newTracker(configuration)](./react-native-tracker.newtracker.md) | Creates a new tracker instance with the given configuration |
 |  [removeAllTrackers()](./react-native-tracker.removealltrackers.md) | Removes all initialized trackers |
 |  [removeTracker(trackerNamespace)](./react-native-tracker.removetracker.md) | Removes a tracker given its namespace |

--- a/common/changes/@snowplow/react-native-tracker/fix-docs-build_2025-10-17-01-19.json
+++ b/common/changes/@snowplow/react-native-tracker/fix-docs-build_2025-10-17-01-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/react-native-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/trackers/react-native-tracker/src/web_view_interface.ts
+++ b/trackers/react-native-tracker/src/web_view_interface.ts
@@ -111,8 +111,7 @@ function webViewPayloadBuilder(pb: PayloadBuilder): PayloadBuilder {
  * Enables tracking events from apps rendered in react-native-webview components.
  * The apps need to use the Snowplow WebView tracker to track the events.
  *
- * To subscribe for the events, set the `onMessage` attribute:
- * `<WebView onMessage={getWebViewCallback()} ... />`
+ * To subscribe for the events, use as the `onMessage` prop for a `WebView` component.
  *
  * @returns Callback to subscribe for events from Web views tracked using the Snowplow WebView tracker.
  */


### PR DESCRIPTION
This is a follow-up to #1444 which tried to fix our API docs build, but ended up being unsuccessful once the release CI job actually ran.

Probably because we're on pretty old versions of things, _something_ is getting confused with the nested JSX-in-markdown-in-JSX; I thought I'd managed to escape it properly in that change but it still didn't work.

So this change just removes the nested JSX, removing all the ambiguity, which fixes the build properly.