### PR TITLE
Allow opt-in bubble-phase form tracking

### DIFF
--- a/common/changes/@snowplow/browser-plugin-form-tracking/fix-CSTMR-1776-form-bubbling_2025-10-17-01-21.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/fix-CSTMR-1776-form-bubbling_2025-10-17-01-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-form-tracking",
+      "comment": "Allow opt-in bubble-phase listeners for change/submit",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking"
+}

--- a/common/changes/@snowplow/javascript-tracker/fix-CSTMR-1776-form-bubbling_2025-10-17-01-21.json
+++ b/common/changes/@snowplow/javascript-tracker/fix-CSTMR-1776-form-bubbling_2025-10-17-01-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/javascript-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker"
+}

--- a/trackers/javascript-tracker/test/pages/form-tracking.html
+++ b/trackers/javascript-tracker/test/pages/form-tracking.html
@@ -144,14 +144,15 @@
 
       switch (parseQuery().filter) {
         case 'exclude':
-          snowplow('enableFormTracking', { options: { fields: { denylist: ['fname'] } } });
+          snowplow('enableFormTracking', { options: { useCapture: true, fields: { denylist: ['fname'] } } });
           break;
         case 'include':
-          snowplow('enableFormTracking', { options: { fields: { allowlist: ['lname'] } } });
+          snowplow('enableFormTracking', { options: { useCapture: false, fields: { allowlist: ['lname'] } } });
           break;
         case 'filter':
           snowplow('enableFormTracking', {
             options: {
+              useCapture: undefined,
               forms: { allowlist: ['formy-mcformface'] },
               fields: { filter: formFilter },
             },
@@ -160,22 +161,23 @@
         case 'transform':
           snowplow('enableFormTracking', {
             options: {
+              useCapture: true,
               fields: { transform: redactPII },
             },
           });
           break;
         case 'excludedForm':
-          snowplow('enableFormTracking', { options: { forms: { denylist: ['excluded-form'] } } });
+          snowplow('enableFormTracking', { options: { useCapture: false, forms: { denylist: ['excluded-form'] } } });
           break;
         case 'onlyFocus':
-          snowplow('enableFormTracking', { options: { events: ['focus_form'] } });
+          snowplow('enableFormTracking', { options: { useCapture: undefined, events: ['focus_form'] } });
           break;
         case 'iframeForm':
           var forms = iframe.contentWindow.document.getElementsByTagName('form');
-          snowplow('enableFormTracking', { options: { forms: forms } });
+          snowplow('enableFormTracking', { options: { useCapture: true, forms: forms } });
           break;
         case 'shadow':
-          snowplow('enableFormTracking', { options: { forms: { allowlist: ['shadow-form'] } } });
+          snowplow('enableFormTracking', { options: { useCapture: false, forms: { allowlist: ['shadow-form'] } } });
           break;
         default:
           snowplow('enableFormTracking', {


### PR DESCRIPTION
In v4 we switched to document-level listeners in the Form Tracking plugin to avoid needing to periodically re-call `enableFormTracking` when new forms have been added to the DOM for them to be tracked (and also less listeners theoretically has better performance).

As part of this change, we also switched to using capture-phase events.
This was for two main reasons:
- The `focus` event doesn't actually bubble, so if we weren't using capture phase the tracking just doesn't work for this event
- Several users had reported not being able to track events because their framework/platform (e.g. Salesforce) was calling [`stopImmediatePropagation`](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation) which meant our target/bubble phase listeners never got called and so they could not track some events at all; since capture phase goes first we could track the events before propagation was stopped so this was more reliable

The downside of firing in the earlier phase is that if you require some kind of state to change in the target/bubble phase (e.g. form validation) and you rely on that in your transform/filter functions, those operations will no longer occur in time for you to depend on them.

Such a situation was reported in CSTMR-1776.

This change allows opt-in disabling capture phase for the `change`/`submit` events to go back to the old bubble-phase behavior. This lets you choose less reliable event detection in exchange for running later if needed, via a `useCapture: false` option.

The default remains using capture-phase, and capture-phase is hard-coded for the `focus` event since it would fail to work otherwise.

Not sure who is best to review on your team @cksnp so just assigning to you for now. :)