### PR TITLE
Fix/optimizely personalization campaign

### DIFF
--- a/plugins/browser-plugin-optimizely-x/pnpm-lock.yaml
+++ b/plugins/browser-plugin-optimizely-x/pnpm-lock.yaml
@@ -1,0 +1,67 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@snowplow/browser-tracker-core':
+        specifier: ~4.6.9
+        version: 4.6.9
+      '@snowplow/tracker-core':
+        specifier: ~4.6.9
+        version: 4.6.9
+
+packages:
+
+  '@snowplow/browser-tracker-core@4.6.9':
+    resolution: {integrity: sha512-KyW/zU7Isb49/2XcliwTb7yOZvowHXBfdlODiEOGXWn9QcWyAEawqETh/gZJua/+lg+9d6zp2F9bqkKPpwtpKg==}
+
+  '@snowplow/tracker-core@4.6.9':
+    resolution: {integrity: sha512-ybKK3t7pd+JwX9BA+DeiuyzbOgE0RpbzhTpPwHvIom+gAQUYCZpyECxFT5FBLrdZtGeWdIaoY93JXneDNfVGLg==}
+
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  sha1@1.1.1:
+    resolution: {integrity: sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+snapshots:
+
+  '@snowplow/browser-tracker-core@4.6.9':
+    dependencies:
+      '@snowplow/tracker-core': 4.6.9
+      sha1: 1.1.1
+      tslib: 2.8.1
+      uuid: 10.0.0
+
+  '@snowplow/tracker-core@4.6.9':
+    dependencies:
+      tslib: 2.8.1
+      uuid: 10.0.0
+
+  charenc@0.0.2: {}
+
+  crypt@0.0.2: {}
+
+  sha1@1.1.1:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+
+  tslib@2.8.1: {}
+
+  uuid@10.0.0: {}

--- a/plugins/browser-plugin-optimizely-x/src/contexts.ts
+++ b/plugins/browser-plugin-optimizely-x/src/contexts.ts
@@ -32,6 +32,7 @@
  * Schema for an Optimizely X summary context
  */
 export interface OptimizelyxSummary {
+  campaignId?: number | null;    // added: captures the Personalization campaign layerId
   experimentId?: number | null;
   variationName?: string | null;
   variation?: number | null;

--- a/plugins/browser-plugin-optimizely-x/src/index.ts
+++ b/plugins/browser-plugin-optimizely-x/src/index.ts
@@ -48,7 +48,7 @@ declare global {
 }
 
 /**
- * Adds Opimizely X context to events
+ * Adds Optimizely X context to events
  */
 export function OptimizelyXPlugin(): BrowserPlugin {
   /**
@@ -66,24 +66,32 @@ export function OptimizelyXPlugin(): BrowserPlugin {
   }
 
   /**
-   * Get data for OptimizelyX contexts - active experiments on current page
+   * Get data for OptimizelyX contexts - active campaigns on current page.
+   * Uses getCampaignStates() instead of getActiveExperimentIds() to correctly
+   * capture campaignId (layerId) for both Web Experimentation and Personalization
+   * campaigns. For Personalization campaigns, experimentId will reflect the
+   * experience ID (the sub-unit within the campaign).
    *
-   * @returns Array content of lite optimizely lite context
+   * @returns Array content of optimizely summary context
    */
   function getOptimizelyXSummary(): OptimizelyxSummary[] {
     const state = getOptimizelyXData('state');
     if (state == null) return [];
-    var experiment_ids = state.getActiveExperimentIds() || [];
-    var variationMap = state.getVariationMap();
-    var visitor = getOptimizelyXData('visitor');
 
-    return experiment_ids.map((activeExperiment: string) => {
-      var variation = variationMap[activeExperiment];
-      var variationName = (variation && variation.name && variation.name.toString()) || null;
-      var variationId = variation && variation.id;
-      var visitorId = (visitor && visitor.visitorId && visitor.visitorId.toString()) || null;
+    const campaignStates = state.getCampaignStates({ isActive: true }) || {};
+    const visitor = getOptimizelyXData('visitor');
+    const visitorId = (visitor && visitor.visitorId && visitor.visitorId.toString()) || null;
+
+    return Object.keys(campaignStates).map((campaignId: string) => {
+      const campaign = campaignStates[campaignId];
+      const experimentId = campaign.experiment && campaign.experiment.id;
+      const variationId = campaign.variation && campaign.variation.id;
+      const variationName =
+        (campaign.variation && campaign.variation.name && campaign.variation.name.toString()) || null;
+
       return {
-        experimentId: parseAndValidateInt(activeExperiment) || null,
+        campaignId: parseAndValidateInt(campaignId) || null,
+        experimentId: parseAndValidateInt(experimentId) || null,
         variationName: variationName,
         variation: parseAndValidateInt(variationId) || null,
         visitorId: visitorId,
@@ -100,7 +108,7 @@ export function OptimizelyXPlugin(): BrowserPlugin {
   function getOptimizelyXSummaryContexts() {
     return getOptimizelyXSummary().map(function (experiment) {
       return {
-        schema: 'iglu:com.optimizely.optimizelyx/summary/jsonschema/1-0-0',
+        schema: 'iglu:com.optimizely.optimizelyx/summary/jsonschema/1-1-0',
         data: experiment,
       };
     });


### PR DESCRIPTION
## Summary

Fixes #1462

Replaces `getActiveExperimentIds()` with `getCampaignStates({ isActive: true })` in `getOptimizelyXSummary()` to correctly capture `campaignId` for Optimizely Personalization campaigns.

## Problem

The existing implementation uses two Optimizely state API calls that 
bypass the campaign layer entirely:
```typescript
// Before — misses campaignId completely
var experiment_ids = state.getActiveExperimentIds() || [];
var variationMap = state.getVariationMap();
```

For Optimizely Personalization campaigns, `getActiveExperimentIds()` 
surfaces experience IDs (the sub-unit inside a campaign) but never 
exposes the parent `campaignId` (layerId). This means `campaignId` 
was never captured in Snowplow event data — not as null, not as empty — it simply did not exist in the schema output.

## Solution

`getCampaignStates({ isActive: true })` returns a unified state object 
for both Web Experimentation and Personalization campaigns, where the 
top-level key is the `campaignId`:
```typescript
// After — correctly captures campaignId for all campaign types
const campaignStates = state.getCampaignStates({ isActive: true }) || {};

return Object.keys(campaignStates).map((campaignId: string) => {
  const campaign = campaignStates[campaignId];
  return {
    campaignId: parseAndValidateInt(campaignId) || null,
    experimentId: parseAndValidateInt(campaign.experiment?.id) || null,
    variationName: campaign.variation?.name?.toString() || null,
    variation: parseAndValidateInt(campaign.variation?.id) || null,
    visitorId: visitorId,
  };
});
```

## Behavior by Campaign Type

| Field | Web Experimentation | Personalization |
|---|---|---|
| `campaignId` | layerId (auto-generated wrapper) | layerId of the campaign |
| `experimentId` | experimentId | experienceId (sub-unit of campaign) |
| `variation` | variationId | variationId |

## Changes

- `src/index.ts` — replaced `getActiveExperimentIds()` + `getVariationMap()` 
  with `getCampaignStates({ isActive: true })`, moved `visitorId` resolution 
  outside the loop, updated schema reference to `1-1-0`
- `src/contexts.ts` — added `campaignId?: number | null` to 
  `OptimizelyxSummary` interface

## Schema

This change requires a new schema version 
`iglu:com.optimizely.optimizelyx/summary/jsonschema/1-1-0` with `campaignId` 
added as an optional integer field. This is a minor version bump 
(`1-0-0` → `1-1-0`) as the addition is backward compatible — existing events without `campaignId` remain valid.

## Testing

Verified in browser console against a live Optimizely Personalization 
campaign:
```javascript
optimizely.get('state').getCampaignStates({ isActive: true })
// Returns campaignId, experiment.id, variation.id, and variation.name 
// correctly for both Personalization and Web Experimentation campaigns
```