### PR TITLE
Strip empty strings from optional media player entity fields

### DIFF
--- a/common/changes/@snowplow/browser-plugin-media/fix-disallow-empty-string-media_2026-05-19-13-41.json
+++ b/common/changes/@snowplow/browser-plugin-media/fix-disallow-empty-string-media_2026-05-19-13-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-media",
+      "comment": "Prevent empty values in media entity",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media"
+}

--- a/plugins/browser-plugin-media/src/core.ts
+++ b/plugins/browser-plugin-media/src/core.ts
@@ -18,7 +18,7 @@ export function buildMediaPlayerEvent(event: MediaEvent): SelfDescribingJson {
 export function buildMediaPlayerEntity(mediaPlayer: MediaPlayer): SelfDescribingJson {
   return {
     schema: MEDIA_PLAYER_SCHEMA,
-    data: removeEmptyProperties(mediaPlayer, { stripEmptyStrings: true }),
+    data: removeEmptyProperties(mediaPlayer),
   };
 }
 
@@ -44,19 +44,15 @@ export function buildMediaAdBreakEntity(adBreak: MediaAdBreak): SelfDescribingJs
 }
 
 /**
- * Returns a copy of a JSON with undefined and null properties removed
+ * Returns a copy of a JSON with undefined, null, and empty string properties removed
  *
  * @param event - Object to clean
- * @param options - Optional settings; if stripEmptyStrings is true, empty string values are also removed
  * @returns A cleaned copy of eventJson
  */
-function removeEmptyProperties(
-  event: Record<string, unknown>,
-  options?: { stripEmptyStrings?: boolean }
-): Record<string, unknown> {
+function removeEmptyProperties(event: Record<string, unknown>): Record<string, unknown> {
   const ret: Record<string, unknown> = {};
   for (const k in event) {
-    if (event[k] != null && (!options?.stripEmptyStrings || event[k] !== '')) {
+    if (event[k] != null && event[k] !== '') {
       ret[k] = event[k];
     }
   }

--- a/plugins/browser-plugin-media/src/core.ts
+++ b/plugins/browser-plugin-media/src/core.ts
@@ -18,7 +18,7 @@ export function buildMediaPlayerEvent(event: MediaEvent): SelfDescribingJson {
 export function buildMediaPlayerEntity(mediaPlayer: MediaPlayer): SelfDescribingJson {
   return {
     schema: MEDIA_PLAYER_SCHEMA,
-    data: removeEmptyProperties(mediaPlayer),
+    data: removeEmptyProperties(mediaPlayer, { stripEmptyStrings: true }),
   };
 }
 
@@ -47,12 +47,16 @@ export function buildMediaAdBreakEntity(adBreak: MediaAdBreak): SelfDescribingJs
  * Returns a copy of a JSON with undefined and null properties removed
  *
  * @param event - Object to clean
+ * @param options - Optional settings; if stripEmptyStrings is true, empty string values are also removed
  * @returns A cleaned copy of eventJson
  */
-function removeEmptyProperties(event: Record<string, unknown>): Record<string, unknown> {
+function removeEmptyProperties(
+  event: Record<string, unknown>,
+  options?: { stripEmptyStrings?: boolean }
+): Record<string, unknown> {
   const ret: Record<string, unknown> = {};
   for (const k in event) {
-    if (event[k] != null) {
+    if (event[k] != null && (!options?.stripEmptyStrings || event[k] !== '')) {
       ret[k] = event[k];
     }
   }

--- a/plugins/browser-plugin-media/src/core.ts
+++ b/plugins/browser-plugin-media/src/core.ts
@@ -16,9 +16,14 @@ export function buildMediaPlayerEvent(event: MediaEvent): SelfDescribingJson {
 }
 
 export function buildMediaPlayerEntity(mediaPlayer: MediaPlayer): SelfDescribingJson {
+  const player = { ...mediaPlayer };
+  if (player.label === '') delete player.label;
+  if (player.playerType === '') delete player.playerType;
+  if (player.quality === '') delete player.quality;
+
   return {
     schema: MEDIA_PLAYER_SCHEMA,
-    data: removeEmptyProperties(mediaPlayer),
+    data: removeEmptyProperties(player),
   };
 }
 
@@ -44,7 +49,7 @@ export function buildMediaAdBreakEntity(adBreak: MediaAdBreak): SelfDescribingJs
 }
 
 /**
- * Returns a copy of a JSON with undefined, null, and empty string properties removed
+ * Returns a copy of a JSON with undefined and null properties removed
  *
  * @param event - Object to clean
  * @returns A cleaned copy of eventJson
@@ -52,7 +57,7 @@ export function buildMediaAdBreakEntity(adBreak: MediaAdBreak): SelfDescribingJs
 function removeEmptyProperties(event: Record<string, unknown>): Record<string, unknown> {
   const ret: Record<string, unknown> = {};
   for (const k in event) {
-    if (event[k] != null && event[k] !== '') {
+    if (event[k] != null) {
       ret[k] = event[k];
     }
   }

--- a/plugins/browser-plugin-media/test/api.test.ts
+++ b/plugins/browser-plugin-media/test/api.test.ts
@@ -316,6 +316,38 @@ describe('Media Tracking API', () => {
       ]);
     });
 
+    it('strips empty string values from optional media player fields', () => {
+      startMediaTracking({
+        id,
+        session: false,
+        player: { label: '', playerType: '', quality: '' },
+      });
+
+      trackMediaPlay({ id });
+
+      const playerContext = eventQueue[0].context[0].data;
+      expect(playerContext).not.toHaveProperty('label');
+      expect(playerContext).not.toHaveProperty('playerType');
+      expect(playerContext).not.toHaveProperty('quality');
+    });
+
+    it('preserves non-empty string values for optional media player fields', () => {
+      startMediaTracking({
+        id,
+        session: false,
+        player: { label: 'My Video', playerType: 'html5', quality: '1080p' },
+      });
+
+      trackMediaPlay({ id });
+
+      const playerContext = eventQueue[0].context[0].data;
+      expect(playerContext).toMatchObject({
+        label: 'My Video',
+        playerType: 'html5',
+        quality: '1080p',
+      });
+    });
+
     it('tracks error event', () => {
       startMediaTracking({ id, session: false });
 


### PR DESCRIPTION
The media_player entity (iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0) can produce inconsistent values for optional string fields (label, playerType, quality). The `removeEmptyProperties` function in `browser-plugin-media/src/core.ts` strips null and undefined but passes through empty strings "". This means callers supplying "" where undefined is intended produce events where the field is present but empty, rather than absent.

Downstream, the dbt media player package treats "" and NULL as distinct values. When the same media content generates events with both representations, it produces different surrogate keys for media_identifier, causing merge conflicts and duplicate rows in aggregated models.

### Fix
Added a stripEmptyStrings option to removeEmptyProperties, enabled only for buildMediaPlayerEntity. This keeps the change scoped to the media player entity — other entity builders (ad, ad break, session, event) are unaffected.
When stripEmptyStrings is true, empty string values are filtered out alongside null/undefined, so optional string fields that are "" are omitted from the payload entirely (equivalent to NULL in the warehouse).
