### PR TITLE
fix: update uuid to v11, drop closure-compiler (keep Node 18 support)

### DIFF
--- a/common/changes/@snowplow/browser-plugin-ad-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-ad-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ad-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ad-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-ad-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-ad-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-ad-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-ad-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-ad-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-bot-detection/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-bot-detection/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-bot-detection"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-bot-detection",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-bot-detection/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-bot-detection/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-bot-detection"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-bot-detection",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-bot-detection"
 }

--- a/common/changes/@snowplow/browser-plugin-button-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-button-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-button-click-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-button-click-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-button-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-button-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-button-click-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-button-click-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-button-click-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-client-hints/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-client-hints"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-client-hints",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-client-hints"
 }

--- a/common/changes/@snowplow/browser-plugin-client-hints/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-client-hints/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-client-hints"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-client-hints",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-debugger/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-debugger/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-debugger"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-debugger",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-debugger/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-debugger/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-debugger"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-debugger",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-debugger"
 }

--- a/common/changes/@snowplow/browser-plugin-element-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-element-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-element-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-element-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-element-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-element-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-element-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-element-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-element-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-enhanced-consent/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-consent/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-enhanced-consent"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-enhanced-consent",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-enhanced-consent"
 }

--- a/common/changes/@snowplow/browser-plugin-enhanced-consent/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-consent/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-enhanced-consent"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-enhanced-consent",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
 }

--- a/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-enhanced-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-enhanced-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-enhanced-ecommerce",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-error-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-error-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-error-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-error-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-error-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-error-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-error-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-error-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-event-specifications/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-event-specifications/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-event-specifications"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-event-specifications",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-event-specifications/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-event-specifications/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-event-specifications"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-event-specifications",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-event-specifications"
 }

--- a/common/changes/@snowplow/browser-plugin-focalmeter/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-focalmeter/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-focalmeter"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-focalmeter",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-focalmeter/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-focalmeter/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-focalmeter"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-focalmeter",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-focalmeter"
 }

--- a/common/changes/@snowplow/browser-plugin-form-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-form-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-form-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-form-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-form-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-form-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-form-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-form-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-ga-cookies/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-ga-cookies/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-ga-cookies"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-ga-cookies",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-ga-cookies"
 }

--- a/common/changes/@snowplow/browser-plugin-ga-cookies/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-ga-cookies/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-ga-cookies"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-ga-cookies",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-geolocation/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-geolocation/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-geolocation"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-geolocation",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-geolocation"
 }

--- a/common/changes/@snowplow/browser-plugin-geolocation/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-geolocation/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-geolocation"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-geolocation",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-link-click-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-link-click-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-link-click-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-link-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-link-click-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-link-click-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-link-click-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-media-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-media-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-media-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-media-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-media-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-media-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-media-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-media/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-media/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-media"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-media",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-media"
 }

--- a/common/changes/@snowplow/browser-plugin-media/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-media/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-media"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-media",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely-x/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-optimizely-x"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-optimizely-x",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-optimizely-x/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-optimizely-x/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-optimizely-x"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-optimizely-x",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-optimizely-x"
 }

--- a/common/changes/@snowplow/browser-plugin-performance-navigation-timing/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-performance-navigation-timing/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-performance-navigation-timing"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-performance-navigation-timing",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-performance-navigation-timing/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-performance-navigation-timing/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-performance-navigation-timing"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-performance-navigation-timing",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-performance-navigation-timing"
 }

--- a/common/changes/@snowplow/browser-plugin-performance-timing/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-performance-timing/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-performance-timing"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-performance-timing",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-performance-timing"
 }

--- a/common/changes/@snowplow/browser-plugin-performance-timing/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-performance-timing/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-performance-timing"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-performance-timing",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-privacy-sandbox/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-privacy-sandbox/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-privacy-sandbox"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-privacy-sandbox",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-privacy-sandbox"
 }

--- a/common/changes/@snowplow/browser-plugin-privacy-sandbox/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-privacy-sandbox/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-privacy-sandbox"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-privacy-sandbox",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-screen-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-screen-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-screen-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-screen-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-screen-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-screen-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-screen-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-screen-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-screen-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-site-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-site-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-site-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-site-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-site-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-site-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-site-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-site-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-site-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
 }

--- a/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-snowplow-ecommerce/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-snowplow-ecommerce"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-snowplow-ecommerce",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-timezone/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-timezone/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-timezone"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-timezone",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-timezone"
 }

--- a/common/changes/@snowplow/browser-plugin-timezone/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-timezone/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-timezone"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-timezone",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-vimeo-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-vimeo-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-vimeo-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-vimeo-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-vimeo-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-vimeo-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-vimeo-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-vimeo-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-vimeo-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-web-vitals/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-web-vitals/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-web-vitals"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-web-vitals",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-web-vitals"
 }

--- a/common/changes/@snowplow/browser-plugin-web-vitals/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-web-vitals/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-web-vitals"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-web-vitals",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-webview/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-webview/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-webview"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-webview",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-plugin-webview/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-webview/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-webview"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-webview",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-webview"
 }

--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-plugin-youtube-tracking"
     }
   ],
-  "packageName": "@snowplow/browser-plugin-youtube-tracking",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-plugin-youtube-tracking"
 }

--- a/common/changes/@snowplow/browser-plugin-youtube-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-plugin-youtube-tracking/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-plugin-youtube-tracking"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-youtube-tracking",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/browser-tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-tracker-core"
     }
   ],
-  "packageName": "@snowplow/browser-tracker-core",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-tracker-core"
 }

--- a/common/changes/@snowplow/browser-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/browser-tracker"
     }
   ],
-  "packageName": "@snowplow/browser-tracker",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/browser-tracker"
 }

--- a/common/changes/@snowplow/browser-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/browser-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/javascript-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/javascript-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/javascript-tracker"
     }
   ],
-  "packageName": "@snowplow/javascript-tracker",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/javascript-tracker"
 }

--- a/common/changes/@snowplow/javascript-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/javascript-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/javascript-tracker"
+    }
+  ],
+  "packageName": "@snowplow/javascript-tracker",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/react-native-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/react-native-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/react-native-tracker"
     }
   ],
-  "packageName": "@snowplow/react-native-tracker",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/react-native-tracker"
 }

--- a/common/changes/@snowplow/react-native-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/react-native-tracker/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/react-native-tracker"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update uuid to v11 and remove closure-compiler from the build pipeline",
+      "type": "none",
+      "packageName": "@snowplow/tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/tracker-core",
+  "email": "matus.tomlein@gmail.com"
+}

--- a/common/changes/@snowplow/tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
+++ b/common/changes/@snowplow/tracker-core/fix-update-uuid-v11_2026-06-24-08-39.json
@@ -6,6 +6,5 @@
       "packageName": "@snowplow/tracker-core"
     }
   ],
-  "packageName": "@snowplow/tracker-core",
-  "email": "matus.tomlein@gmail.com"
+  "packageName": "@snowplow/tracker-core"
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.0
+        specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
       '@rollup/plugin-commonjs':
@@ -89,7 +89,7 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.0
+        specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
       '@rollup/plugin-commonjs':
@@ -1203,7 +1203,7 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.0
+        specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
       '@rollup/plugin-commonjs':
@@ -1276,7 +1276,7 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.0
+        specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
       '@rollup/plugin-commonjs':
@@ -1614,7 +1614,7 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.0
+        specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
       '@rollup/plugin-commonjs':
@@ -2131,7 +2131,7 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.0
+        specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
       '@rollup/plugin-commonjs':
@@ -2549,7 +2549,7 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.0
+        specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
       '@react-native-async-storage/async-storage':

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -19,12 +19,9 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -40,9 +37,6 @@ importers:
       '@types/jsdom':
         specifier: ~16.2.14
         version: 16.2.15
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -95,12 +89,9 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -113,9 +104,6 @@ importers:
       '@types/node':
         specifier: ~14.6.0
         version: 14.6.4
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -165,9 +153,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -244,9 +229,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -314,9 +296,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -387,9 +366,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -463,9 +439,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -536,9 +509,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -606,9 +576,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -682,9 +649,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -758,9 +722,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -834,9 +795,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -904,9 +862,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -974,9 +929,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1044,9 +996,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1114,9 +1063,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1184,9 +1130,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1260,12 +1203,9 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1278,9 +1218,6 @@ importers:
       '@types/jsdom':
         specifier: ~16.2.14
         version: 16.2.15
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -1339,12 +1276,9 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1357,9 +1291,6 @@ importers:
       '@types/jsdom':
         specifier: ~16.2.14
         version: 16.2.15
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -1415,9 +1346,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1485,9 +1413,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1555,9 +1480,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1625,9 +1547,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1695,12 +1614,9 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1716,9 +1632,6 @@ importers:
       '@types/lodash':
         specifier: ~4.14.180
         version: 4.14.202
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -1777,9 +1690,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1853,9 +1763,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -1932,9 +1839,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -2014,9 +1918,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -2090,9 +1991,6 @@ importers:
         specifier: ~4.2.4
         version: 4.2.4
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -2163,9 +2061,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -2236,12 +2131,9 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -2254,9 +2146,6 @@ importers:
       '@types/jsdom':
         specifier: ~16.2.14
         version: 16.2.15
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@types/youtube':
         specifier: ~0.0.46
         version: 0.0.50
@@ -2315,9 +2204,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-commonjs':
         specifier: ~21.0.2
         version: 21.0.3(rollup@2.70.2)
@@ -2469,9 +2355,6 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
     devDependencies:
-      '@ampproject/rollup-plugin-closure-compiler':
-        specifier: ~0.27.0
-        version: 0.27.0(rollup@2.70.2)
       '@rollup/plugin-alias':
         specifier: ~3.1.9
         version: 3.1.9(rollup@2.70.2)
@@ -2666,8 +2549,8 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
       '@react-native-async-storage/async-storage':
         specifier: ^2.0.0
@@ -2684,9 +2567,6 @@ importers:
       '@types/react':
         specifier: ^18.2.44
         version: 18.3.18
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.15.0
         version: 5.15.0(@typescript-eslint/parser@5.15.0(eslint@8.11.0)(typescript@4.6.4))(eslint@8.11.0)(typescript@4.6.4)
@@ -2723,19 +2603,9 @@ importers:
 
 packages:
 
-  '@ampproject/remapping@0.2.0':
-    resolution: {integrity: sha512-a4EztS9/GOVQjX5Ol+Iz33TFhaXvYBF7aB6D8+Qz0/SCIxOm3UNRhGZiwcCuJ8/Ifc6NCogp3S48kc5hFxRpUw==}
-    engines: {node: '>=6.0.0'}
-
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-
-  '@ampproject/rollup-plugin-closure-compiler@0.27.0':
-    resolution: {integrity: sha512-stpAOn2ZZEJuAV39HFw9cnKJYNhEeHtcsoa83orpLDhSxsxSbVEKwHaWlFBaQYpQRSOdapC4eJhJnCzocZxnqg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      rollup: '>=1.27'
 
   '@ark/schema@0.56.0':
     resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
@@ -3934,10 +3804,6 @@ packages:
   '@jridgewell/remapping@2.3.5':
     resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
-  '@jridgewell/resolve-uri@1.0.0':
-    resolution: {integrity: sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -4383,9 +4249,6 @@ packages:
   '@types/ua-parser-js@0.7.39':
     resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
 
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-
   '@types/vimeo__player@2.16.3':
     resolution: {integrity: sha512-hsOe6CZFTNyfjRjQUrNHBF4LDmjvjcU2yQIPWp5AglKeGxt11JYGToQhKUPM876gBXggqR6rMQ0/sNI06ec2Rg==}
 
@@ -4579,10 +4442,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@7.1.1:
-    resolution: {integrity: sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==}
-    engines: {node: '>=0.4.0'}
-
   acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
@@ -4590,11 +4449,6 @@ packages:
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
-
-  acorn@7.3.1:
-    resolution: {integrity: sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
@@ -5207,10 +5061,6 @@ packages:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
-  clone-buffer@1.0.0:
-    resolution: {integrity: sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==}
-    engines: {node: '>= 0.10'}
-
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
@@ -5218,19 +5068,9 @@ packages:
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
-  clone-stats@1.0.0:
-    resolution: {integrity: sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==}
-
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-
-  clone@2.1.2:
-    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
-    engines: {node: '>=0.8'}
-
-  cloneable-readable@1.1.3:
-    resolution: {integrity: sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -5869,9 +5709,6 @@ packages:
   estree-walker@1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
 
-  estree-walker@2.0.1:
-    resolution: {integrity: sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==}
-
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -6260,29 +6097,6 @@ packages:
   globule@1.3.4:
     resolution: {integrity: sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==}
     engines: {node: '>= 0.10'}
-
-  google-closure-compiler-java@20210808.0.0:
-    resolution: {integrity: sha512-7dEQfBzOdwdjwa/Pq8VAypNBKyWRrOcKjnNYOO9gEg2hjh8XVMeQzTqw4uANfVvvANGdE/JjD+HF6zHVgLRwjg==}
-
-  google-closure-compiler-linux@20210808.0.0:
-    resolution: {integrity: sha512-byKi5ITUiWRvEIcQo76i1siVnOwrTmG+GNcBG4cJ7x8IE6+4ki9rG5pUe4+DOYHkfk52XU6XHt9aAAgCcFDKpg==}
-    cpu: [x64, x86]
-    os: [linux]
-
-  google-closure-compiler-osx@20210808.0.0:
-    resolution: {integrity: sha512-iwyAY6dGj1FrrBdmfwKXkjtTGJnqe8F+9WZbfXxiBjkWLtIsJt2dD1+q7g/sw3w8mdHrGQAdxtDZP/usMwj/Rg==}
-    cpu: [x64, x86, arm64]
-    os: [darwin]
-
-  google-closure-compiler-windows@20210808.0.0:
-    resolution: {integrity: sha512-VI+UUYwtGWDYwpiixrWRD8EklHgl6PMbiEaHxQSrQbH8PDXytwaOKqmsaH2lWYd5Y/BOZie2MzjY7F5JI69q1w==}
-    cpu: [x64]
-    os: [win32]
-
-  google-closure-compiler@20210808.0.0:
-    resolution: {integrity: sha512-+R2+P1tT1lEnDDGk8b+WXfyVZgWjcCK9n1mmZe8pMEzPaPWxqK7GMetLVWnqfTDJ5Q+LRspOiFBv3Is+0yuhCA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -8377,13 +8191,6 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
-  remove-trailing-separator@1.1.0:
-    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
-
-  replace-ext@1.0.1:
-    resolution: {integrity: sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==}
-    engines: {node: '>= 0.10'}
-
   request@2.88.2:
     resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
     engines: {node: '>= 6'}
@@ -9305,17 +9112,13 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-
-  uuid@8.1.0:
-    resolution: {integrity: sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -9341,13 +9144,6 @@ packages:
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
-
-  vinyl-sourcemaps-apply@0.2.1:
-    resolution: {integrity: sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==}
-
-  vinyl@2.2.1:
-    resolution: {integrity: sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==}
-    engines: {node: '>= 0.10'}
 
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
@@ -9659,26 +9455,10 @@ packages:
 
 snapshots:
 
-  '@ampproject/remapping@0.2.0':
-    dependencies:
-      '@jridgewell/resolve-uri': 1.0.0
-      sourcemap-codec: 1.4.8
-
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
-
-  '@ampproject/rollup-plugin-closure-compiler@0.27.0(rollup@2.70.2)':
-    dependencies:
-      '@ampproject/remapping': 0.2.0
-      acorn: 7.3.1
-      acorn-walk: 7.1.1
-      estree-walker: 2.0.1
-      google-closure-compiler: 20210808.0.0
-      magic-string: 0.25.7
-      rollup: 2.70.2
-      uuid: 8.1.0
 
   '@ark/schema@0.56.0':
     dependencies:
@@ -11445,8 +11225,6 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@jridgewell/resolve-uri@1.0.0': {}
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/set-array@1.2.1': {}
@@ -12120,8 +11898,6 @@ snapshots:
 
   '@types/ua-parser-js@0.7.39': {}
 
-  '@types/uuid@10.0.0': {}
-
   '@types/vimeo__player@2.16.3': {}
 
   '@types/which@2.0.2': {}
@@ -12485,15 +12261,11 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
-  acorn-walk@7.1.1: {}
-
   acorn-walk@7.2.0: {}
 
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.14.0
-
-  acorn@7.3.1: {}
 
   acorn@7.4.1: {}
 
@@ -13334,8 +13106,6 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.2
 
-  clone-buffer@1.0.0: {}
-
   clone-deep@4.0.1:
     dependencies:
       is-plain-object: 2.0.4
@@ -13346,17 +13116,7 @@ snapshots:
     dependencies:
       mimic-response: 1.0.1
 
-  clone-stats@1.0.0: {}
-
   clone@1.0.4: {}
-
-  clone@2.1.2: {}
-
-  cloneable-readable@1.1.3:
-    dependencies:
-      inherits: 2.0.4
-      process-nextick-args: 2.0.1
-      readable-stream: 2.3.8
 
   co@4.6.0: {}
 
@@ -14064,8 +13824,6 @@ snapshots:
 
   estree-walker@1.0.1: {}
 
-  estree-walker@2.0.1: {}
-
   estree-walker@2.0.2: {}
 
   esutils@2.0.3: {}
@@ -14579,29 +14337,6 @@ snapshots:
       glob: 7.1.7
       lodash: 4.17.21
       minimatch: 3.0.8
-
-  google-closure-compiler-java@20210808.0.0: {}
-
-  google-closure-compiler-linux@20210808.0.0:
-    optional: true
-
-  google-closure-compiler-osx@20210808.0.0:
-    optional: true
-
-  google-closure-compiler-windows@20210808.0.0:
-    optional: true
-
-  google-closure-compiler@20210808.0.0:
-    dependencies:
-      chalk: 2.4.2
-      google-closure-compiler-java: 20210808.0.0
-      minimist: 1.2.8
-      vinyl: 2.2.1
-      vinyl-sourcemaps-apply: 0.2.1
-    optionalDependencies:
-      google-closure-compiler-linux: 20210808.0.0
-      google-closure-compiler-osx: 20210808.0.0
-      google-closure-compiler-windows: 20210808.0.0
 
   gopd@1.2.0: {}
 
@@ -17262,10 +16997,6 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
-  remove-trailing-separator@1.1.0: {}
-
-  replace-ext@1.0.1: {}
-
   request@2.88.2:
     dependencies:
       aws-sign2: 0.7.0
@@ -18291,11 +18022,9 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@10.0.0: {}
+  uuid@11.1.1: {}
 
   uuid@3.4.0: {}
-
-  uuid@8.1.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -18323,19 +18052,6 @@ snapshots:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
-
-  vinyl-sourcemaps-apply@0.2.1:
-    dependencies:
-      source-map: 0.5.7
-
-  vinyl@2.2.1:
-    dependencies:
-      clone: 2.1.2
-      clone-buffer: 1.0.0
-      clone-stats: 1.0.0
-      cloneable-readable: 1.1.3
-      remove-trailing-separator: 1.1.0
-      replace-ext: 1.0.1
 
   vlq@1.0.1: {}
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9a816d9b355d66a3970b215b67a6ea8ca1dba3c5",
+  "pnpmShrinkwrapHash": "2e2d7b02bf81d75c5130fbd96fc340d4c41b7c6a",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "2e2d7b02bf81d75c5130fbd96fc340d4c41b7c6a",
+  "pnpmShrinkwrapHash": "f30cccdb28d2e4a61e45699e278b31d4aaac0145",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/browser-tracker-core/package.json
+++ b/libraries/browser-tracker-core/package.json
@@ -24,15 +24,13 @@
   "dependencies": {
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",
     "@types/jsdom": "~16.2.14",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "eslint": "~8.11.0",

--- a/libraries/browser-tracker-core/package.json
+++ b/libraries/browser-tracker-core/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~21.0.2",

--- a/libraries/browser-tracker-core/rollup.config.js
+++ b/libraries/browser-tracker-core/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -50,7 +49,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },
   {

--- a/libraries/browser-tracker-core/test/id_cookie.test.ts
+++ b/libraries/browser-tracker-core/test/id_cookie.test.ts
@@ -31,7 +31,7 @@
 import * as uuid from 'uuid';
 jest.mock('uuid');
 const MOCK_UUID = '123456789';
-jest.spyOn(uuid, 'v4').mockReturnValue(MOCK_UUID);
+(jest.spyOn(uuid, 'v4') as jest.SpyInstance).mockReturnValue(MOCK_UUID);
 
 import { payloadBuilder } from '@snowplow/tracker-core';
 import {
@@ -173,7 +173,7 @@ describe('startNewIdCookieSession', () => {
 
     let before = sessionIdFromIdCookie(idCookie);
 
-    jest.spyOn(uuid, 'v4').mockReturnValueOnce('another_random_uuid');
+    (jest.spyOn(uuid, 'v4') as jest.SpyInstance).mockReturnValueOnce('another_random_uuid');
     startNewIdCookieSession(idCookie);
     let after = sessionIdFromIdCookie(idCookie);
 

--- a/libraries/browser-tracker-core/test/tracker/cross_domain.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/cross_domain.test.ts
@@ -1,7 +1,7 @@
 import * as uuid from 'uuid';
 jest.mock('uuid');
 const MOCK_UUID = '123456789';
-jest.spyOn(uuid, 'v4').mockReturnValue(MOCK_UUID);
+(jest.spyOn(uuid, 'v4') as jest.SpyInstance).mockReturnValue(MOCK_UUID);
 
 import { createTracker } from '../helpers';
 import { getByText, queryByText, waitFor } from '@testing-library/dom';

--- a/libraries/browser-tracker-core/test/tracker/session_data.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/session_data.test.ts
@@ -31,7 +31,7 @@
 import * as uuid from 'uuid';
 jest.mock('uuid');
 const MOCK_UUID = '123456789';
-jest.spyOn(uuid, 'v4').mockReturnValue(MOCK_UUID);
+(jest.spyOn(uuid, 'v4') as jest.SpyInstance).mockReturnValue(MOCK_UUID);
 
 import { createTestIdCookie, createTestSessionIdCookie, createTracker } from '../helpers';
 

--- a/libraries/tracker-core/package.json
+++ b/libraries/tracker-core/package.json
@@ -45,15 +45,13 @@
   },
   "dependencies": {
     "tslib": "^2.3.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-json": "~4.1.0",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/node": "~14.6.0",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "ava": "~5.1.1",

--- a/libraries/tracker-core/package.json
+++ b/libraries/tracker-core/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "tslib": "^2.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~21.0.2",

--- a/libraries/tracker-core/rollup.config.js
+++ b/libraries/tracker-core/rollup.config.js
@@ -33,7 +33,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     output: [{ file: pkg['umd:main'].replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },
   {

--- a/plugins/browser-plugin-ad-tracking/package.json
+++ b/plugins/browser-plugin-ad-tracking/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-ad-tracking/rollup.config.js
+++ b/plugins/browser-plugin-ad-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-bot-detection/package.json
+++ b/plugins/browser-plugin-bot-detection/package.json
@@ -28,7 +28,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-bot-detection/rollup.config.js
+++ b/plugins/browser-plugin-bot-detection/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Preferred over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-button-click-tracking/package.json
+++ b/plugins/browser-plugin-button-click-tracking/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-button-click-tracking/rollup.config.js
+++ b/plugins/browser-plugin-button-click-tracking/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-client-hints/package.json
+++ b/plugins/browser-plugin-client-hints/package.json
@@ -26,7 +26,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@snowplow/tracker-core": "workspace:*",

--- a/plugins/browser-plugin-client-hints/rollup.config.js
+++ b/plugins/browser-plugin-client-hints/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-debugger/package.json
+++ b/plugins/browser-plugin-debugger/package.json
@@ -28,7 +28,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-debugger/rollup.config.js
+++ b/plugins/browser-plugin-debugger/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-element-tracking/package.json
+++ b/plugins/browser-plugin-element-tracking/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-element-tracking/rollup.config.js
+++ b/plugins/browser-plugin-element-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Preferred over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-enhanced-consent/package.json
+++ b/plugins/browser-plugin-enhanced-consent/package.json
@@ -26,7 +26,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-enhanced-consent/rollup.config.js
+++ b/plugins/browser-plugin-enhanced-consent/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-enhanced-ecommerce/package.json
+++ b/plugins/browser-plugin-enhanced-ecommerce/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-enhanced-ecommerce/rollup.config.js
+++ b/plugins/browser-plugin-enhanced-ecommerce/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-error-tracking/package.json
+++ b/plugins/browser-plugin-error-tracking/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-error-tracking/rollup.config.js
+++ b/plugins/browser-plugin-error-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-event-specifications/package.json
+++ b/plugins/browser-plugin-event-specifications/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-event-specifications/rollup.config.js
+++ b/plugins/browser-plugin-event-specifications/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Preferred over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-focalmeter/package.json
+++ b/plugins/browser-plugin-focalmeter/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-focalmeter/rollup.config.js
+++ b/plugins/browser-plugin-focalmeter/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-form-tracking/package.json
+++ b/plugins/browser-plugin-form-tracking/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-form-tracking/rollup.config.js
+++ b/plugins/browser-plugin-form-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-ga-cookies/package.json
+++ b/plugins/browser-plugin-ga-cookies/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-ga-cookies/rollup.config.js
+++ b/plugins/browser-plugin-ga-cookies/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-geolocation/package.json
+++ b/plugins/browser-plugin-geolocation/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-geolocation/rollup.config.js
+++ b/plugins/browser-plugin-geolocation/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-link-click-tracking/package.json
+++ b/plugins/browser-plugin-link-click-tracking/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-link-click-tracking/rollup.config.js
+++ b/plugins/browser-plugin-link-click-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-media-tracking/package.json
+++ b/plugins/browser-plugin-media-tracking/package.json
@@ -25,15 +25,13 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",
     "@types/jsdom": "~16.2.14",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "eslint": "~8.11.0",

--- a/plugins/browser-plugin-media-tracking/package.json
+++ b/plugins/browser-plugin-media-tracking/package.json
@@ -25,7 +25,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~21.0.2",

--- a/plugins/browser-plugin-media-tracking/rollup.config.js
+++ b/plugins/browser-plugin-media-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts';
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner(true)],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner(true)],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-media/package.json
+++ b/plugins/browser-plugin-media/package.json
@@ -25,15 +25,13 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",
     "@types/jsdom": "~16.2.14",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "eslint": "~8.11.0",

--- a/plugins/browser-plugin-media/package.json
+++ b/plugins/browser-plugin-media/package.json
@@ -25,7 +25,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~21.0.2",

--- a/plugins/browser-plugin-media/rollup.config.js
+++ b/plugins/browser-plugin-media/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-optimizely-x/package.json
+++ b/plugins/browser-plugin-optimizely-x/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-optimizely-x/rollup.config.js
+++ b/plugins/browser-plugin-optimizely-x/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-performance-navigation-timing/package.json
+++ b/plugins/browser-plugin-performance-navigation-timing/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-performance-navigation-timing/rollup.config.js
+++ b/plugins/browser-plugin-performance-navigation-timing/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Preferred over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-performance-timing/package.json
+++ b/plugins/browser-plugin-performance-timing/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-performance-timing/rollup.config.js
+++ b/plugins/browser-plugin-performance-timing/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-privacy-sandbox/package.json
+++ b/plugins/browser-plugin-privacy-sandbox/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-privacy-sandbox/rollup.config.js
+++ b/plugins/browser-plugin-privacy-sandbox/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Preferred over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-screen-tracking/package.json
+++ b/plugins/browser-plugin-screen-tracking/package.json
@@ -25,16 +25,14 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",
     "@types/jsdom": "~16.2.14",
     "@types/lodash": "~4.14.180",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",
     "eslint": "~8.11.0",

--- a/plugins/browser-plugin-screen-tracking/package.json
+++ b/plugins/browser-plugin-screen-tracking/package.json
@@ -25,7 +25,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/tracker-core": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~21.0.2",

--- a/plugins/browser-plugin-screen-tracking/rollup.config.js
+++ b/plugins/browser-plugin-screen-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-site-tracking/package.json
+++ b/plugins/browser-plugin-site-tracking/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-site-tracking/rollup.config.js
+++ b/plugins/browser-plugin-site-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-snowplow-ecommerce/package.json
+++ b/plugins/browser-plugin-snowplow-ecommerce/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-snowplow-ecommerce/rollup.config.js
+++ b/plugins/browser-plugin-snowplow-ecommerce/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-timezone/package.json
+++ b/plugins/browser-plugin-timezone/package.json
@@ -28,7 +28,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-timezone/rollup.config.js
+++ b/plugins/browser-plugin-timezone/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-vimeo-tracking/package.json
+++ b/plugins/browser-plugin-vimeo-tracking/package.json
@@ -28,7 +28,6 @@
     "@vimeo/player": "2.16.4"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-vimeo-tracking/rollup.config.js
+++ b/plugins/browser-plugin-vimeo-tracking/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-web-vitals/package.json
+++ b/plugins/browser-plugin-web-vitals/package.json
@@ -28,7 +28,6 @@
     "web-vitals": "~4.2.4"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-web-vitals/rollup.config.js
+++ b/plugins/browser-plugin-web-vitals/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Preferred over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-webview/package.json
+++ b/plugins/browser-plugin-webview/package.json
@@ -28,7 +28,6 @@
     "@snowplow/webview-tracker": "^0.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/plugins/browser-plugin-webview/rollup.config.js
+++ b/plugins/browser-plugin-webview/rollup.config.js
@@ -2,7 +2,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts'; // Preferred over @rollup/plugin-typescript as it bundles .d.ts files
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -21,7 +20,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/plugins/browser-plugin-youtube-tracking/package.json
+++ b/plugins/browser-plugin-youtube-tracking/package.json
@@ -25,15 +25,13 @@
     "@snowplow/tracker-core": "workspace:*",
     "@snowplow/browser-plugin-media": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",
     "@types/jsdom": "~16.2.14",
-    "@types/uuid": "^10.0.0",
     "@types/youtube": "~0.0.46",
     "@typescript-eslint/eslint-plugin": "~5.15.0",
     "@typescript-eslint/parser": "~5.15.0",

--- a/plugins/browser-plugin-youtube-tracking/package.json
+++ b/plugins/browser-plugin-youtube-tracking/package.json
@@ -25,7 +25,7 @@
     "@snowplow/tracker-core": "workspace:*",
     "@snowplow/browser-plugin-media": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~21.0.2",

--- a/plugins/browser-plugin-youtube-tracking/rollup.config.js
+++ b/plugins/browser-plugin-youtube-tracking/rollup.config.js
@@ -32,7 +32,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import ts from 'rollup-plugin-ts';
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
@@ -51,7 +50,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), terser(), cleanup({ comments: 'none' }), banner(true)],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner(true)],
     treeshake: { moduleSideEffects: ['sha1'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', sourcemap: true, name: umdName }],
   },

--- a/trackers/browser-tracker/package.json
+++ b/trackers/browser-tracker/package.json
@@ -41,7 +41,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/jest": "~28.1.1",

--- a/trackers/browser-tracker/rollup.config.js
+++ b/trackers/browser-tracker/rollup.config.js
@@ -32,7 +32,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import ts from 'rollup-plugin-ts'; // Prefered over @rollup/plugin-typescript as it bundles .d.ts files
 import commonjs from '@rollup/plugin-commonjs';
 import { banner } from '../../banner';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
+import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import pkg from './package.json';
 
@@ -56,7 +56,7 @@ export default [
   },
   {
     input: './src/index.ts',
-    plugins: [...umdPlugins, compiler(), cleanup({ comments: 'none' }), banner()],
+    plugins: [...umdPlugins, terser(), cleanup({ comments: 'none' }), banner()],
     treeshake: { moduleSideEffects: ['jstimezonedetect'] },
     output: [{ file: pkg.main.replace('.js', '.min.js'), format: 'umd', name: umdName, sourcemap: true }],
   },

--- a/trackers/javascript-tracker/package.json
+++ b/trackers/javascript-tracker/package.json
@@ -69,7 +69,6 @@
     "@snowplow/browser-plugin-event-specifications": "workspace:*"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "~0.27.0",
     "@rollup/plugin-alias": "~3.1.9",
     "@rollup/plugin-commonjs": "~21.0.2",
     "@rollup/plugin-json": "~4.1.0",

--- a/trackers/javascript-tracker/rollup.config.js
+++ b/trackers/javascript-tracker/rollup.config.js
@@ -34,7 +34,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import { banner } from '../../banner';
 import { whitelabelBuild } from './build-config/index';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import sizes from 'rollup-plugin-sizes';
@@ -48,7 +47,6 @@ export default (cmdlineArgs) => {
     nodeResolve({ browser: true }),
     commonjs(),
     ts(),
-    compiler(),
     terser(),
     cleanup({ comments: 'none' }),
     banner(),

--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -54,7 +54,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/browser-plugin-screen-tracking": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@react-native-async-storage/async-storage": "^2.0.0",
@@ -65,7 +65,6 @@
     "typescript": "~4.6.2",
     "@types/jest": "~28.1.1",
     "@types/node": "~14.6.0",
-    "@types/uuid": "^10.0.0",
     "jest": "~28.1.3",
     "react": "18.2.0",
     "ts-jest": "~28.0.8",

--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -54,7 +54,7 @@
     "@snowplow/browser-tracker-core": "workspace:*",
     "@snowplow/browser-plugin-screen-tracking": "workspace:*",
     "tslib": "^2.3.1",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@react-native-async-storage/async-storage": "^2.0.0",


### PR DESCRIPTION
## Summary

Alternative to #1480 that keeps **Node 18 / CommonJS consumer support** by pinning `uuid` to **v11** instead of v14.

`uuid` v12+ is **ESM-only** (CommonJS support was dropped in v12). Since `@snowplow/tracker-core` / `@snowplow/node-tracker` ship CommonJS builds that `require('uuid')`, jumping to v14 would break downstream CJS consumers on Node < 20.19. **uuid v11 still ships both CJS and ESM builds**, so it's the last line that preserves that support — and it is not yet deprecated (the deprecation notice itself recommends v11 for CommonJS codebases).

The code uses only the `v4` named import, which is unchanged across these versions.

Fixes #1471.

## Changes

- **`uuid` `^10.0.0` → `^11.0.0`** in the 7 packages that use it (`tracker-core`, `browser-tracker-core`, `react-native-tracker`, and the `media`, `media-tracking`, `youtube-tracking`, `screen-tracking` plugins).
- **Removed the redundant `@types/uuid`** devDependency (uuid v11 bundles its own types).
- **Dropped `@ampproject/rollup-plugin-closure-compiler`** from all 33 rollup configs and their `package.json` devDependencies. This is **required**, not optional: uuid v11 emits modern syntax (`??` / `?.`) that closure-compiler's bundled `acorn-walk@7.1.1` cannot parse — the build fails at the closure step otherwise. 31 configs already chained `compiler(), terser()` → now just `terser()`; `browser-tracker` (closure was its only minifier) was swapped to `terser()` (already an available devDependency).
- **Updated the `uuid.v4` jest spies** in 3 `browser-tracker-core` test files to satisfy v11's overloaded type signature (`v4` now also has a `Uint8Array`-returning overload).
- Regenerated the lockfile and added Rush change files.

## Validation

- ✅ `rush build` succeeds for every package (only the pre-existing browserslist warning remains).
- ✅ Tests pass for all affected packages: `tracker-core` (130), `browser-tracker-core` (162), `react-native-tracker` (68), `media` (67), `media-tracking` (38), `screen-tracking` (9), `youtube-tracking` (15).
- ✅ `rush change --verify` passes.

## Size trade-off

Dropping closure-compiler costs ~2–3% gzipped per bundle (≤0.8 KB on `sp.js`); terser retains ~97–98% of the minification benefit. Same trade-off as #1480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)