### PR TITLE
fix(react-native-tracker): allow react-native-get-random-values v2.0.0

### DIFF
--- a/common/changes/@snowplow/react-native-tracker/claude-loving-feynman-b5ef83_2026-07-02-08-48.json
+++ b/common/changes/@snowplow/react-native-tracker/claude-loving-feynman-b5ef83_2026-07-02-08-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Widen react-native-get-random-values peer dependency range to allow v2.0.0 for React Native 0.81+ compatibility",
+      "type": "none",
+      "packageName": "@snowplow/react-native-tracker"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2592,7 +2592,7 @@ importers:
         specifier: ^0.42.1
         version: 0.42.1
       react-native-get-random-values:
-        specifier: ^1.11.0
+        specifier: ^1.11.0 || ^2.0.0
         version: 1.11.0(react-native@0.74.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.3.18)(encoding@0.1.13)(react@18.2.0))
       ts-jest:
         specifier: ~28.0.8

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f30cccdb28d2e4a61e45699e278b31d4aaac0145",
+  "pnpmShrinkwrapHash": "522137187baf312832dbbe14a3a2ef4fafb57ca6",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -47,7 +47,7 @@
     "@react-native-async-storage/async-storage": "^2.0.0",
     "react": "*",
     "react-native": "*",
-    "react-native-get-random-values": "^1.11.0"
+    "react-native-get-random-values": "^1.11.0 || ^2.0.0"
   },
   "dependencies": {
     "@snowplow/tracker-core": "workspace:*",
@@ -72,7 +72,7 @@
     "react-native": "0.74.5",
     "node-fetch": "~3.3.2",
     "react-native-builder-bob": "^0.42.1",
-    "react-native-get-random-values": "^1.11.0"
+    "react-native-get-random-values": "^1.11.0 || ^2.0.0"
   },
   "resolutions": {
     "@types/react": "^18.2.44"


### PR DESCRIPTION
## Summary

Widens the `react-native-get-random-values` peer dependency range in `@snowplow/react-native-tracker` from `^1.11.0` to `^1.11.0 || ^2.0.0`, so consumers on React Native 0.81+ can install `v2.0.0` (which requires RN >= 0.81), while existing users on older RN versions stay on `v1.x`.

Same pattern as the earlier `@react-native-async-storage/async-storage` bump.

## Why widen instead of bumping to `^2.0.0`

- **`v2.0.0` has no JS API changes.** Per its release notes, the only breaking change is the raised React Native version floor (New Architecture, RN >= 0.81).
- The tracker's only usage is the side-effect polyfill import (`import 'react-native-get-random-values'` in `src/index.ts`), which is unaffected by the major bump.
- Widening (rather than replacing) lets users on RN 0.81+ install `v2`, while **RN < 0.81 users keep working on `v1.x`**. A hard `^2.0.0` would force RN >= 0.81 on all consumers — an unnecessary regression.
- The `devDependencies` entry is widened the same way; pnpm correctly resolves it back to `1.11.0` for the existing dev toolchain (RN 0.74.5), so no dev-side conflict and no risky dev RN upgrade.

## Testing

- `rush update` regenerated the lockfile cleanly (specifier `^1.11.0 || ^2.0.0`, resolved to `1.11.0` for dev), no new peer warnings.
- `rush build --to @snowplow/react-native-tracker` succeeds.
- All 68 tests across 13 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)