### PR TITLE
Release 4.8.4

### DIFF
--- a/common/changes/@snowplow/react-native-tracker/claude-loving-feynman-b5ef83_2026-07-02-08-48.json
+++ b/common/changes/@snowplow/react-native-tracker/claude-loving-feynman-b5ef83_2026-07-02-08-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Widen react-native-get-random-values peer dependency range to allow v2.0.0 for React Native 0.81+ compatibility",
+      "type": "none",
+      "packageName": "@snowplow/react-native-tracker"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2592,7 +2592,7 @@ importers:
         specifier: ^0.42.1
         version: 0.42.1
       react-native-get-random-values:
-        specifier: ^1.11.0
+        specifier: ^1.11.0 || ^2.0.0
         version: 1.11.0(react-native@0.74.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.3.18)(encoding@0.1.13)(react@18.2.0))
       ts-jest:
         specifier: ~28.0.8

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f30cccdb28d2e4a61e45699e278b31d4aaac0145",
+  "pnpmShrinkwrapHash": "522137187baf312832dbbe14a3a2ef4fafb57ca6",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/trackers/react-native-tracker/package.json
+++ b/trackers/react-native-tracker/package.json
@@ -47,7 +47,7 @@
     "@react-native-async-storage/async-storage": "^2.0.0",
     "react": "*",
     "react-native": "*",
-    "react-native-get-random-values": "^1.11.0"
+    "react-native-get-random-values": "^1.11.0 || ^2.0.0"
   },
   "dependencies": {
     "@snowplow/tracker-core": "workspace:*",
@@ -72,7 +72,7 @@
     "react-native": "0.74.5",
     "node-fetch": "~3.3.2",
     "react-native-builder-bob": "^0.42.1",
-    "react-native-get-random-values": "^1.11.0"
+    "react-native-get-random-values": "^1.11.0 || ^2.0.0"
   },
   "resolutions": {
     "@types/react": "^18.2.44"


### PR DESCRIPTION
**Changes**

- fix(react-native-tracker): allow react-native-get-random-values v2.0.0
