### PR TITLE
[AISP-1524] Add getDomainSessionId method

### DIFF
--- a/api-docs/docs/browser-tracker/browser-tracker.api.md
+++ b/api-docs/docs/browser-tracker/browser-tracker.api.md
@@ -79,6 +79,7 @@ export interface BrowserTracker {
     enableAnonymousTracking: (configuration?: EnableAnonymousTrackingConfiguration) => void;
     flushBuffer: (configuration?: FlushBufferConfiguration) => void;
     getCookieName: (basename: string) => string;
+    getDomainSessionId: () => string;
     getDomainSessionIndex: () => number;
     getDomainUserId: () => string;
     getDomainUserInfo: () => ParsedIdCookie;
@@ -340,6 +341,9 @@ export interface FlushBufferConfiguration {
     // (undocumented)
     newBufferSize?: number;
 }
+
+// @public
+export function getDomainSessionId(trackerId?: string): string | undefined;
 
 // @public
 export type JsonProcessor = (payloadBuilder: PayloadBuilder, jsonForProcessing: EventJson, contextEntitiesForProcessing: SelfDescribingJson[]) => void;

--- a/common/changes/@snowplow/browser-tracker-core/feature-aisp-1524-add-domain-session-id-getter_2026-07-16-09-28.json
+++ b/common/changes/@snowplow/browser-tracker-core/feature-aisp-1524-add-domain-session-id-getter_2026-07-16-09-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core"
+}

--- a/common/changes/@snowplow/browser-tracker/feature-aisp-1524-add-domain-session-id-getter_2026-07-16-09-28.json
+++ b/common/changes/@snowplow/browser-tracker/feature-aisp-1524-add-domain-session-id-getter_2026-07-16-09-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-tracker",
+      "comment": "Add getDomainSessionId method",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker"
+}

--- a/common/changes/@snowplow/react-native-tracker/feature-aisp-1524-add-domain-session-id-getter_2026-07-16-09-58.json
+++ b/common/changes/@snowplow/react-native-tracker/feature-aisp-1524-add-domain-session-id-getter_2026-07-16-09-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/react-native-tracker",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/react-native-tracker"
+}

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -586,7 +586,8 @@ export function Tracker(
 
       if (isActivityMetricsEnabled()) {
         if (activityMetricsState.lastScrollX !== undefined && activityMetricsState.lastScrollY !== undefined) {
-          activityMetricsState.metrics.scrollDistance += Math.abs(x - activityMetricsState.lastScrollX) + Math.abs(y - activityMetricsState.lastScrollY);
+          activityMetricsState.metrics.scrollDistance +=
+            Math.abs(x - activityMetricsState.lastScrollX) + Math.abs(y - activityMetricsState.lastScrollY);
         }
         activityMetricsState.lastScrollX = x;
         activityMetricsState.lastScrollY = y;
@@ -1351,6 +1352,10 @@ export function Tracker(
 
       getDomainUserInfo: function () {
         return loadDomainUserIdCookie();
+      },
+
+      getDomainSessionId: function () {
+        return sessionIdFromIdCookie(loadDomainUserIdCookie());
       },
 
       setReferrerUrl: function (url: string) {

--- a/libraries/browser-tracker-core/src/tracker/index.ts
+++ b/libraries/browser-tracker-core/src/tracker/index.ts
@@ -1355,7 +1355,7 @@ export function Tracker(
       },
 
       getDomainSessionId: function () {
-        return sessionIdFromIdCookie(loadDomainUserIdCookie());
+        return memorizedSessionId || sessionIdFromIdCookie(loadDomainUserIdCookie());
       },
 
       setReferrerUrl: function (url: string) {

--- a/libraries/browser-tracker-core/src/tracker/types.ts
+++ b/libraries/browser-tracker-core/src/tracker/types.ts
@@ -406,6 +406,13 @@ export interface BrowserTracker {
   getDomainUserInfo: () => ParsedIdCookie;
 
   /**
+   * Get the current domain session ID (from first party cookie)
+   *
+   * @returns Domain session ID
+   */
+  getDomainSessionId: () => string;
+
+  /**
    * Override referrer
    *
    * @param url - the custom referrer

--- a/libraries/browser-tracker-core/test/tracker/session_data.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/session_data.test.ts
@@ -131,6 +131,20 @@ describe('Tracker API: ', () => {
     expect(tracker?.getDomainSessionIndex()).toEqual(2);
   });
 
+  it('Returns the current domain session id from an existing session', () => {
+    const sessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    document.cookie = createTestIdCookie({ sessionId }) + ' ' + createTestSessionIdCookie();
+    const tracker = createTracker();
+
+    expect(tracker?.getDomainSessionId()).toEqual(sessionId);
+  });
+
+  it('Returns a newly generated domain session id on a new session', () => {
+    const tracker = createTracker();
+
+    expect(tracker?.getDomainSessionId()).toEqual(MOCK_UUID);
+  });
+
   it('Adds the client session context entity when enabled', (done) => {
     const tracker = createTracker({
       contexts: { session: true },

--- a/libraries/browser-tracker-core/test/tracker/session_data.test.ts
+++ b/libraries/browser-tracker-core/test/tracker/session_data.test.ts
@@ -145,6 +145,16 @@ describe('Tracker API: ', () => {
     expect(tracker?.getDomainSessionId()).toEqual(MOCK_UUID);
   });
 
+  it('Returns the updated domain session id after newSession()', () => {
+    const sessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    document.cookie = createTestIdCookie({ sessionId }) + ' ' + createTestSessionIdCookie();
+    const tracker = createTracker();
+    expect(tracker?.getDomainSessionId()).toEqual(sessionId);
+
+    tracker?.newSession();
+    expect(tracker?.getDomainSessionId()).toEqual(MOCK_UUID);
+  });
+
   it('Adds the client session context entity when enabled', (done) => {
     const tracker = createTracker({
       contexts: { session: true },

--- a/trackers/browser-tracker/src/api.ts
+++ b/trackers/browser-tracker/src/api.ts
@@ -118,7 +118,9 @@ export function newSession(trackers?: Array<string>) {
  * @returns The domain session ID, or undefined if no matching tracker is found
  */
 export function getDomainSessionId(trackerId?: string): string | undefined {
-  const tracker = getTracker(trackerId ?? allTrackerNames()[0]);
+  const resolvedTrackerId = trackerId ?? allTrackerNames()[0];
+  if (!resolvedTrackerId) return undefined;
+  const tracker = getTracker(resolvedTrackerId);
   return tracker ? tracker.getDomainSessionId() : undefined;
 }
 

--- a/trackers/browser-tracker/src/api.ts
+++ b/trackers/browser-tracker/src/api.ts
@@ -30,6 +30,8 @@
 
 import {
   dispatchToTrackers,
+  getTracker,
+  allTrackerNames,
   ActivityTrackingConfiguration,
   ActivityTrackingConfigurationCallback,
   ActivityCallback,
@@ -106,6 +108,18 @@ export function newSession(trackers?: Array<string>) {
   dispatchToTrackers(trackers, (t) => {
     t.newSession();
   });
+}
+
+/**
+ * Get the domain session ID (from the first-party cookie) for a tracker.
+ *
+ * @param trackerId - The tracker identifier which the domain session ID will be retrieved from.
+ *                     Defaults to the first initialised tracker.
+ * @returns The domain session ID, or undefined if no matching tracker is found
+ */
+export function getDomainSessionId(trackerId?: string): string | undefined {
+  const tracker = getTracker(trackerId ?? allTrackerNames()[0]);
+  return tracker ? tracker.getDomainSessionId() : undefined;
 }
 
 /**

--- a/trackers/browser-tracker/test/api.test.ts
+++ b/trackers/browser-tracker/test/api.test.ts
@@ -41,8 +41,12 @@ describe('Browser Tracker API: #getDomainSessionId', () => {
     jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar);
   });
 
+  afterEach(() => {
+    cookieJar = '';
+  });
+
   afterAll(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('exposes the domain session id of a named tracker', () => {

--- a/trackers/browser-tracker/test/api.test.ts
+++ b/trackers/browser-tracker/test/api.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { newTracker, getDomainSessionId } from '../src';
+
+describe('Browser Tracker API: #getDomainSessionId', () => {
+  let cookieJar: string;
+
+  beforeAll(() => {
+    cookieJar = '';
+    jest.spyOn(document, 'cookie', 'set').mockImplementation((cookie) => {
+      cookieJar += cookie;
+    });
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar);
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it('exposes the domain session id of a named tracker', () => {
+    const tracker = newTracker('sp-api-1', '', { stateStorageStrategy: 'cookie' });
+    const sessionId = tracker?.getDomainSessionId();
+
+    expect(sessionId).toMatch(/^[0-9a-f-]+$/);
+    expect(getDomainSessionId('sp-api-1')).toEqual(sessionId);
+  });
+
+  it('defaults to the first initialised tracker when no id is provided', () => {
+    // 'sp-api-1' is the only/first tracker registered in this module
+    expect(getDomainSessionId()).toEqual(getDomainSessionId('sp-api-1'));
+  });
+
+  it('returns undefined for an unknown tracker id', () => {
+    expect(getDomainSessionId('missing-tracker')).toBeUndefined();
+  });
+});

--- a/trackers/react-native-tracker/src/plugins.ts
+++ b/trackers/react-native-tracker/src/plugins.ts
@@ -26,6 +26,7 @@ function toBrowserTracker(namespace: string, core: TrackerCore): BrowserTracker 
     getUserId: () => undefined,
     getDomainUserId: () => '',
     getDomainUserInfo: (): ParsedIdCookie => ['', '', 0, 0, 0, undefined, '', '', '', undefined, 0],
+    getDomainSessionId: () => '',
     setReferrerUrl: () => notImplemented,
     setCustomUrl: () => notImplemented,
     setDocumentTitle: () => notImplemented,


### PR DESCRIPTION
Expose `getDomainSessionId` method on the browser and javascript tracker.