### PR TITLE
Add fallback for element_index

### DIFF
--- a/common/changes/@snowplow/browser-plugin-element-tracking/fix-add-minimum-position-element-tracking_2026-07-16-16-03.json
+++ b/common/changes/@snowplow/browser-plugin-element-tracking/fix-add-minimum-position-element-tracking_2026-07-16-16-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@snowplow/browser-plugin-element-tracking",
+      "comment": "Fix element tracking plugin sending element_index of 0 on expose_element and obscure_element events",
+      "type": "none"
+    }
+  ],
+  "packageName": "@snowplow/browser-plugin-element-tracking"
+}

--- a/plugins/browser-plugin-element-tracking/src/api.ts
+++ b/plugins/browser-plugin-element-tracking/src/api.ts
@@ -527,7 +527,13 @@ function intersectionCallback(entries: IntersectionObserverEntry[], observer: In
     configurations.forEach((config) => {
       if (entry.target.matches(config.selector)) {
         const siblings = getMatchingElements(config);
-        const position = siblings.findIndex((el) => el.isSameNode(entry.target)) + 1;
+        const foundIndex = siblings.findIndex((el) => el.isSameNode(entry.target));
+        const position = foundIndex !== -1 ? foundIndex + 1 : Math.max(state.lastPosition + 1, 1);
+        const matchCount = foundIndex !== -1 ? siblings.length : Math.max(siblings.length + 1, position);
+
+        if (foundIndex !== -1) {
+          state.lastPosition = foundIndex;
+        }
 
         if (entry.isIntersecting) {
           if (state.state !== ElementStatus.EXPOSED && state.state !== ElementStatus.PENDING) {
@@ -547,7 +553,7 @@ function intersectionCallback(entries: IntersectionObserverEntry[], observer: In
                 trackEvent(Events.ELEMENT_EXPOSE, config, entry.target, {
                   boundingRect: entry.boundingClientRect,
                   position,
-                  matches: siblings.length,
+                  matches: matchCount,
                 });
               }
             }
@@ -573,7 +579,7 @@ function intersectionCallback(entries: IntersectionObserverEntry[], observer: In
             trackEvent(Events.ELEMENT_OBSCURE, config, entry.target, {
               boundingRect: entry.boundingClientRect,
               position,
-              matches: siblings.length,
+              matches: matchCount,
             });
           }
 

--- a/plugins/browser-plugin-element-tracking/test/api.test.ts
+++ b/plugins/browser-plugin-element-tracking/test/api.test.ts
@@ -548,4 +548,73 @@ describe('Element Tracking Plugin API', () => {
       });
     });
   });
+
+  describe('intersectionCallback position fallback', () => {
+    let intersectionCallback: IntersectionObserverCallback;
+
+    beforeAll(() => {
+      // Mock IntersectionObserver to capture the callback
+      (globalThis as any).IntersectionObserver = class {
+        constructor(cb: IntersectionObserverCallback) {
+          intersectionCallback = cb;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    });
+
+    afterAll(() => {
+      delete (globalThis as any).IntersectionObserver;
+    });
+
+    it('uses last-known position when element is no longer in DOM during intersection callback', () => {
+      // Create two matching elements so position > 1 is testable
+      const div1 = document.createElement('div');
+      div1.classList.add('disappearing');
+      document.body.appendChild(div1);
+
+      const div2 = document.createElement('div');
+      div2.classList.add('disappearing');
+      document.body.appendChild(div2);
+
+      startElementTracking({
+        elements: {
+          selector: '.disappearing',
+          expose: true,
+        },
+      });
+
+      // Remove div2 from DOM before firing intersection
+      document.body.removeChild(div2);
+
+      // Simulate intersection callback for the now-removed div2
+      const fakeEntry = {
+        target: div2,
+        isIntersecting: true,
+        intersectionRatio: 1,
+        intersectionRect: { height: 100, width: 100 } as DOMRect,
+        boundingClientRect: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+        rootBounds: null,
+        time: performance.now(),
+      } as IntersectionObserverEntry;
+
+      intersectionCallback([fakeEntry], {} as IntersectionObserver);
+
+      return inNewTask(() => {
+        expect(eventQueue.length).toBeGreaterThanOrEqual(1);
+
+        const exposeEvent = eventQueue.find((e) => unstructOf(e, 'expose_element'));
+        expect(exposeEvent).toBeDefined();
+
+        const elementEntities = entityOf(exposeEvent!, 'element') as Record<string, unknown>[];
+        expect(elementEntities).toBeDefined();
+        expect(elementEntities.length).toBeGreaterThanOrEqual(1);
+
+        // element_index must be >= 1, never 0
+        const elementEntity = elementEntities[0];
+        expect(elementEntity.element_index).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
 });

--- a/plugins/browser-plugin-element-tracking/test/api.test.ts
+++ b/plugins/browser-plugin-element-tracking/test/api.test.ts
@@ -599,7 +599,11 @@ describe('Element Tracking Plugin API', () => {
         time: performance.now(),
       } as IntersectionObserverEntry;
 
-      intersectionCallback([fakeEntry], {} as IntersectionObserver);
+      intersectionCallback([fakeEntry], {
+        unobserve() {},
+        observe() {},
+        disconnect() {},
+      } as unknown as IntersectionObserver);
 
       return inNewTask(() => {
         expect(eventQueue.length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
- When the intersection observer callback fires, the plugin re-queries the DOM to determine the element's position among siblings. If the element has already been removed, findIndex returns -1, producing element_index: 0 which fails validation against the element schema (minimum: 1).
- Fall back to the element's last-known position stored in state.lastPosition when the DOM lookup
  fails, and keep that value fresh by updating it on every successful lookup.