### PR TITLE
[AISP-1002] fix(browser-tracker-core): use ResizeObserver entry sizes to avoid fo…

### DIFF
--- a/common/changes/@snowplow/browser-tracker-core/fix-browser-props-resize-observer-reflow_2026-07-16-20-23.json
+++ b/common/changes/@snowplow/browser-tracker-core/fix-browser-props-resize-observer-reflow_2026-07-16-20-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Avoid forced reflows when reading document size from ResizeObserver callbacks",
+      "type": "none",
+      "packageName": "@snowplow/browser-tracker-core"
+    }
+  ],
+  "packageName": "@snowplow/browser-tracker-core",
+  "email": "198982749+Copilot@users.noreply.github.com"
+}

--- a/libraries/browser-tracker-core/src/helpers/browser_props.ts
+++ b/libraries/browser-tracker-core/src/helpers/browser_props.ts
@@ -17,8 +17,23 @@ function useResizeObserver(): boolean {
   return 'ResizeObserver' in window;
 }
 
+type ObservedSize = { width: number; height: number };
+
 let resizeObserverInitialized = false;
 let readBrowserPropertiesTask: number | null = null;
+let observedBodySize: ObservedSize | null = null;
+let observedDocumentElementSize: ObservedSize | null = null;
+
+function getSizeFromEntry(entry: ResizeObserverEntry): ObservedSize {
+  if (entry.borderBoxSize?.[0]) {
+    return {
+      width: entry.borderBoxSize[0].inlineSize,
+      height: entry.borderBoxSize[0].blockSize,
+    };
+  }
+  return { width: entry.contentRect.width, height: entry.contentRect.height };
+}
+
 function initializeResizeObserver() {
   if (resizeObserverInitialized) {
     return;
@@ -28,7 +43,14 @@ function initializeResizeObserver() {
   }
   resizeObserverInitialized = true;
 
-  const resizeObserver = new ResizeObserver(() => {
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.target === document.body) {
+        observedBodySize = getSizeFromEntry(entry);
+      } else if (entry.target === document.documentElement) {
+        observedDocumentElementSize = getSizeFromEntry(entry);
+      }
+    }
     if (!readBrowserPropertiesTask) {
       // The browser property lookup causes a forced synchronous layout when offsets/sizes are
       // queried. It's possible that the forced synchronous layout causes the ResizeObserver
@@ -117,6 +139,16 @@ function detectViewport() {
  * - http://andylangton.co.uk/articles/javascript/get-viewport-size-javascript/
  */
 function detectDocumentSize() {
+  // Use sizes from ResizeObserver entries when available to avoid forced reflow.
+  // The entries provide border-box dimensions which correspond to offsetWidth/offsetHeight.
+  if (observedBodySize && observedDocumentElementSize) {
+    return makeDimension(
+      Math.max(observedDocumentElementSize.width, observedBodySize.width),
+      Math.max(observedDocumentElementSize.height, observedBodySize.height)
+    );
+  }
+
+  // Fallback for initial read or browsers without ResizeObserver (may cause forced reflow).
   var de = document.documentElement, // Alias
     be = document.body,
     // document.body may not have rendered, so check whether be.offsetHeight is null

--- a/libraries/browser-tracker-core/test/browser_props.test.ts
+++ b/libraries/browser-tracker-core/test/browser_props.test.ts
@@ -28,4 +28,111 @@ describe('Browser props', () => {
       });
     });
   });
+
+  describe('ResizeObserver entry size caching', () => {
+    function makeContentRect(width: number, height: number): DOMRectReadOnly {
+      return {
+        x: 0,
+        y: 0,
+        width,
+        height,
+        top: 0,
+        right: width,
+        bottom: height,
+        left: 0,
+        toJSON: () => ({}),
+      } as DOMRectReadOnly;
+    }
+
+    function makeEntry(target: Element, width: number, height: number): ResizeObserverEntry {
+      return {
+        target,
+        contentRect: makeContentRect(width, height),
+        borderBoxSize: [{ inlineSize: width, blockSize: height }] as unknown as ReadonlyArray<ResizeObserverSize>,
+        contentBoxSize: [{ inlineSize: width, blockSize: height }] as unknown as ReadonlyArray<ResizeObserverSize>,
+        devicePixelContentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
+      };
+    }
+
+    it('uses borderBoxSize from ResizeObserver entries for document size', () => {
+      let capturedCallback: ResizeObserverCallback | undefined;
+      const origRO = (global as any).ResizeObserver;
+
+      jest.useFakeTimers();
+      jest.isolateModules(() => {
+        (global as any).ResizeObserver = class {
+          constructor(cb: ResizeObserverCallback) {
+            capturedCallback = cb;
+          }
+          observe = jest.fn();
+          disconnect = jest.fn();
+        };
+
+        const { getBrowserProperties: freshGetBrowserProperties } = require('../src/helpers/browser_props');
+
+        // Initial call sets up ResizeObserver
+        freshGetBrowserProperties();
+        expect(capturedCallback).toBeDefined();
+
+        // Simulate ResizeObserver firing: body=900x2000, documentElement=1440x900
+        capturedCallback!(
+          [makeEntry(document.body, 900, 2000), makeEntry(document.documentElement, 1440, 900)],
+          {} as ResizeObserver
+        );
+
+        // Run the scheduled requestAnimationFrame
+        jest.runAllTimers();
+
+        const props = freshGetBrowserProperties();
+        // Width: max(1440, 900) = 1440; Height: max(900, 2000) = 2000
+        expect(props.documentSize).toBe('1440x2000');
+      });
+
+      (global as any).ResizeObserver = origRO;
+      jest.useRealTimers();
+    });
+
+    it('falls back to contentRect when borderBoxSize is absent', () => {
+      let capturedCallback: ResizeObserverCallback | undefined;
+      const origRO = (global as any).ResizeObserver;
+
+      jest.useFakeTimers();
+      jest.isolateModules(() => {
+        (global as any).ResizeObserver = class {
+          constructor(cb: ResizeObserverCallback) {
+            capturedCallback = cb;
+          }
+          observe = jest.fn();
+          disconnect = jest.fn();
+        };
+
+        const { getBrowserProperties: freshGetBrowserProperties } = require('../src/helpers/browser_props');
+
+        freshGetBrowserProperties();
+
+        // Entries without borderBoxSize - should fall back to contentRect
+        const entryWithoutBorderBox = (target: Element, width: number, height: number): ResizeObserverEntry => ({
+          target,
+          contentRect: makeContentRect(width, height),
+          borderBoxSize: undefined as any,
+          contentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
+          devicePixelContentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
+        });
+
+        capturedCallback!(
+          [entryWithoutBorderBox(document.body, 600, 1500), entryWithoutBorderBox(document.documentElement, 1280, 800)],
+          {} as ResizeObserver
+        );
+
+        jest.runAllTimers();
+
+        const props = freshGetBrowserProperties();
+        // Width: max(1280, 600) = 1280; Height: max(800, 1500) = 1500
+        expect(props.documentSize).toBe('1280x1500');
+      });
+
+      (global as any).ResizeObserver = origRO;
+      jest.useRealTimers();
+    });
+  });
 });

--- a/libraries/browser-tracker-core/test/browser_props.test.ts
+++ b/libraries/browser-tracker-core/test/browser_props.test.ts
@@ -44,11 +44,18 @@ describe('Browser props', () => {
       } as DOMRectReadOnly;
     }
 
-    function makeEntry(target: Element, width: number, height: number): ResizeObserverEntry {
+    function makeEntry(
+      target: Element,
+      width: number,
+      height: number,
+      includeBorderBoxSize = true
+    ): ResizeObserverEntry {
       return {
         target,
         contentRect: makeContentRect(width, height),
-        borderBoxSize: [{ inlineSize: width, blockSize: height }] as unknown as ReadonlyArray<ResizeObserverSize>,
+        borderBoxSize: includeBorderBoxSize
+          ? ([{ inlineSize: width, blockSize: height }] as unknown as ReadonlyArray<ResizeObserverSize>)
+          : (undefined as any),
         contentBoxSize: [{ inlineSize: width, blockSize: height }] as unknown as ReadonlyArray<ResizeObserverSize>,
         devicePixelContentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
       };
@@ -110,17 +117,8 @@ describe('Browser props', () => {
 
         freshGetBrowserProperties();
 
-        // Entries without borderBoxSize - should fall back to contentRect
-        const entryWithoutBorderBox = (target: Element, width: number, height: number): ResizeObserverEntry => ({
-          target,
-          contentRect: makeContentRect(width, height),
-          borderBoxSize: undefined as any,
-          contentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
-          devicePixelContentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
-        });
-
         capturedCallback!(
-          [entryWithoutBorderBox(document.body, 600, 1500), entryWithoutBorderBox(document.documentElement, 1280, 800)],
+          [makeEntry(document.body, 600, 1500, false), makeEntry(document.documentElement, 1280, 800, false)],
           {} as ResizeObserver
         );
 
@@ -133,6 +131,81 @@ describe('Browser props', () => {
 
       (global as any).ResizeObserver = origRO;
       jest.useRealTimers();
+    });
+
+    it('does not read layout properties once ResizeObserver sizes are cached', () => {
+      let capturedCallback: ResizeObserverCallback | undefined;
+      const origRO = (global as any).ResizeObserver;
+      const docEl = document.documentElement;
+      const body = document.body;
+      const originalDescriptors = {
+        bodyOffsetHeight: Object.getOwnPropertyDescriptor(body, 'offsetHeight'),
+        bodyScrollHeight: Object.getOwnPropertyDescriptor(body, 'scrollHeight'),
+        docClientWidth: Object.getOwnPropertyDescriptor(docEl, 'clientWidth'),
+        docOffsetWidth: Object.getOwnPropertyDescriptor(docEl, 'offsetWidth'),
+        docScrollWidth: Object.getOwnPropertyDescriptor(docEl, 'scrollWidth'),
+        docClientHeight: Object.getOwnPropertyDescriptor(docEl, 'clientHeight'),
+        docOffsetHeight: Object.getOwnPropertyDescriptor(docEl, 'offsetHeight'),
+        docScrollHeight: Object.getOwnPropertyDescriptor(docEl, 'scrollHeight'),
+      };
+
+      const throwIfRead = () => {
+        throw new Error('layout property read');
+      };
+
+      const restoreDescriptor = (target: object, key: string, descriptor?: PropertyDescriptor) => {
+        if (descriptor) {
+          Object.defineProperty(target, key, descriptor);
+        } else {
+          delete (target as Record<string, unknown>)[key];
+        }
+      };
+
+      jest.useFakeTimers();
+      try {
+        jest.isolateModules(() => {
+          (global as any).ResizeObserver = class {
+            constructor(cb: ResizeObserverCallback) {
+              capturedCallback = cb;
+            }
+            observe = jest.fn();
+            disconnect = jest.fn();
+          };
+
+          const { getBrowserProperties: freshGetBrowserProperties } = require('../src/helpers/browser_props');
+
+          freshGetBrowserProperties();
+
+          capturedCallback!(
+            [makeEntry(document.body, 900, 2000), makeEntry(document.documentElement, 1440, 900)],
+            {} as ResizeObserver
+          );
+
+          jest.runAllTimers();
+
+          Object.defineProperty(body, 'offsetHeight', { configurable: true, get: throwIfRead });
+          Object.defineProperty(body, 'scrollHeight', { configurable: true, get: throwIfRead });
+          Object.defineProperty(docEl, 'clientWidth', { configurable: true, get: throwIfRead });
+          Object.defineProperty(docEl, 'offsetWidth', { configurable: true, get: throwIfRead });
+          Object.defineProperty(docEl, 'scrollWidth', { configurable: true, get: throwIfRead });
+          Object.defineProperty(docEl, 'clientHeight', { configurable: true, get: throwIfRead });
+          Object.defineProperty(docEl, 'offsetHeight', { configurable: true, get: throwIfRead });
+          Object.defineProperty(docEl, 'scrollHeight', { configurable: true, get: throwIfRead });
+
+          expect(() => freshGetBrowserProperties()).not.toThrow();
+        });
+      } finally {
+        restoreDescriptor(body, 'offsetHeight', originalDescriptors.bodyOffsetHeight);
+        restoreDescriptor(body, 'scrollHeight', originalDescriptors.bodyScrollHeight);
+        restoreDescriptor(docEl, 'clientWidth', originalDescriptors.docClientWidth);
+        restoreDescriptor(docEl, 'offsetWidth', originalDescriptors.docOffsetWidth);
+        restoreDescriptor(docEl, 'scrollWidth', originalDescriptors.docScrollWidth);
+        restoreDescriptor(docEl, 'clientHeight', originalDescriptors.docClientHeight);
+        restoreDescriptor(docEl, 'offsetHeight', originalDescriptors.docOffsetHeight);
+        restoreDescriptor(docEl, 'scrollHeight', originalDescriptors.docScrollHeight);
+        (global as any).ResizeObserver = origRO;
+        jest.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Google PageSpeed flagged the JS tracker as causing forced synchronous layouts originating from `detectDocumentSize()` in `browser-tracker-core`. Accessing `offsetWidth`, `offsetHeight`, `scrollWidth`, `scrollHeight`, `clientWidth`, and `clientHeight` after a DOM change forces the browser to immediately recompute layout.

The `ResizeObserver` callback already deferred cache updates via `requestAnimationFrame`, but the update path still called `readBrowserProperties()` which re-queried all the reflow-triggering layout properties on each resize event.

Fixes AISP-1002.

## Changes

- Store element dimensions captured from `ResizeObserverEntry` (`borderBoxSize` with `contentRect` fallback) in module-level variables updated by the ResizeObserver callback.
- Update `detectDocumentSize()` to use those stored entry values when available, falling back to direct DOM reads only on the initial call (before the ResizeObserver has fired) or in browsers without ResizeObserver support.
- Add `getSizeFromEntry()` helper to extract border-box dimensions from an entry with a `contentRect` fallback for older ResizeObserver implementations.

## Validation

- All 6 tests in `browser_props.test.ts` pass, including two new tests covering the `borderBoxSize` path and the `contentRect` fallback.
